### PR TITLE
"Remove group" action

### DIFF
--- a/packages/app/src/sampleView/groupOperations.js
+++ b/packages/app/src/sampleView/groupOperations.js
@@ -13,10 +13,10 @@ import { isNumber } from "vega-util";
  * @param {SampleGroup} sampleGroup
  * @param {function(any):any} accessor
  * @param {any[]} [groups] Explicitly specify the groups and their order
- * @param {string[]} [labels] Custom labels for the groups
+ * @param {string[]} [titles] Custom titles for the groups
  */
-export function groupSamplesByAccessor(sampleGroup, accessor, groups, labels) {
-    if (labels && !groups) {
+export function groupSamplesByAccessor(sampleGroup, accessor, groups, titles) {
+    if (titles && !groups) {
         throw new Error("Custom labels need explicit group order!");
     }
 
@@ -42,7 +42,7 @@ export function groupSamplesByAccessor(sampleGroup, accessor, groups, labels) {
 
     groupGroup.groups = sortedEntries.map(([name, samples], i) => ({
         name: "" + name,
-        label: labels ? labels[i] : name,
+        title: titles ? titles[i] : name,
         samples,
     }));
 
@@ -66,16 +66,21 @@ function groupSamplesByRawThresholds(sampleGroup, accessor, thresholds) {
             thresholds[i + 1].operator == "lte" ? "]" : ")"
         }`;
 
+    const groupName = (/** @type {number} */ groupIndex) =>
+        `Group ${groupIndex + 1}`;
+
     // TODO: Group ids should indicate if multiple identical thresholds were merged
     const groupIds = range(thresholds.length - 1).reverse();
 
+    const ta = createThresholdAccessor(
+        accessor,
+        thresholds.slice(1, thresholds.length - 1)
+    );
+
     groupSamplesByAccessor(
         sampleGroup,
-        createThresholdAccessor(
-            accessor,
-            thresholds.slice(1, thresholds.length - 1)
-        ),
-        groupIds,
+        (sample) => groupName(ta(sample)),
+        groupIds.map(groupName),
         groupIds.map(formatInterval)
     );
 }
@@ -118,7 +123,7 @@ export function groupSamplesByQuartiles(sampleGroup, accessor) {
 }
 
 /**
- * Returns an accessor that extracts a threshold-index (1-based) based
+ * Returns an accessor that extracts a group index (0-based) based
  * on the given thresholds.
  *
  * @param {function(any):any} accessor

--- a/packages/app/src/sampleView/groupOperations.js
+++ b/packages/app/src/sampleView/groupOperations.js
@@ -1,6 +1,7 @@
 import { group, quantileSorted, range, sort as d3sort } from "d3-array";
 import { format as d3format } from "d3-format";
 import { isNumber } from "vega-util";
+import { isGroupGroup } from "./sampleSlice";
 
 /**
  * @typedef {import("./sampleState").Group} Group
@@ -120,6 +121,37 @@ export function groupSamplesByQuartiles(sampleGroup, accessor) {
             operand: t,
         }))
     );
+}
+
+/**
+ *
+ * @param {GroupGroup} rootGroup
+ * @param {string[]} path An array of group names representing the path to the group.
+ *      The implicit ROOT group is excluded.
+ */
+export function removeGroup(rootGroup, path) {
+    if (path.length == 0) {
+        // Error!
+        return;
+    }
+
+    const index = rootGroup.groups.findIndex((group) => group.name == path[0]);
+
+    if (index < 0) {
+        // Error!
+        return;
+    }
+
+    if (path.length == 1) {
+        rootGroup.groups.splice(index, 1);
+    } else if (path.length > 1) {
+        const child = rootGroup.groups[index];
+        if (isGroupGroup(child)) {
+            removeGroup(child, [...path].splice(1));
+        } else {
+            // Error!
+        }
+    }
 }
 
 /**

--- a/packages/app/src/sampleView/groupPanel.js
+++ b/packages/app/src/sampleView/groupPanel.js
@@ -35,13 +35,20 @@ export class GroupPanel extends LayerView {
                     },
                     {
                         type: "formula",
-                        as: "_NA",
-                        expr: "datum.label == null",
+                        as: "_title",
+                        // The following fails if title is zero (number).
+                        // TODO: Implement isValid() from https://github.com/vega/vega/tree/main/packages/vega-functions
+                        expr: "datum.title || datum.name",
                     },
                     {
                         type: "formula",
-                        as: "label",
-                        expr: "datum.label != null ? datum.label: 'NA'",
+                        as: "_NA",
+                        expr: "datum._title === null",
+                    },
+                    {
+                        type: "formula",
+                        as: "_title",
+                        expr: "datum._title !== null ? datum._title: 'NA'",
                     },
                 ],
 
@@ -95,7 +102,7 @@ export class GroupPanel extends LayerView {
                             tooltip: null,
                         },
                         encoding: {
-                            text: { field: "label" },
+                            text: { field: "_title" },
                             opacity: {
                                 field: "_NA",
                                 type: "nominal",
@@ -160,10 +167,14 @@ export class GroupPanel extends LayerView {
 
         const data = groupLocations.map((g) => ({
             _index: g.key.index,
-            _name: g.key.group.name,
             _depth: g.key.depth,
             attribute: g.key.attributeLabel,
-            label: g.key.group.label,
+            // Name identifies a group
+            name: g.key.group.name,
+            // Title is shown in the vis, defaults to name
+            ...(g.key.group.name != g.key.group.title
+                ? { title: g.key.group.title }
+                : {}),
             n: g.key.n,
         }));
 

--- a/packages/app/src/sampleView/payloadTypes.d.ts
+++ b/packages/app/src/sampleView/payloadTypes.d.ts
@@ -36,6 +36,13 @@ export interface GroupByThresholds extends PayloadWithAttribute {
     thresholds: Threshold[];
 }
 
+export interface RemoveGroup {
+    /**
+     * An array of group names that represent the path to the group.
+     * The implicit ROOT group is excluded. */
+    path: string[];
+}
+
 export interface FilterByQuantitative extends PayloadWithAttribute {
     /** The comparison operator */
     operator: ComparisonOperatorType;

--- a/packages/app/src/sampleView/sampleSlice.js
+++ b/packages/app/src/sampleView/sampleSlice.js
@@ -64,7 +64,7 @@ function createInitialState() {
         groupMetadata: [],
         rootGroup: {
             name: "ROOT",
-            label: "Root",
+            title: "Root",
             samples: [],
         },
     };
@@ -134,7 +134,7 @@ export function createSampleSlice(getAttributeInfo) {
 
                 state.rootGroup = {
                     name: "ROOT",
-                    label: "Root",
+                    title: "Root",
                     samples: state.sampleData.ids,
                 };
             },

--- a/packages/app/src/sampleView/sampleSlice.js
+++ b/packages/app/src/sampleView/sampleSlice.js
@@ -4,6 +4,7 @@ import {
     groupSamplesByAccessor,
     groupSamplesByQuartiles,
     groupSamplesByThresholds,
+    removeGroup,
 } from "./groupOperations";
 import {
     filterNominal,
@@ -17,6 +18,7 @@ import {
 
 import { format as d3format } from "d3-format";
 import { html } from "lit";
+import { join } from "lit/directives/join.js";
 import {
     faSortAmountDown,
     faFilter,
@@ -51,6 +53,7 @@ const REMOVE_UNDEFINED = "removeUndefined";
 const GROUP_BY_NOMINAL = "groupByNominal";
 const GROUP_BY_QUARTILES = "groupToQuartiles";
 const GROUP_BY_THRESHOLDS = "groupByThresholds";
+const REMOVE_GROUP = "removeGroup";
 const RETAIN_MATCHED = "retainMatched";
 
 export const SAMPLE_SLICE_NAME = "sampleView";
@@ -274,6 +277,17 @@ export function createSampleSlice(getAttributeInfo) {
                 state.groupMetadata.push({
                     attribute: action.payload.attribute,
                 });
+            },
+
+            [REMOVE_GROUP]: (
+                state,
+                /** @type {PayloadAction<import("./payloadTypes").RemoveGroup>} */
+                action
+            ) => {
+                const root = state.rootGroup;
+                if (isGroupGroup(root)) {
+                    removeGroup(root, action.payload.path);
+                }
             },
 
             [RETAIN_MATCHED]: (
@@ -611,6 +625,20 @@ export function getActionInfo(action, getAttributeInfo) {
                     on ${attributeTitle}
                 `,
                 icon: faObjectGroup,
+            };
+        case REMOVE_GROUP:
+            return {
+                title: "Remove group",
+                provenanceTitle: html`
+                    Remove group
+                    ${join(
+                        /** @type {import("./payloadTypes").RemoveGroup} */ (
+                            payload
+                        ).path.map((name) => html`<strong>${name}</strong>`),
+                        " / "
+                    )}
+                `,
+                icon: faTrashAlt,
             };
         case RETAIN_MATCHED:
             return {

--- a/packages/app/src/sampleView/sampleState.d.ts
+++ b/packages/app/src/sampleView/sampleState.d.ts
@@ -22,8 +22,8 @@ export interface BaseGroup {
     /** e.g., an attribute value that forms a group. Used as a key when identifying subgroups. */
     name: string;
 
-    /** A descriptive label for the group. May contain quantile intervals, etc. */
-    label: string;
+    /** A descriptive title for the group. May contain quantile intervals, etc. */
+    title: string;
 }
 
 export interface SampleGroup extends BaseGroup {

--- a/packages/core/src/spec/channel.d.ts
+++ b/packages/core/src/spec/channel.d.ts
@@ -293,7 +293,10 @@ export interface StringFieldDef<F extends Field>
     extends FieldDefWithoutScale<F>,
         FormatMixins {}
 
-export type TextDef<F extends Field> = StringFieldDef<F> | StringDatumDef;
+export type TextDef<F extends Field> =
+    | StringFieldDef<F>
+    | StringDatumDef
+    | ExprDef;
 
 export type ChannelDef<F extends Field = string> =
     Encoding<F>[keyof Encoding<F>];


### PR DESCRIPTION
Allows removal of groups. An example use case:

Split samples into three groups based on PFI thresholds 180 and 365:
* Poor survivors (PFI < 180)
* Uninteresting survivors (180 <= PFI < 365)
* Good survivors (365 <= PFI)

... and remove the *Uninteresting* group

![image](https://user-images.githubusercontent.com/399972/197618662-28b416b9-864d-4f2f-b04d-de76d6efb1f6.png)
