### PR TITLE
feat(playground): validate spec using JSON schema

### DIFF
--- a/.github/workflows/docs-and-playground.yml
+++ b/.github/workflows/docs-and-playground.yml
@@ -35,14 +35,14 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Build JSON schema
+        run: npm -w @genome-spy/core run build:schema
+        
       - name: Build packages
         run: |
           npm -w @genome-spy/doc-embed run build
           npm -w @genome-spy/playground run build
 
-      - name: Build JSON schema
-        run: npm -w @genome-spy/core run build:schema
-        
       - name: Build docs
         run: npm run build:docs
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "vite-raw-plugin": "^1.0.1"
   },
   "scripts": {
-    "build": "npm -ws run build --if-present",
+    "build": "lerna run build",
     "build:docs": "mkdir -p docs/app && cp packages/doc-embed/dist/* docs/app/ && cp packages/core/dist/genome-spy-schema.json docs/ && mkdocs build",
     "lint": "eslint packages/*/src/",
     "test": "jest",

--- a/packages/app/src/app.js
+++ b/packages/app/src/app.js
@@ -314,7 +314,7 @@ export default class App {
             hashData.viewSettings = viewSettings;
         }
 
-        let hash =
+        const hash =
             hashData.actions.length ||
             Object.keys(hashData.scaleDomains).length ||
             hashData.viewSettings
@@ -362,22 +362,6 @@ export default class App {
         }
     }
 
