### PR TITLE
feat(app): remote bookmarks and bookmark tour

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,6 @@ module.exports = {
         "no-nested-ternary": "off",
         "dot-notation": "off",
         "no-unused-vars": ["error", { args: "none" }],
-        "require-await": "warn",
+        "require-await": "off",
     },
 };

--- a/packages/app/src/app.js
+++ b/packages/app/src/app.js
@@ -18,7 +18,7 @@ import MergeSampleFacets from "./sampleView/mergeFacets";
 import { transforms } from "@genome-spy/core/data/transforms/transformFactory";
 import { messageBox } from "./utils/ui/modal";
 import { compressToUrlHash, decompressFromUrlHash } from "./utils/urlHash";
-import { restoreBookmark } from "./bookmark/bookmark";
+import { restoreBookmarkAndShowInfoBox } from "./bookmark/bookmark";
 import StoreHelper from "./state/storeHelper";
 import { watch } from "./state/watch";
 import { viewSettingsSlice } from "./viewSettingsSlice";
@@ -302,7 +302,7 @@ export default class App {
             try {
                 /** @type {import("./appTypes").UrlHash} */
                 const entry = decompressFromUrlHash(hash);
-                restoreBookmark(entry, this);
+                restoreBookmarkAndShowInfoBox(entry, this);
                 return true;
             } catch (e) {
                 console.error(e);

--- a/packages/app/src/app.js
+++ b/packages/app/src/app.js
@@ -6,7 +6,7 @@ import { html, render } from "lit";
 
 import { VISIT_STOP } from "@genome-spy/core/view/view";
 import SampleView, { isSampleSpec } from "./sampleView/sampleView";
-import BookmarkDatabase from "./bookmarkDatabase";
+import BookmarkDatabase from "./bookmark/bookmarkDatabase";
 import { asArray } from "@genome-spy/core/utils/arrayUtils";
 
 import "./components/toolbar";
@@ -18,7 +18,7 @@ import MergeSampleFacets from "./sampleView/mergeFacets";
 import { transforms } from "@genome-spy/core/data/transforms/transformFactory";
 import { messageBox } from "./utils/ui/modal";
 import { compressToUrlHash, decompressFromUrlHash } from "./utils/urlHash";
-import { restoreBookmark } from "./bookmark";
+import { restoreBookmark } from "./bookmark/bookmark";
 import StoreHelper from "./state/storeHelper";
 import { watch } from "./state/watch";
 import { viewSettingsSlice } from "./viewSettingsSlice";
@@ -56,7 +56,10 @@ export default class App {
         this.appContainer = appContainerElement;
         this._configureContainer();
 
-        /** Local bookmarks in the IndexedDB */
+        /**
+         * Local bookmarks in the IndexedDB
+         * @type {BookmarkDatabase}
+         */
         this.bookmarkDatabase =
             typeof config.specId == "string"
                 ? new BookmarkDatabase(config.specId)
@@ -64,7 +67,7 @@ export default class App {
 
         /**
          * Remote bookmarks loaded from a URL
-         * @type {import("./databaseSchema").BookmarkEntry[]}
+         * @type {import("./bookmark/databaseSchema").BookmarkEntry[]}
          */
         this.remoteBookmarks = undefined;
 
@@ -149,7 +152,7 @@ export default class App {
     }
 
     async launch() {
-        /** @type {Promise<import("./databaseSchema").BookmarkEntry[]>} */
+        /** @type {Promise<import("./bookmark/databaseSchema").BookmarkEntry[]>} */
         const remoteBookmarkPromise = this.config.bookmarks?.remote
             ? vegaLoader({ baseURL: this.config.baseUrl })
                   .load(this.config.bookmarks.remote.url)

--- a/packages/app/src/app.js
+++ b/packages/app/src/app.js
@@ -203,7 +203,7 @@ export default class App {
 
         try {
             const remoteBookmarks = await remoteBookmarkPromise;
-            if (remoteBookmarks) {
+            if (remoteBookmarks.length) {
                 this.remoteBookmarkDatabase = new SimpleBookmarkDatabase(
                     remoteBookmarks
                 );

--- a/packages/app/src/bookmark.js
+++ b/packages/app/src/bookmark.js
@@ -5,7 +5,7 @@ import { viewSettingsSlice } from "./viewSettingsSlice";
 
 /**
  * @param {Partial<import("./databaseSchema").BookmarkEntry>} entry
- * @param {import("./app").App} app
+ * @param {import("./app").default} app
  */
 export async function restoreBookmark(entry, app) {
     try {

--- a/packages/app/src/bookmark/bookmark.js
+++ b/packages/app/src/bookmark/bookmark.js
@@ -1,5 +1,6 @@
 import { icon } from "@fortawesome/fontawesome-svg-core";
 import {
+    faChevronDown,
     faStepBackward,
     faStepForward,
 } from "@fortawesome/free-solid-svg-icons";
@@ -134,7 +135,15 @@ export async function updateBookmarkInfoBox(entry, app, bookmarkDatabase) {
           `
         : html` <button @click=${close}>Close</button> `;
 
+    const toggleCollapse = (/** @type {MouseEvent} */ event) =>
+        /** @type {HTMLElement} */ (event.target)
+            .closest(".gs-modal")
+            .classList.toggle("collapsed");
+
     const template = html`
+        <button class="collapse" @click=${toggleCollapse}>
+            ${icon(faChevronDown).node[0]}
+        </button>
         <div class="modal-title">${title}</div>
         <div class="modal-body" style="max-width: 700px">${content}</div>
         <div class="modal-buttons">${buttons}</div>

--- a/packages/app/src/bookmark/bookmark.js
+++ b/packages/app/src/bookmark/bookmark.js
@@ -4,13 +4,13 @@ import {
     faStepForward,
 } from "@fortawesome/free-solid-svg-icons";
 import { html, render } from "lit";
-import safeMarkdown from "./utils/safeMarkdown";
-import { createModal, messageBox } from "./utils/ui/modal";
-import { viewSettingsSlice } from "./viewSettingsSlice";
+import safeMarkdown from "../utils/safeMarkdown";
+import { createModal, messageBox } from "../utils/ui/modal";
+import { viewSettingsSlice } from "../viewSettingsSlice";
 
 /**
  * @param {Partial<import("./databaseSchema").BookmarkEntry>} entry
- * @param {import("./app").default} app
+ * @param {import("../app").default} app
  * @param {Partial<import("./databaseSchema").BookmarkEntry[]>} [entryCollection]
  *      An optional collection that contains the entry. Used for next/prev buttons.
  */
@@ -58,7 +58,7 @@ export async function restoreBookmark(entry, app, entryCollection) {
 /**
  *
  * @param {Partial<import("./databaseSchema").BookmarkEntry>} entry
- * @param {import("./app").default} app
+ * @param {import("../app").default} app
  * @param {Partial<import("./databaseSchema").BookmarkEntry[]>} [entryCollection]
  *      An optional collection that contains the entry. Used for next/prev buttons.
  */

--- a/packages/app/src/bookmark/bookmark.js
+++ b/packages/app/src/bookmark/bookmark.js
@@ -141,7 +141,7 @@ export async function updateBookmarkInfoBox(entry, app, bookmarkDatabase) {
             .classList.toggle("collapsed");
 
     const template = html`
-        <button class="collapse" @click=${toggleCollapse}>
+        <button title="Collapse" class="collapse" @click=${toggleCollapse}>
             ${icon(faChevronDown).node[0]}
         </button>
         <div class="modal-title">${title}</div>

--- a/packages/app/src/bookmark/bookmark.js
+++ b/packages/app/src/bookmark/bookmark.js
@@ -145,7 +145,9 @@ export async function updateBookmarkInfoBox(entry, app, bookmarkDatabase) {
             ${icon(faChevronDown).node[0]}
         </button>
         <div class="modal-title">${title}</div>
-        <div class="modal-body" style="max-width: 700px">${content}</div>
+        <div class="modal-body markdown" style="max-width: 600px">
+            ${content}
+        </div>
         <div class="modal-buttons">${buttons}</div>
     `;
 

--- a/packages/app/src/bookmark/bookmark.js
+++ b/packages/app/src/bookmark/bookmark.js
@@ -25,7 +25,7 @@ import { viewSettingsSlice } from "../viewSettingsSlice";
 let infoBox;
 
 /**
- * @param {Partial<import("./databaseSchema").BookmarkEntry>} entry
+ * @param {import("./databaseSchema").BookmarkEntry} entry
  * @param {import("../app").default} app
  */
 export async function restoreBookmark(entry, app) {
@@ -66,7 +66,7 @@ export async function restoreBookmark(entry, app) {
 }
 
 /**
- * @param {Partial<import("./databaseSchema").BookmarkEntry>} entry
+ * @param {import("./databaseSchema").BookmarkEntry} entry
  * @param {import("../app").default} app
  * @param {BookmarkInfoBoxOptions} [options]
  */
@@ -79,7 +79,7 @@ export async function restoreBookmarkAndShowInfoBox(entry, app, options = {}) {
 
 /**
  *
- * @param {Partial<import("./databaseSchema").BookmarkEntry>} entry
+ * @param {import("./databaseSchema").BookmarkEntry} entry
  * @param {import("../app").default} app
  * @param {BookmarkInfoBoxOptions} [options]
  */
@@ -91,7 +91,7 @@ export async function showBookmarkInfoBox(entry, app, options = {}) {
 
 /**
  *
- * @param {Partial<import("./databaseSchema").BookmarkEntry>} entry
+ * @param {import("./databaseSchema").BookmarkEntry} entry
  * @param {import("../app").default} app
  * @param {BookmarkInfoBoxOptions} [options]
  */
@@ -122,12 +122,29 @@ export async function updateBookmarkInfoBox(entry, app, options) {
         restoreBookmarkAndShowInfoBox(entry, app, options);
     };
 
+    const importBookmark = async () => {
+        if (
+            await showEnterBookmarkInfoDialog(
+                app.localBookmarkDatabase,
+                entry,
+                false
+            )
+        ) {
+            try {
+                await app.localBookmarkDatabase.put(entry);
+            } catch (e) {
+                console.warn(e);
+                messageBox(`Cannot import bookmark: ${e}`);
+            }
+        }
+    };
+
     const buttons = html` <button @click=${close}>
             ${options.mode == "tour" ? "End tour" : "Close"}
         </button>
-        ${options.mode == "shared"
+        ${options.mode == "shared" && app.localBookmarkDatabase
             ? html`
-                  <button @click=${() => alert("TODO")}>
+                  <button @click=${importBookmark}>
                       ${icon(faBookmark).node[0]} Import bookmark
                   </button>
               `

--- a/packages/app/src/bookmark/bookmark.js
+++ b/packages/app/src/bookmark/bookmark.js
@@ -9,12 +9,15 @@ import { createModal, messageBox } from "../utils/ui/modal";
 import { viewSettingsSlice } from "../viewSettingsSlice";
 
 /**
+ * @type {import("../utils/ui/modal").Modal}
+ */
+let infoBox;
+
+/**
  * @param {Partial<import("./databaseSchema").BookmarkEntry>} entry
  * @param {import("../app").default} app
- * @param {Partial<import("./databaseSchema").BookmarkEntry[]>} [entryCollection]
- *      An optional collection that contains the entry. Used for next/prev buttons.
  */
-export async function restoreBookmark(entry, app, entryCollection) {
+export async function restoreBookmark(entry, app) {
     try {
         if (entry.actions) {
             app.provenance.dispatchBookmark(entry.actions);
@@ -41,10 +44,6 @@ export async function restoreBookmark(entry, app, entryCollection) {
             }
         }
         await Promise.all(promises);
-
-        if (entry.notes?.length || entryCollection?.length) {
-            createOrUpdateMessageBox(entry, app, entryCollection);
-        }
     } catch (e) {
         console.error(e);
         messageBox(
@@ -56,52 +55,90 @@ export async function restoreBookmark(entry, app, entryCollection) {
 }
 
 /**
+ * @param {Partial<import("./databaseSchema").BookmarkEntry>} entry
+ * @param {import("../app").default} app
+ * @param {import("./bookmarkDatabase").default} [bookmarkDatabase]
+ *      An optional collection that contains the entry. Used for next/prev buttons.
+ */
+export async function restoreBookmarkAndShowInfoBox(
+    entry,
+    app,
+    bookmarkDatabase
+) {
+    await restoreBookmark(entry, app);
+    if (entry.notes || infoBox) {
+        await showBookmarkInfoBox(entry, app, bookmarkDatabase);
+    }
+}
+
+/**
  *
  * @param {Partial<import("./databaseSchema").BookmarkEntry>} entry
  * @param {import("../app").default} app
- * @param {Partial<import("./databaseSchema").BookmarkEntry[]>} [entryCollection]
+ * @param {import("./bookmarkDatabase").default} [bookmarkDatabase]
  *      An optional collection that contains the entry. Used for next/prev buttons.
  */
-function createOrUpdateMessageBox(entry, app, entryCollection) {
-    const entryIndex = entryCollection
-        ? entryCollection.findIndex((e) => e.name == entry.name)
-        : -1;
+export async function showBookmarkInfoBox(entry, app, bookmarkDatabase) {
+    infoBox ??= createModal("tour");
+
+    await updateBookmarkInfoBox(entry, app, bookmarkDatabase);
+}
+
+/**
+ *
+ * @param {Partial<import("./databaseSchema").BookmarkEntry>} entry
+ * @param {import("../app").default} app
+ * @param {import("./bookmarkDatabase").default} [bookmarkDatabase]
+ *      An optional collection that contains the entry. Used for next/prev buttons.
+ */
+export async function updateBookmarkInfoBox(entry, app, bookmarkDatabase) {
+    const names = bookmarkDatabase ? await bookmarkDatabase.getNames() : [];
+
+    const entryIndex = names.indexOf(entry.name);
+
     const tour = entryIndex >= 0;
 
-    const modal = createModal("tour");
+    const of = tour ? ` ${entryIndex + 1} of ${names.length}` : "";
+    const title = `${bookmarkDatabase ? "Bookmark" : "Shared link"}${of}: ${
+        entry.name
+    }`;
 
-    return new Promise((resolve, reject) => {
-        const close = () => {
-            modal.close();
-            resolve(true);
-        };
+    const content = entry.notes ? safeMarkdown(entry.notes) : "No notes";
 
-        const of = tour
-            ? ` ${entryIndex + 1} of ${entryCollection.length}`
-            : "";
+    const close = () => {
+        infoBox?.close();
+        infoBox = undefined;
+    };
 
-        const title = `Bookmark${of}: ${entry.name}`;
+    const jumpTo = async (/** @type {number} */ index) => {
+        // TODO: Prevent double clicks, etc
+        const entry = await bookmarkDatabase.get(names[index]);
+        restoreBookmarkAndShowInfoBox(entry, app, bookmarkDatabase);
+    };
 
-        const content = safeMarkdown(entry.notes);
+    const buttons = tour
+        ? html`
+              <button @click=${close}>Close</button>
+              <button
+                  @click=${() => jumpTo(entryIndex - 1)}
+                  ?disabled=${entryIndex <= 0}
+              >
+                  ${icon(faStepBackward).node[0]} Previous
+              </button>
+              <button
+                  @click=${() => jumpTo(entryIndex + 1)}
+                  ?disabled=${entryIndex >= names.length - 1}
+              >
+                  Next ${icon(faStepForward).node[0]}
+              </button>
+          `
+        : html` <button @click=${close}>Close</button> `;
 
-        const buttons = tour
-            ? html`
-                  <button @click=${close}>Close</button>
-                  <button ?disabled=${entryIndex <= 0}>
-                      ${icon(faStepBackward).node[0]} Previous
-                  </button>
-                  <button ?disabled=${entryIndex >= entryCollection.length - 1}>
-                      Next ${icon(faStepForward).node[0]}
-                  </button>
-              `
-            : html` <button @click=${close}>Close</button> `;
+    const template = html`
+        <div class="modal-title">${title}</div>
+        <div class="modal-body" style="max-width: 700px">${content}</div>
+        <div class="modal-buttons">${buttons}</div>
+    `;
 
-        const template = html`
-            <div class="modal-title">${title}</div>
-            <div class="modal-body" style="max-width: 700px">${content}</div>
-            <div class="modal-buttons">${buttons}</div>
-        `;
-
-        render(template, modal.content);
-    });
+    render(template, infoBox.content);
 }

--- a/packages/app/src/bookmark/bookmarkDatabase.js
+++ b/packages/app/src/bookmark/bookmarkDatabase.js
@@ -3,7 +3,7 @@ import { openDB } from "idb";
 const BOOKMARKS_STORE = "bookmarks";
 
 /**
- * @typedef {import("./state/provenance").Action} Action
+ * @typedef {import("../state/provenance").Action} Action
  */
 export default class BookmarkDatabase {
     /**

--- a/packages/app/src/bookmark/databaseSchema.d.ts
+++ b/packages/app/src/bookmark/databaseSchema.d.ts
@@ -5,7 +5,7 @@ import { Action } from "../state/provenance";
 
 export interface BookmarkEntry {
     name: string;
-    timestamp: number;
+    timestamp?: number;
 
     notes?: string;
 

--- a/packages/app/src/bookmark/databaseSchema.d.ts
+++ b/packages/app/src/bookmark/databaseSchema.d.ts
@@ -1,7 +1,7 @@
 import { DBSchema } from "idb";
 import { ChromosomalLocus } from "@genome-spy/core/genome/genome";
-import { ViewSettings } from "./state";
-import { Action } from "./state/provenance";
+import { ViewSettings } from "../state";
+import { Action } from "../state/provenance";
 
 export interface BookmarkEntry {
     name: string;

--- a/packages/app/src/bookmark/idbBookmarkDatabase.js
+++ b/packages/app/src/bookmark/idbBookmarkDatabase.js
@@ -1,0 +1,104 @@
+import { openDB } from "idb";
+import BookmarkDatabase from "./bookmarkDatabase";
+
+const BOOKMARKS_STORE = "bookmarks";
+
+/**
+ * @typedef {import("../state/provenance").Action} Action
+ */
+
+/**
+ * A bookmark database based on IndexedDB
+ */
+export default class IDBBookmarkDatabase extends BookmarkDatabase {
+    /**
+     *
+     * @param {string} specId
+     */
+    constructor(specId) {
+        super();
+
+        this.specId = specId;
+
+        /** @type {Promise<import("idb").IDBPDatabase<import("./databaseSchema").BookmarkDB>>} */
+        this._db = undefined;
+    }
+
+    async _getDB() {
+        // TODO: Only create the initial database if a new bookmark is being added.
+        if (!this._db) {
+            // We create a different database for each spec. Rationale: if an origin
+            // uses multiple GenomeSpy versions, a single shared database would likely to
+            // be a problem when the schema needs to be changed.
+            const dbName = `GenomeSpy: ${this.specId}`;
+
+            this._db = openDB(dbName, 1, {
+                upgrade(db, oldVersion, newVersion, transaction) {
+                    // eslint-disable-next-line no-unused-vars
+                    const store = db.createObjectStore(BOOKMARKS_STORE, {
+                        keyPath: "name",
+                    });
+                },
+                blocked() {
+                    // …
+                },
+                blocking() {
+                    // …
+                },
+                terminated() {
+                    // …
+                },
+            });
+        }
+
+        return this._db;
+    }
+
+    isReadonly() {
+        return false;
+    }
+
+    /**
+     * @param {import("./databaseSchema").BookmarkEntry} entry
+     * @param {string} [nameToReplace]
+     */
+    async put(entry, nameToReplace) {
+        const db = await this._getDB();
+
+        const tx = db.transaction(BOOKMARKS_STORE, "readwrite");
+        try {
+            if (nameToReplace) {
+                await tx.store.delete(nameToReplace);
+                await tx.store.put(entry);
+            } else {
+                await tx.store.put(entry);
+            }
+            await tx.done;
+        } catch (error) {
+            tx.abort();
+            throw error;
+        }
+    }
+
+    /**
+     * @param {string} name
+     */
+    async delete(name) {
+        const db = await this._getDB();
+        db.delete(BOOKMARKS_STORE, name);
+    }
+
+    async getNames() {
+        const db = await this._getDB();
+        return db.getAllKeys(BOOKMARKS_STORE);
+    }
+
+    /**
+     *
+     * @param {string} name
+     */
+    async get(name) {
+        const db = await this._getDB();
+        return db.get(BOOKMARKS_STORE, name);
+    }
+}

--- a/packages/app/src/bookmark/simpleBookmarkDatabase.js
+++ b/packages/app/src/bookmark/simpleBookmarkDatabase.js
@@ -1,0 +1,31 @@
+import BookmarkDatabase from "./bookmarkDatabase";
+
+/**
+ * A simple readonly database that wraps an array of bookmark objects
+ */
+export default class SimpleBookmarkDatabase extends BookmarkDatabase {
+    /**
+     * @param {import("./databaseSchema").BookmarkEntry[]} bookmarks
+     */
+    constructor(bookmarks) {
+        super();
+
+        this.bookmarks = bookmarks;
+        this.names = bookmarks.map((bookmark) => bookmark.name);
+    }
+
+    /**
+     * @returns {Promise<string[]>}
+     */
+    async getNames() {
+        return this.names;
+    }
+
+    /**
+     * @param {string} name
+     * @returns {Promise<import("./databaseSchema").BookmarkEntry>}
+     */
+    async get(name) {
+        return this.bookmarks.find((bookmark) => bookmark.name == name);
+    }
+}

--- a/packages/app/src/components/bookmarkButton.js
+++ b/packages/app/src/components/bookmarkButton.js
@@ -287,9 +287,18 @@ class BookmarkButton extends LitElement {
     }
 
     render() {
-        if (!this.app.localBookmarkDatabase) {
+        if (
+            !this.app.localBookmarkDatabase &&
+            !this.app.remoteBookmarkDatabase
+        ) {
             return nothing;
         }
+
+        const add = this.app.localBookmarkDatabase
+            ? html` <li>
+                  <a @click=${() => this._addBookmark()}>Add bookmark...</a>
+              </li>`
+            : nothing;
 
         return html`
             <div class="dropdown bookmark-dropdown">
@@ -301,12 +310,7 @@ class BookmarkButton extends LitElement {
                     ${icon(faBookmark).node[0]}
                 </button>
                 <ul class="gs-dropdown-menu">
-                    <li>
-                        <a @click=${() => this._addBookmark()}
-                            >Add bookmark...</a
-                        >
-                    </li>
-                    ${this._getBookmarks()}
+                    ${add} ${this._getBookmarks()}
                 </ul>
             </div>
         `;

--- a/packages/app/src/components/bookmarkButton.js
+++ b/packages/app/src/components/bookmarkButton.js
@@ -13,7 +13,7 @@ import { createCloseEvent, createModal, messageBox } from "../utils/ui/modal";
 import { dropdownMenu, menuItemToTemplate } from "../utils/ui/contextMenu";
 import { queryDependency } from "../utils/dependency";
 import { compressToUrlHash } from "../utils/urlHash";
-import { restoreBookmark } from "../bookmark";
+import { restoreBookmark } from "../bookmark/bookmark";
 
 class BookmarkButton extends LitElement {
     constructor() {
@@ -51,7 +51,7 @@ class BookmarkButton extends LitElement {
 
         const editing = !!existingEntry;
 
-        /** @type {import("../databaseSchema").BookmarkEntry} */
+        /** @type {import("../bookmark/databaseSchema").BookmarkEntry} */
         const bookmarkEntry = existingEntry
             ? {
                   ...existingEntry,

--- a/packages/app/src/components/bookmarkButton.js
+++ b/packages/app/src/components/bookmarkButton.js
@@ -238,7 +238,19 @@ class BookmarkButton extends LitElement {
     }
 
     _getBookmarks() {
-        return until(
+        /** @type {import("../utils/ui/contextMenu").MenuItem[]} */
+        const remoteMenuItems = this.app.remoteBookmarks.length
+            ? [
+                  { type: "divider" },
+                  { label: "Remote bookmarks", type: "header" },
+                  ...this.app.remoteBookmarks.map((entry) => ({
+                      label: entry.name,
+                      callback: () => restoreBookmark(entry, this.app),
+                  })),
+              ]
+            : [];
+
+        const localTemplate = until(
             this.app.bookmarkDatabase.getNames().then((names) => {
                 const items = names.map((name) => ({
                     label: name,
@@ -256,6 +268,10 @@ class BookmarkButton extends LitElement {
             }),
             html` Loading... `
         );
+
+        return html`${remoteMenuItems.map((item) =>
+            menuItemToTemplate(item)
+        )}${localTemplate}`;
     }
 
     render() {

--- a/packages/app/src/components/bookmarkButton.js
+++ b/packages/app/src/components/bookmarkButton.js
@@ -221,7 +221,12 @@ class BookmarkButton extends LitElement {
                 <button
                     class="tool-btn"
                     title="Bookmarks"
-                    @click=${toggleDropdown}
+                    @click=${(/** @type {MouseEvent} */ event) => {
+                        if (toggleDropdown(event)) {
+                            // TODO: Use redux actions to save bookmarks
+                            this.requestUpdate();
+                        }
+                    }}
                 >
                     ${icon(faBookmark).node[0]}
                 </button>

--- a/packages/app/src/components/bookmarkButton.js
+++ b/packages/app/src/components/bookmarkButton.js
@@ -192,7 +192,9 @@ class BookmarkButton extends LitElement {
     async _loadBookmark(bookmarkDatabase, name) {
         const entry = await bookmarkDatabase.get(name);
         if (entry) {
-            restoreBookmarkAndShowInfoBox(entry, this.app, bookmarkDatabase);
+            restoreBookmarkAndShowInfoBox(entry, this.app, {
+                database: bookmarkDatabase,
+            });
         }
     }
 

--- a/packages/app/src/components/toolbar.js
+++ b/packages/app/src/components/toolbar.js
@@ -71,11 +71,9 @@ export default class Toolbar extends LitElement {
             `);
         }
 
-        if (this.app.localBookmarkDatabase) {
-            elements.push(html`
-                <genome-spy-bookmark-button></genome-spy-bookmark-button>
-            `);
-        }
+        elements.push(html`
+            <genome-spy-bookmark-button></genome-spy-bookmark-button>
+        `);
 
         /**
          * The first entry in the description array is shown as a title in the toolbar

--- a/packages/app/src/components/toolbar.js
+++ b/packages/app/src/components/toolbar.js
@@ -71,7 +71,7 @@ export default class Toolbar extends LitElement {
             `);
         }
 
-        if (this.app.bookmarkDatabase) {
+        if (this.app.localBookmarkDatabase) {
             elements.push(html`
                 <genome-spy-bookmark-button></genome-spy-bookmark-button>
             `);

--- a/packages/app/src/components/toolbar.js
+++ b/packages/app/src/components/toolbar.js
@@ -19,7 +19,7 @@ export default class Toolbar extends LitElement {
     constructor() {
         super();
 
-        /** @type {import("../app").App} */
+        /** @type {import("../app").default} */
         this.app = undefined;
 
         /** Just to signal (and re-render) once GenomeSpy has been launched */
@@ -48,7 +48,9 @@ export default class Toolbar extends LitElement {
         if (provenance.isEnabled()) {
             elements.push(
                 html`
-                    <genome-spy-provenance-buttons .provenance=${provenance} />
+                    <genome-spy-provenance-buttons
+                        .provenance=${provenance}
+                    ></genome-spy-provenance-buttons>
                 `
             );
         }

--- a/packages/app/src/databaseSchema.d.ts
+++ b/packages/app/src/databaseSchema.d.ts
@@ -3,7 +3,7 @@ import { ChromosomalLocus } from "@genome-spy/core/genome/genome";
 import { ViewSettings } from "./state";
 import { Action } from "./state/provenance";
 
-interface BookmarkEntry {
+export interface BookmarkEntry {
     name: string;
     timestamp: number;
 
@@ -24,7 +24,8 @@ interface BookmarkEntry {
      */
     viewSettings?: ViewSettings;
 }
-interface BookmarkDB extends DBSchema {
+
+export interface BookmarkDB extends DBSchema {
     bookmarks: {
         value: BookmarkEntry;
         key: string;

--- a/packages/app/src/sampleView/sampleAttributePanel.js
+++ b/packages/app/src/sampleView/sampleAttributePanel.js
@@ -13,7 +13,7 @@ import { resolveScalesAndAxes } from "@genome-spy/core/view/viewUtils";
 import { easeQuadInOut } from "d3-ease";
 import { peek } from "@genome-spy/core/utils/arrayUtils";
 import { ActionCreators } from "redux-undo";
-import contextMenu from "../utils/ui/contextMenu";
+import { contextMenu } from "../utils/ui/contextMenu";
 
 // TODO: Move to a more generic place
 /** @type {Record<string, import("@genome-spy/core/spec/channel").Type>} */

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -34,7 +34,7 @@ import CompositeAttributeInfoSource from "./compositeAttributeInfoSource";
 import { watch } from "../state/watch";
 import { createSelector } from "@reduxjs/toolkit";
 import { calculateLocations, getSampleLocationAt } from "./locations";
-import contextMenu from "../utils/ui/contextMenu";
+import { contextMenu } from "../utils/ui/contextMenu";
 
 const VALUE_AT_LOCUS = "VALUE_AT_LOCUS";
 

--- a/packages/app/src/spec/appSpec.d.ts
+++ b/packages/app/src/spec/appSpec.d.ts
@@ -1,5 +1,19 @@
 import { RootSpec } from "@genome-spy/core/spec/root";
 
+export interface RemoteBookmarkConfig {
+    url: string;
+
+    /**
+     * Should the user be shown a tour of the remote bookmarks when the visualization
+     * is launched?
+     */
+    tour?: boolean;
+}
+
+export interface BookmarkConfig {
+    remote?: RemoteBookmarkConfig;
+}
+
 interface AppRootConfig {
     /**
      * A unique identifier that is used in storing state bookmarks to browser's
@@ -7,6 +21,8 @@ interface AppRootConfig {
      * are served from the same origin, i.e., the same host and port.
      */
     specId?: string;
+
+    bookmarks?: BookmarkConfig;
 }
 
 export type AppRootSpec = RootSpec & AppRootConfig;

--- a/packages/app/src/spec/appSpec.d.ts
+++ b/packages/app/src/spec/appSpec.d.ts
@@ -5,9 +5,16 @@ export interface RemoteBookmarkConfig {
 
     /**
      * Should the user be shown a tour of the remote bookmarks when the visualization
-     * is launched?
+     * is launched? If the `initialBookmark` property is not defined, the tour starts
+     * from the first bookmark.
      */
     tour?: boolean;
+
+    /**
+     * Name of the bookmark that should be loaded as the initial state. A message box
+     * is shown only if the `tour` property is set to `true`.
+     */
+    initialBookmark?: string;
 }
 
 export interface BookmarkConfig {

--- a/packages/app/src/styles/genome-spy-app.scss
+++ b/packages/app/src/styles/genome-spy-app.scss
@@ -477,6 +477,7 @@ $menu-line-height: 22px;
 
     .modal-title {
         font-weight: bold;
+        padding-bottom: 0;
     }
 
     .modal-body {
@@ -569,6 +570,46 @@ $menu-line-height: 22px;
             margin: $basic-spacing;
             box-shadow: 0px 3px 15px 0px rgba(0, 0, 0, 0.21),
                 0px 2px 5px 0px rgba(0, 0, 0, 0.21);
+        }
+
+        .modal-title {
+            padding-right: 3em;
+        }
+    }
+
+    .collapse {
+        position: absolute;
+        right: $basic-spacing;
+        top: $basic-spacing;
+        background: none;
+        border: none;
+        font-size: 1.1em;
+
+        border-radius: 2px;
+        cursor: pointer;
+
+        svg {
+            transition: transform 0.3s;
+        }
+
+        &:hover {
+            background-color: #e8e8e8;
+        }
+    }
+
+    &.collapsed {
+        > .content > :not(:is(.modal-title, .collapse)) {
+            display: none;
+        }
+
+        .modal-title {
+            padding-bottom: $basic-spacing;
+        }
+
+        .collapse {
+            svg {
+                transform: rotate(180deg);
+            }
         }
     }
 }

--- a/packages/app/src/styles/genome-spy-app.scss
+++ b/packages/app/src/styles/genome-spy-app.scss
@@ -532,10 +532,43 @@ $menu-line-height: 22px;
                 cursor: pointer;
             }
 
-            svg:first-child {
+            svg:first-child:not(:last-child) {
                 font-size: 85%;
                 margin-right: 0.3em;
             }
+
+            svg:last-child:not(:first-child) {
+                font-size: 85%;
+                margin-left: 0.3em;
+            }
+        }
+    }
+
+    &.tour {
+        pointer-events: none;
+
+        justify-content: right;
+        align-content: end;
+
+        &.visible .backdrop {
+            opacity: 1;
+        }
+
+        .backdrop {
+            pointer-events: none;
+
+            background: linear-gradient(
+                160deg,
+                transparent 60%,
+                rgba(0, 0, 0, 0.15)
+            );
+        }
+
+        .content {
+            pointer-events: all;
+            margin: $basic-spacing;
+            box-shadow: 0px 3px 15px 0px rgba(0, 0, 0, 0.21),
+                0px 2px 5px 0px rgba(0, 0, 0, 0.21);
         }
     }
 }

--- a/packages/app/src/styles/genome-spy-app.scss
+++ b/packages/app/src/styles/genome-spy-app.scss
@@ -595,12 +595,30 @@ $menu-line-height: 22px;
         cursor: pointer;
 
         svg {
-            transition: transform 0.3s;
+            transition: transform 0.5s;
         }
 
         &:hover {
             background-color: #e8e8e8;
         }
+    }
+
+    &:not(.collapsed) .content:not(:hover) .collapse {
+        @keyframes move {
+            0% {
+                transform: translateY(0);
+            }
+            25% {
+                transform: translateY(-2px);
+            }
+            75% {
+                transform: translateY(2px);
+            }
+            100% {
+                transform: translateY(0);
+            }
+        }
+        animation: move 0.25s 0.5s 3 linear;
     }
 
     &.collapsed {

--- a/packages/app/src/styles/genome-spy-app.scss
+++ b/packages/app/src/styles/genome-spy-app.scss
@@ -724,6 +724,12 @@ $form-control-border: 1px solid $form-control-border-color;
         background-color: #fff3cd;
         border-color: #ffecb5;
     }
+
+    &.info {
+        color: #055160;
+        background-color: #cff4fc;
+        border-color: #b6effb;
+    }
 }
 
 .snarkdown {

--- a/packages/app/src/styles/genome-spy-app.scss
+++ b/packages/app/src/styles/genome-spy-app.scss
@@ -513,7 +513,7 @@ $menu-line-height: 22px;
             box-shadow: inset 0 1px 0 rgb(255 255 255 / 20%),
                 0 1px 2px rgb(0 0 0 / 5%);
 
-            transition: color 0.1s;
+            transition: color 0.15s;
 
             &:hover:not(:disabled) {
                 background-image: linear-gradient(to bottom, #f8f8f8, #d8d8d8);
@@ -559,8 +559,8 @@ $menu-line-height: 22px;
 
             background: linear-gradient(
                 160deg,
-                transparent 60%,
-                rgba(0, 0, 0, 0.15)
+                transparent 70%,
+                rgba(0, 0, 0, 0.2)
             );
         }
 

--- a/packages/app/src/styles/genome-spy-app.scss
+++ b/packages/app/src/styles/genome-spy-app.scss
@@ -326,6 +326,38 @@ $menu-line-height: 22px;
     li > .disabled-item {
         color: #999;
     }
+
+    a.menu-ellipsis {
+        padding: 0;
+        display: flex;
+        align-items: center;
+
+        position: absolute;
+        top: 0px;
+        right: $menu-item-h-padding * 0.5;
+        height: $menu-line-height;
+
+        background-color: $menu-hover-bg-color;
+        border-radius: 3em;
+
+        color: #707070;
+
+        svg {
+            margin: 0;
+            width: $menu-line-height;
+        }
+
+        &:hover {
+            background-color: color.scale(
+                $menu-hover-bg-color,
+                $lightness: 30%
+            );
+        }
+    }
+
+    li:not(:hover) a.menu-ellipsis {
+        display: none;
+    }
 }
 
 .provenance-menu {
@@ -363,38 +395,6 @@ $menu-line-height: 22px;
         background-color: #e0e0e0;
         border-left: $tickSize solid #c0c0c0;
         padding-left: $menu-item-h-padding - $tickSize;
-    }
-
-    a.menu-ellipsis {
-        padding: 0;
-        display: flex;
-        align-items: center;
-
-        position: absolute;
-        top: 0px;
-        right: $menu-item-h-padding * 0.5;
-        height: $menu-line-height;
-
-        background-color: $menu-hover-bg-color;
-        border-radius: 3em;
-
-        color: #707070;
-
-        svg {
-            margin: 0;
-            width: $menu-line-height;
-        }
-
-        &:hover {
-            background-color: color.scale(
-                $menu-hover-bg-color,
-                $lightness: 30%
-            );
-        }
-    }
-
-    li:not(:hover) a.menu-ellipsis {
-        display: none;
     }
 
     // Checkbox stuff --------------------

--- a/packages/app/src/styles/genome-spy-app.scss
+++ b/packages/app/src/styles/genome-spy-app.scss
@@ -579,8 +579,7 @@ $menu-line-height: 22px;
         .modal-body.markdown img {
             max-width: 350px;
             display: block;
-            margin-left: auto;
-            margin-right: auto;
+            margin: 1em auto;
         }
     }
 

--- a/packages/app/src/styles/genome-spy-app.scss
+++ b/packages/app/src/styles/genome-spy-app.scss
@@ -575,6 +575,13 @@ $menu-line-height: 22px;
         .modal-title {
             padding-right: 3em;
         }
+
+        .modal-body.markdown img {
+            max-width: 350px;
+            display: block;
+            margin-left: auto;
+            margin-right: auto;
+        }
     }
 
     .collapse {

--- a/packages/app/src/utils/ui/modal.js
+++ b/packages/app/src/utils/ui/modal.js
@@ -8,7 +8,14 @@ export function createCloseEvent() {
 }
 
 /**
+ * @typedef {object} Modal
+ * @prop {HTMLDivElement} content
+ * @prop {() => void} close
+ */
+
+/**
  * @param {"default" | "tour"} type
+ * @returns {Modal}
  */
 export function createModal(type = "default") {
     const root = document.createElement("div");

--- a/packages/app/src/utils/ui/modal.js
+++ b/packages/app/src/utils/ui/modal.js
@@ -7,9 +7,16 @@ export function createCloseEvent() {
     return new CustomEvent(CLOSE_EVENT_TYPE, { bubbles: true });
 }
 
-export function createModal() {
+/**
+ * @param {"default" | "tour"} type
+ */
+export function createModal(type = "default") {
     const root = document.createElement("div");
-    root.className = "gs-modal";
+    root.classList.add("gs-modal");
+
+    if (type != "default") {
+        root.classList.add(type);
+    }
 
     const onKeyDown = (/** @type {KeyboardEvent} */ event) => {
         switch (event.key) {


### PR DESCRIPTION
This PR implements support for (readonly) server-side bookmarks. The bookmarks can be replayed as a "tour" that presents interesting findings, etc.

Also implemented a share button for making a link with the visualization state, title, and notes, without first saving a bookmark. Shared bookmarks can also be imported easily to the local IndexedDB.