-    /**
-     *
-     * @param {import("@genome-spy/core/spec/root").RootSpec} config
-     */
-    async updateConfig(config) {
-        // TODO: provenance etc must be re-registered etc
-        throw new Error("Broken");
-
-        /*
-        this.config = config;
-        // TODO: Preserve viewport
-        this.genomeSpy.destroy();
-        await this.launch();
-		*/
-    }
-
     getSampleView() {
         if (!this.genomeSpy?.viewRoot) {
             return;
@@ -403,8 +387,8 @@ export default class App {
  * @param {string} favImg
  */
 function setFavicon(favImg) {
-    let headTitle = document.querySelector("head");
-    let setFavicon = document.createElement("link");
+    const headTitle = document.querySelector("head");
+    const setFavicon = document.createElement("link");
     setFavicon.setAttribute("rel", "shortcut icon");
     setFavicon.setAttribute("href", favImg);
     headTitle.appendChild(setFavicon);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "exports": {
     ".": "./src/index.js",
     "./*": "./src/*",
-    "./genome-spy-schema.json": "./dist/genome-spy-schema.json"
+    "./schema.json": "./dist/schema.json"
   },
   "files": [
     "dist/",
@@ -30,7 +30,7 @@
     "prepublishOnly": "npm run build",
     "test:tsc": "tsc -p tsconfig.json",
     "checkSpec": "tsc --allowJs --checkJs --strict --noEmit --moduleResolution node --target es6 src/spec/root.d.ts",
-    "build:schema": "mkdir -p dist && ts-json-schema-generator --path 'src/spec/*.ts' --type RootSpec > dist/genome-spy-schema.json"
+    "build:schema": "mkdir -p dist && ts-json-schema-generator --path 'src/spec/*.ts' --type RootSpec > dist/schema.json"
   },
   "dependencies": {
     "@types/d3-array": "^3.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,8 @@
   "module": "src/index.js",
   "exports": {
     ".": "./src/index.js",
-    "./*": "./src/*"
+    "./*": "./src/*",
+    "./genome-spy-schema.json": "./dist/genome-spy-schema.json"
   },
   "files": [
     "dist/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "dev": "node dev-server.js",
-    "build": "vite build",
-    "prepublishOnly": "npm run build && npm run build:schema",
+    "build": "vite build && npm run build:schema",
+    "prepublishOnly": "npm run build",
     "test:tsc": "tsc -p tsconfig.json",
     "checkSpec": "tsc --allowJs --checkJs --strict --noEmit --moduleResolution node --target es6 src/spec/root.d.ts",
     "build:schema": "mkdir -p dist && ts-json-schema-generator --path 'src/spec/*.ts' --type RootSpec > dist/genome-spy-schema.json"

--- a/packages/core/src/spec/root.d.ts
+++ b/packages/core/src/spec/root.d.ts
@@ -2,7 +2,7 @@ import { GenomeConfig } from "./genome";
 import { ViewSpec } from "./view";
 
 interface RootConfig {
-    $schema: string;
+    $schema?: string;
 
     genome?: GenomeConfig;
 

--- a/packages/core/src/spec/root.d.ts
+++ b/packages/core/src/spec/root.d.ts
@@ -2,6 +2,8 @@ import { GenomeConfig } from "./genome";
 import { ViewSpec } from "./view";
 
 interface RootConfig {
+    $schema: string;
+
     genome?: GenomeConfig;
 
     baseUrl?: string;

--- a/packages/playground/src/codeEditor.js
+++ b/packages/playground/src/codeEditor.js
@@ -10,6 +10,8 @@ import "monaco-editor/esm/vs/editor/browser/controller/coreCommands.js";
 import "monaco-editor/esm/vs/editor/contrib/folding/folding.js";
 import "monaco-editor/esm/vs/editor/contrib/multicursor/multicursor.js";
 import "monaco-editor/esm/vs/editor/contrib/bracketMatching/bracketMatching.js";
+import "monaco-editor/esm/vs/editor/contrib/hover/hover.js";
+
 // @ts-ignore
 import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 

--- a/packages/playground/src/index.js
+++ b/packages/playground/src/index.js
@@ -5,10 +5,18 @@ import { faColumns, faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
 import { embed, icon as genomeSpyIcon } from "@genome-spy/core";
 import { debounce } from "@genome-spy/core/utils/debounce";
 import defaultSpec from "./defaultspec.json.txt";
+
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
+// Available after the core package has been built
+import schema from "@genome-spy/core/genome-spy-schema.json";
+
 import packageJson from "../package.json";
 import "./codeEditor";
 import "./filePane";
 import "./playground.scss";
+import addMarkdownProps from "./markdownProps";
+
+registerJsonSchema();
 
 const STORAGE_KEY = "playgroundSpec";
 
@@ -34,6 +42,20 @@ function toggleLayout() {
     layout = layouts[(layouts.indexOf(layout) + 1) % layouts.length];
     renderLayout();
     window.dispatchEvent(new Event("resize"));
+}
+
+function registerJsonSchema() {
+    addMarkdownProps(schema);
+    monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+        validate: true,
+        schemas: [
+            {
+                uri: "http://myserver/foo-schema.json", // id of the first schema
+                fileMatch: ["*"], // associate with our model
+                schema,
+            },
+        ],
+    });
 }
 
 /**

--- a/packages/playground/src/index.js
+++ b/packages/playground/src/index.js
@@ -8,7 +8,7 @@ import defaultSpec from "./defaultspec.json.txt";
 
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 // Available after the core package has been built
-import schema from "@genome-spy/core/genome-spy-schema.json";
+import schema from "@genome-spy/core/schema.json";
 
 import packageJson from "../package.json";
 import "./codeEditor";

--- a/packages/playground/src/markdownProps.js
+++ b/packages/playground/src/markdownProps.js
@@ -1,0 +1,22 @@
+/**
+ * Adds markdownDescription props to a schema. See https://github.com/Microsoft/monaco-editor/issues/885
+ *
+ * Copypasted from: https://github.com/vega/editor/blob/master/src/utils/markdownProps.ts
+ *
+ * @param {any} value
+ */
+export default function addMarkdownProps(value) {
+    if (typeof value === "object" && value !== null) {
+        if (value.description) {
+            value.markdownDescription = value.description;
+        }
+
+        for (const key in value) {
+            // eslint-disable-next-line no-prototype-builtins
+            if (value.hasOwnProperty(key)) {
+                value[key] = addMarkdownProps(value[key]);
+            }
+        }
+    }
+    return value;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,9 @@
       ],
       "@genome-spy/core/*": [
         "packages/core/src/*"
+      ],
+      "@genome-spy/core/genome-spy-schema.json": [
+        "packages/core/dist/genome-spy-schema.json"
       ]
     },
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,8 @@
       "@genome-spy/core/*": [
         "packages/core/src/*"
       ],
-      "@genome-spy/core/genome-spy-schema.json": [
-        "packages/core/dist/genome-spy-schema.json"
+      "@genome-spy/core/schema.json": [
+        "packages/core/dist/schema.json"
       ]
     },
     "resolveJsonModule": true,


### PR DESCRIPTION
The playground app now validates the spec against the latest schema. An explicit `$schema` prop is not needed. closes #67

There are still some issues that need to be fixed later:

- Publish the schema on the `genomespy.app` website. It's now available through CDNs. For example: `https://unpkg.com/@genome-spy/core/dist/schema.json`
- Publish a schema for the `app` package. It's almost the same as the `core` schema but has some additional props (such as `specId`) at the top level