### PR TITLE
refactor: add `dataParent` to views, reorganize view hierarchy

### DIFF
--- a/packages/app/src/app.js
+++ b/packages/app/src/app.js
@@ -121,13 +121,15 @@ export default class App {
             (
                 /** @type {import("@genome-spy/core/spec/sampleView").SampleSpec} */ spec,
                 context,
-                parent,
+                layoutParent,
+                dataParent,
                 defaultName
             ) =>
                 new SampleView(
                     spec,
                     context,
-                    parent,
+                    layoutParent,
+                    dataParent,
                     defaultName,
                     this.provenance
                 )

--- a/packages/app/src/components/viewSettingsButton.js
+++ b/packages/app/src/components/viewSettingsButton.js
@@ -4,7 +4,6 @@ import { LitElement, html, nothing } from "lit";
 import { live } from "lit/directives/live.js";
 import AxisView from "@genome-spy/core/view/axisView";
 import LayerView from "@genome-spy/core/view/layerView";
-import { VISIT_SKIP } from "@genome-spy/core/view/view";
 import {
     findUniqueViewNames,
     isCustomViewName,
@@ -14,11 +13,15 @@ import { queryDependency } from "../utils/dependency";
 import { nestPaths } from "../utils/nestPaths";
 import { toggleDropdown } from "../utils/ui/dropdown";
 import { viewSettingsSlice } from "../viewSettingsSlice";
+import {
+    nodesToTreesWithAccessor,
+    visitTree,
+} from "@genome-spy/core/utils/trees";
 
-/**
- * @typedef {import("@genome-spy/core/view/view").default} View
- */
 class ViewSettingsButton extends LitElement {
+    /**
+     * @typedef {import("@genome-spy/core/view/view").default} View
+     */
     constructor() {
         super();
 
@@ -110,20 +113,29 @@ class ViewSettingsButton extends LitElement {
         }
 
         /** @type {View[]} */
-        const views = [];
+        const nodes = [];
 
-        viewRoot.visit((view) => {
-            if (view instanceof AxisView) {
-                return VISIT_SKIP;
-            }
-            views.push(view);
-        });
+        for (const tree of nodesToTreesWithAccessor(
+            viewRoot.getDescendants(),
+            (view) => view.dataParent
+        )) {
+            visitTree(tree, {
+                preOrder: (node) => {
+                    const view = node.ref;
+                    if (view instanceof AxisView) {
+                        return "skip";
+                    }
+                    nodes.push(view);
+                },
+            });
+        }
 
-        const paths = views
+        // Do some flattening to the hierarchy, filter some levels out
+        const paths = nodes
             .filter(
                 (view) => isCustomViewName(view.name) && isConfigurable(view)
             )
-            .map((view) => [...view.getLayoutAncestors()].reverse());
+            .map((view) => [...view.getDataAncestors()].reverse());
 
         this.nestedPaths = nestPaths(paths);
     }

--- a/packages/app/src/components/viewSettingsButton.js
+++ b/packages/app/src/components/viewSettingsButton.js
@@ -123,7 +123,7 @@ class ViewSettingsButton extends LitElement {
             .filter(
                 (view) => isCustomViewName(view.name) && isConfigurable(view)
             )
-            .map((view) => [...view.getAncestors()].reverse());
+            .map((view) => [...view.getLayoutAncestors()].reverse());
 
         this.nestedPaths = nestPaths(paths);
     }
@@ -218,6 +218,6 @@ class ViewSettingsButton extends LitElement {
 
 const isConfigurable = (/** @type {View} */ view) =>
     view.spec.configurableVisibility ??
-    !(view.parent && view.parent instanceof LayerView);
+    !(view.layoutParent && view.layoutParent instanceof LayerView);
 
 customElements.define("genome-spy-view-visibility", ViewSettingsButton);

--- a/packages/app/src/sampleView/groupPanel.js
+++ b/packages/app/src/sampleView/groupPanel.js
@@ -5,11 +5,6 @@ import LayerView from "@genome-spy/core/view/layerView";
 import { contextMenu } from "../utils/ui/contextMenu";
 import { iterateGroupHierarchy } from "./sampleSlice";
 
-/**
- * @typedef {import("./sampleView").Sample} Sample
- * @typedef {import("@genome-spy/core/view/view").default} View
- *
- */
 export class GroupPanel extends LayerView {
     /**
      * @param {import("./sampleView").default} sampleView

--- a/packages/app/src/sampleView/groupPanel.js
+++ b/packages/app/src/sampleView/groupPanel.js
@@ -120,6 +120,7 @@ export class GroupPanel extends LayerView {
             },
             sampleView.context,
             undefined,
+            undefined,
             "sample-groups"
         );
 
@@ -236,7 +237,7 @@ export class GroupPanel extends LayerView {
         }
 
         // TODO: Get rid of the following. Should happen automatically:
-        peek([...this.getAncestors()]).visit((view) =>
+        peek([...this.getLayoutAncestors()]).visit((view) =>
             invalidatePrefix(view, "size")
         );
     }

--- a/packages/app/src/sampleView/mergeFacets.js
+++ b/packages/app/src/sampleView/mergeFacets.js
@@ -182,7 +182,7 @@ export default class MergeSampleFacets extends FlowNode {
  * @param {View} view
  */
 function findProvenance(view) {
-    for (const v of view.getAncestors()) {
+    for (const v of view.getLayoutAncestors()) {
         if (v instanceof SampleView) {
             return v.provenance;
         }

--- a/packages/app/src/sampleView/sampleAttributePanel.js
+++ b/packages/app/src/sampleView/sampleAttributePanel.js
@@ -333,6 +333,7 @@ export class SampleAttributePanel extends ConcatView {
         views.push(
             this.context.createView(
                 createLabelViewSpec(this.sampleView.spec.samples),
+                this,
                 this
             )
         );
@@ -340,6 +341,7 @@ export class SampleAttributePanel extends ConcatView {
         for (const attribute of this.getAttributeNames()) {
             const view = this.context.createView(
                 this._createAttributeViewSpec(attribute),
+                this,
                 this
             );
             view.opacityFunction = (parentOpacity) =>

--- a/packages/app/src/sampleView/sampleAttributePanel.js
+++ b/packages/app/src/sampleView/sampleAttributePanel.js
@@ -55,6 +55,8 @@ export class SampleAttributePanel extends ConcatView {
             sampleView.context,
             // TODO: fix parent
             undefined,
+            // TODO: fix parent
+            undefined,
             "sample-metadata"
         );
 
@@ -105,23 +107,22 @@ export class SampleAttributePanel extends ConcatView {
         });
 
         // TODO: Implement "mouseleave" event. Let's hack for now...
-        peek([...this.sampleView.getAncestors()]).addInteractionEventListener(
-            "mousemove",
-            (coords, event) => {
-                if (!this._attributeHighlighState.currentAttribute) {
-                    return;
-                }
-                if (event.target) {
-                    for (const view of event.target.getAncestors()) {
-                        if (view == this) {
-                            return;
-                        }
+        peek([
+            ...this.sampleView.getLayoutAncestors(),
+        ]).addInteractionEventListener("mousemove", (coords, event) => {
+            if (!this._attributeHighlighState.currentAttribute) {
+                return;
+            }
+            if (event.target) {
+                for (const view of event.target.getLayoutAncestors()) {
+                    if (view == this) {
+                        return;
                     }
                 }
-
-                this._handleAttributeHighlight(undefined);
             }
-        );
+
+            this._handleAttributeHighlight(undefined);
+        });
     }
 
     /**
@@ -505,7 +506,7 @@ export class SampleAttributePanel extends ConcatView {
 
     /**
      * @param {string} channel
-     * @param {import("@genome-spy/core/view/containerView").ResolutionTarget} resolutionType
+     * @param {import("@genome-spy/core/spec/view").ResolutionTarget} resolutionType
      * @returns {import("@genome-spy/core/spec/view").ResolutionBehavior}
      */
     getDefaultResolution(channel, resolutionType) {

--- a/packages/app/src/sampleView/sampleAttributePanel.js
+++ b/packages/app/src/sampleView/sampleAttributePanel.js
@@ -29,14 +29,12 @@ const SAMPLE_NAME = "SAMPLE_NAME";
 const attributeViewRegex = /^attribute-(.*)$/;
 
 /**
- * @typedef {import("./sampleView").Sample} Sample
- * @typedef {import("@genome-spy/core/view/view").default} View
- */
-
-/**
  * This special-purpose class takes care of rendering sample labels and metadata.
  */
 export class SampleAttributePanel extends ConcatView {
+    /**
+     * @typedef {import("@genome-spy/core/view/view").default} View
+     */
     /**
      * @param {import("./sampleView").default} sampleView
      */
@@ -53,10 +51,8 @@ export class SampleAttributePanel extends ConcatView {
                 },
             },
             sampleView.context,
-            // TODO: fix parent
-            undefined,
-            // TODO: fix parent
-            undefined,
+            sampleView,
+            sampleView,
             "sample-metadata"
         );
 
@@ -265,7 +261,7 @@ export class SampleAttributePanel extends ConcatView {
     /**
      * TODO: Attach this to state observer
      *
-     * @param {Sample[]} samples
+     * @param {import("./sampleState").Sample[]} samples
      */
     _setSamples(samples) {
         if (this.childCount) {

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -54,23 +54,25 @@ const SPACING = 10;
  * Implements faceting of multiple samples. The samples are displayed
  * as tracks and optional metadata.
  *
- * @typedef {import("./sampleState").Group} Group
- * @typedef {import("./sampleState").Sample} Sample
- * @typedef {import("@genome-spy/core/utils/layout/flexLayout").LocSize} LocSize
- * @typedef {import("@genome-spy/core/view/view").default} View
- * @typedef {import("@genome-spy/core/view/layerView").default} LayerView
- * @typedef {import("@genome-spy/core/data/dataFlow").default<View>} DataFlow
- * @typedef {import("@genome-spy/core/genome/genome").ChromosomalLocus} ChromosomalLocus
- *
- * @typedef {object} LocusSpecifier
- * @prop {string} view A unique name of the view
- * @prop {string} field
- * @prop {number | ChromosomalLocus} locus Locus on the domain
- *
- * @typedef {import("./sampleViewTypes").SampleLocation} SampleLocation
- * @typedef {import("./sampleViewTypes").GroupLocation} GroupLocation
  */
 export default class SampleView extends ContainerView {
+    /**
+     * @typedef {import("./sampleState").Group} Group
+     * @typedef {import("./sampleState").Sample} Sample
+     * @typedef {import("@genome-spy/core/utils/layout/flexLayout").LocSize} LocSize
+     * @typedef {import("@genome-spy/core/view/view").default} View
+     * @typedef {import("@genome-spy/core/view/layerView").default} LayerView
+     * @typedef {import("@genome-spy/core/data/dataFlow").default<View>} DataFlow
+     * @typedef {import("@genome-spy/core/genome/genome").ChromosomalLocus} ChromosomalLocus
+     *
+     * @typedef {object} LocusSpecifier
+     * @prop {string} view A unique name of the view
+     * @prop {string} field
+     * @prop {number | ChromosomalLocus} locus Locus on the domain
+     *
+     * @typedef {import("./sampleViewTypes").SampleLocation} SampleLocation
+     * @typedef {import("./sampleViewTypes").GroupLocation} GroupLocation
+     */
     _peekState = 0;
 
     /**
@@ -99,7 +101,10 @@ export default class SampleView extends ContainerView {
         );
 
         this.summaryViews = new ConcatView(
-            { vconcat: [] },
+            {
+                configurableVisibility: false,
+                vconcat: [],
+            },
             context,
             this,
             this,

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -76,12 +76,13 @@ export default class SampleView extends ContainerView {
      *
      * @param {import("@genome-spy/core/spec/sampleView").SampleSpec} spec
      * @param {import("@genome-spy/core/types/viewContext").default} context
-     * @param {ContainerView} parent
+     * @param {ContainerView} layoutParent
+     * @param {import("@genome-spy/core/view/view").default} dataParent
      * @param {string} name
      * @param {import("../state/provenance").default<any>} provenance
      */
-    constructor(spec, context, parent, name, provenance) {
-        super(spec, context, parent, name);
+    constructor(spec, context, layoutParent, dataParent, name, provenance) {
+        super(spec, context, layoutParent, dataParent, name);
 
         this.provenance = provenance;
 
@@ -93,12 +94,13 @@ export default class SampleView extends ContainerView {
 
         /** @type { UnitView | LayerView } */
         this.child = /** @type { UnitView | LayerView } */ (
-            context.createView(spec.spec, this, "sample-facets")
+            context.createView(spec.spec, this, this, "sample-facets")
         );
 
         this.summaryViews = new ConcatView(
             { vconcat: [] },
             context,
+            this,
             this,
             "sampleSummaries"
         );
@@ -144,6 +146,7 @@ export default class SampleView extends ContainerView {
             },
             context,
             this,
+            this,
             "sample-sidebar"
         );
         this.peripheryCoords = Rectangle.ZERO;
@@ -159,6 +162,7 @@ export default class SampleView extends ContainerView {
                 const unitView = new UnitView(
                     createBackground(viewBackground),
                     this.context,
+                    this,
                     this,
                     "sample-background"
                 );
@@ -702,7 +706,7 @@ export default class SampleView extends ContainerView {
             return;
         }
 
-        if (!this.parent) {
+        if (!this.layoutParent) {
             // Usually padding is applied by GridView, but if this is the root view, we need to apply it here
             coords = coords.shrink(this.getPadding());
         }
@@ -906,7 +910,7 @@ export default class SampleView extends ContainerView {
             this.getScaleResolution("x").invertToComplex(normalizedXPos);
 
         const uniqueViewNames = findUniqueViewNames(
-            [...this.getAncestors()].at(-1)
+            [...this.getLayoutAncestors()].at(-1)
         );
 
         const fieldInfos = findEncodedFields(this.child)
@@ -1037,7 +1041,7 @@ export default class SampleView extends ContainerView {
 
     /**
      * @param {string} channel
-     * @param {import("@genome-spy/core/view/containerView").ResolutionTarget} resolutionType
+     * @param {import("@genome-spy/core/spec/view").ResolutionTarget} resolutionType
      * @returns {import("@genome-spy/core/spec/view").ResolutionBehavior}
      */
     getDefaultResolution(channel, resolutionType) {

--- a/packages/core/src/data/flowNode.js
+++ b/packages/core/src/data/flowNode.js
@@ -212,13 +212,11 @@ export default class FlowNode {
         const childTree = this.children
             .map((child) => child.subtreeToString(depth + 1))
             .join("");
-        return (
-            " ".repeat(depth * 2) +
-            "* " +
-            /^class ([A-Za-z0-9_]+)/.exec("" + this.constructor)?.[1] +
-            "\n" +
-            childTree
-        );
+        return `${" ".repeat(depth * 2)}* ${this.constructor.name}${
+            ("identifier" in this && this.identifier
+                ? ": " + this.identifier
+                : "") ?? ""
+        } \n${childTree}`;
     }
 
     /**

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -369,7 +369,10 @@ export default class GenomeSpy {
         optimizeDataFlow(flow);
         this.broadcast("dataFlowBuilt", flow);
 
-        flow.dataSources.forEach((ds) => console.log(ds.subtreeToString()));
+        // @ts-expect-error
+        if (import.meta.env.DEV) {
+            flow.dataSources.forEach((ds) => console.log(ds.subtreeToString()));
+        }
 
         // Create encoders (accessors, scales and related metadata)
         unitViews.forEach((view) => view.mark.initializeEncoders());

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -313,11 +313,12 @@ export default class GenomeSpy {
 
             isViewSpec: (spec) => self.viewFactory.isViewSpec(spec),
 
-            createView: function (spec, parent, defaultName) {
+            createView: function (spec, layoutParent, dataParent, defaultName) {
                 return self.viewFactory.createView(
                     spec,
                     context,
-                    parent,
+                    layoutParent,
+                    dataParent,
                     defaultName
                 );
             },
@@ -331,7 +332,7 @@ export default class GenomeSpy {
         }
 
         // Create the view hierarchy
-        this.viewRoot = context.createView(rootSpec, null, "viewRoot");
+        this.viewRoot = context.createView(rootSpec, null, null, "viewRoot");
 
         // Replace placeholder ImportViews with actual views.
         await processImports(this.viewRoot);
@@ -569,7 +570,7 @@ export default class GenomeSpy {
                         ? {
                               type: event.type,
                               viewPath: this._currentHover.mark.unitView
-                                  .getAncestors()
+                                  .getLayoutAncestors()
                                   .map((view) => view.name)
                                   .reverse(),
                               datum: this._currentHover.datum,

--- a/packages/core/src/marks/mark.js
+++ b/packages/core/src/marks/mark.js
@@ -285,7 +285,9 @@ export default class Mark {
             // e.g., view background or an x axis.
             // This could also be more generic and work with other faceting views
             // that will be available in the future.
-            this.unitView.getAncestors().find((view) => "samples" in view.spec)
+            this.unitView
+                .getLayoutAncestors()
+                .find((view) => "samples" in view.spec)
         ) {
             return SAMPLE_FACET_UNIFORM;
         }
@@ -556,7 +558,7 @@ export default class Mark {
             return false;
         }
 
-        for (const view of this.unitView.getAncestors()) {
+        for (const view of this.unitView.getLayoutAncestors()) {
             if (!view.isPickingSupported()) {
                 return false;
             }
@@ -662,7 +664,7 @@ export default class Mark {
             ops.push(() => {
                 /** @type {WebGLTexture} */
                 let facetTexture;
-                for (const view of this.unitView.getAncestors()) {
+                for (const view of this.unitView.getLayoutAncestors()) {
                     facetTexture = view.getSampleFacetTexture();
                     if (facetTexture) {
                         break;

--- a/packages/core/src/types/viewContext.d.ts
+++ b/packages/core/src/types/viewContext.d.ts
@@ -76,7 +76,8 @@ export default interface ViewContext {
 
     createView: (
         spec: ViewSpec,
-        parent?: ContainerView,
+        layoutParent?: ContainerView,
+        dataParent?: View,
         defaultName?: string
     ) => View;
 }

--- a/packages/core/src/utils/trees.js
+++ b/packages/core/src/utils/trees.js
@@ -1,0 +1,78 @@
+/**
+ * Takes an array of nodes that have parent references and turns them into a
+ * tree of nodes. The original nodes are not modified, they are wrapped in a
+ * new object. Uses a custom accessor for parent.
+ *
+ * @param {T[]} nodes
+ * @param {(node: T) => T} parentAccessor
+ * @template T
+ * @returns {NodeWrapper<T>[]}
+ */
+export function nodesToTreesWithAccessor(nodes, parentAccessor) {
+    /**
+     * @typedef {object} NodeWrapper
+     * @prop {T} ref
+     * @prop {NodeWrapper<T>[]} children
+     * @template T
+     */
+
+    /** @type {Map<T, NodeWrapper<T>>} */
+    const nodeMap = new Map();
+    const rootNodes = [];
+
+    for (const node of nodes) {
+        nodeMap.set(node, { ref: node, children: [] });
+    }
+
+    for (const nodeWrapper of nodeMap.values()) {
+        const parent = nodeMap.get(parentAccessor(nodeWrapper.ref));
+        if (parent) {
+            parent.children.push(nodeWrapper);
+        } else {
+            rootNodes.push(nodeWrapper);
+        }
+    }
+
+    return rootNodes;
+}
+
+/**
+ * Takes an array of nodes that have parent references and turns them into a
+ * tree of nodes. The original nodes are not modified, they are wrapped in a
+ * new object.
+ *
+ * @param {T[]} nodes
+ * @template {{ parent: T}} T
+ */
+export function nodesToTrees(nodes) {
+    return nodesToTreesWithAccessor(nodes, (node) => node.parent);
+}
+
+/**
+ * Visits a tree using depth-first search. Uses a custom accessor for children.
+ *
+ * @param {T} rootNode
+ * @param {{ preOrder?: (node: T) => void, postOrder?: (node: T) => void}} visitor
+ * @param {(node: T) => Iterable<T>} childrenAccessor
+ * @template T
+ */
+export function visitTreeWithAccessor(rootNode, visitor, childrenAccessor) {
+    visitor.preOrder?.(rootNode);
+
+    for (const child of childrenAccessor(rootNode)) {
+        visitTreeWithAccessor(child, visitor, childrenAccessor);
+    }
+
+    visitor.postOrder?.(rootNode);
+}
+
+/**
+ * Visits a tree using depth-first search.
+ *
+ * @param {T} rootNode
+ * @param {{ preOrder?: (node: T) => void, postOrder?: (node: T) => void}} visitor
+ * @template {{ children: T[] }} T
+ */
+export function visitTree(rootNode, visitor) {
+    visitTreeWithAccessor(rootNode, visitor, (node) => node.children);
+}

--- a/packages/core/src/utils/trees.test.js
+++ b/packages/core/src/utils/trees.test.js
@@ -1,0 +1,126 @@
+import { expect, test } from "vitest";
+import { nodesToTrees, visitTree } from "./trees";
+import { describe } from "vitest";
+
+describe("NodesToTrees", () => {
+    test("NodesToTrees converts an array of nodes to a tree", () => {
+        const a = { parent: null };
+        const b = { parent: a };
+        const c = { parent: a };
+        const d = { parent: b };
+        const e = { parent: b };
+
+        const nodes = [a, b, c, d, e];
+
+        const trees = nodesToTrees(nodes);
+
+        expect(trees).toEqual([
+            {
+                ref: a,
+                children: [
+                    {
+                        ref: b,
+                        children: [
+                            {
+                                ref: d,
+                                children: [],
+                            },
+                            {
+                                ref: e,
+                                children: [],
+                            },
+                        ],
+                    },
+                    {
+                        ref: c,
+                        children: [],
+                    },
+                ],
+            },
+        ]);
+    });
+
+    test("NodesToTrees converts two disjoint node arrays to two trees", () => {
+        const a = { parent: null };
+        const b = { parent: a };
+
+        const c = { parent: null };
+        const d = { parent: c };
+
+        const nodes = [a, b, c, d];
+
+        const trees = nodesToTrees(nodes);
+
+        expect(trees).toEqual([
+            {
+                ref: a,
+                children: [
+                    {
+                        ref: b,
+                        children: [],
+                    },
+                ],
+            },
+            {
+                ref: c,
+                children: [
+                    {
+                        ref: d,
+                        children: [],
+                    },
+                ],
+            },
+        ]);
+    });
+});
+
+describe("VisitTree", () => {
+    test("VisitTree visits all nodes in a tree in correct order", () => {
+        const tree = {
+            id: "a",
+            children: [
+                {
+                    id: "b",
+                    children: [
+                        {
+                            id: "d",
+                            children: [],
+                        },
+                        {
+                            id: "e",
+                            children: [],
+                        },
+                    ],
+                },
+                {
+                    id: "c",
+                    children: [],
+                },
+            ],
+        };
+
+        const visitedPre = [];
+        const visitedPost = [];
+
+        visitTree(tree, {
+            preOrder: (node) => visitedPre.push(node),
+            postOrder: (node) => visitedPost.push(node),
+        });
+
+        expect(visitedPre.map((node) => node.id)).toEqual([
+            "a",
+            "b",
+            "d",
+            "e",
+            "c",
+        ]);
+
+        expect(visitedPost.map((node) => node.id)).toEqual([
+            "d",
+            "e",
+            "b",
+            "c",
+            "a",
+        ]);
+    });
+});

--- a/packages/core/src/utils/trees.test.js
+++ b/packages/core/src/utils/trees.test.js
@@ -103,8 +103,12 @@ describe("VisitTree", () => {
         const visitedPost = [];
 
         visitTree(tree, {
-            preOrder: (node) => visitedPre.push(node),
-            postOrder: (node) => visitedPost.push(node),
+            preOrder: (node) => {
+                visitedPre.push(node);
+            },
+            postOrder: (node) => {
+                visitedPost.push(node);
+            },
         });
 
         expect(visitedPre.map((node) => node.id)).toEqual([

--- a/packages/core/src/view/axisGridView.js
+++ b/packages/core/src/view/axisGridView.js
@@ -18,9 +18,10 @@ export default class AxisGridView extends LayerView {
      * @param {Axis} axisProps
      * @param {import("../types/viewContext").default} context
      * @param {string} type Data type (quantitative, ..., locus)
-     * @param {import("./containerView").default} parent
+     * @param {import("./containerView").default} layoutParent
+     * @param {import("./view").default} dataParent
      */
-    constructor(axisProps, type, context, parent) {
+    constructor(axisProps, type, context, layoutParent, dataParent) {
         // Now the presence of genomeAxis is based on field type, not scale type.
         // TODO: Use scale instead. However, it would make the initialization much more
         // complex because scales are not available before scale resolution.
@@ -35,7 +36,8 @@ export default class AxisGridView extends LayerView {
         super(
             createAxisGrid(fullAxisProps, type),
             context,
-            parent,
+            layoutParent,
+            dataParent,
             `axisGrid_${axisProps.orient}`
         );
 

--- a/packages/core/src/view/axisView.js
+++ b/packages/core/src/view/axisView.js
@@ -64,9 +64,10 @@ export default class AxisView extends LayerView {
      * @param {Axis} axisProps
      * @param {import("../types/viewContext").default} context
      * @param {string} type Data type (quantitative, ..., locus)
-     * @param {import("./containerView").default} parent
+     * @param {import("./containerView").default} layoutParent
+     * @param {import("./view").default} dataParent
      */
-    constructor(axisProps, type, context, parent) {
+    constructor(axisProps, type, context, layoutParent, dataParent) {
         // Now the presence of genomeAxis is based on field type, not scale type.
         // TODO: Use scale instead. However, it would make the initialization much more
         // complex because scales are not available before scale resolution.
@@ -86,7 +87,8 @@ export default class AxisView extends LayerView {
                 ? createGenomeAxis(fullAxisProps, type)
                 : createAxis(fullAxisProps, type),
             context,
-            parent,
+            layoutParent,
+            dataParent,
             `axis_${axisProps.orient}`
         );
 

--- a/packages/core/src/view/concatView.js
+++ b/packages/core/src/view/concatView.js
@@ -9,14 +9,16 @@ export default class ConcatView extends GridView {
      *
      * @param {import("../spec/view").AnyConcatSpec} spec
      * @param {import("../types/viewContext").default} context
-     * @param {import("./containerView").default} parent
+     * @param {import("./containerView").default} layoutParent
+     * @param {import("./view").default} dataParent
      * @param {string} name
      */
-    constructor(spec, context, parent, name) {
+    constructor(spec, context, layoutParent, dataParent, name) {
         super(
             spec,
             context,
-            parent,
+            layoutParent,
+            dataParent,
             name,
             isConcatSpec(spec)
                 ? spec.columns
@@ -39,7 +41,7 @@ export default class ConcatView extends GridView {
         this.setChildren(
             childSpecs.map((childSpec, i) =>
                 // @ts-expect-error TODO: Fix typing
-                this.context.createView(childSpec, this, "grid" + i)
+                this.context.createView(childSpec, this, this, "grid" + i)
             )
         );
     }

--- a/packages/core/src/view/containerView.js
+++ b/packages/core/src/view/containerView.js
@@ -127,33 +127,11 @@ export default class ContainerView extends View {
     }
 
     /**
-     * @param {import("../spec/channel").Channel | "default"} channel
-     * @param {import("../spec/view").ResolutionTarget} resolutionType
-     * @returns {import("../spec/view").ResolutionBehavior}
-     */
-    getConfiguredResolution(channel, resolutionType) {
-        return this.spec.resolve?.[resolutionType]?.[channel];
-    }
-
-    /**
      * @param {import("../spec/channel").Channel} channel
      * @param {import("../spec/view").ResolutionTarget} resolutionType
      * @returns {import("../spec/view").ResolutionBehavior}
      */
     getDefaultResolution(channel, resolutionType) {
         return "shared";
-    }
-
-    /**
-     * @param {import("../spec/channel").Channel} channel
-     * @param {import("../spec/view").ResolutionTarget} resolutionType
-     * @returns {import("../spec/view").ResolutionBehavior}
-     */
-    getConfiguredOrDefaultResolution(channel, resolutionType) {
-        return (
-            this.getConfiguredResolution(channel, resolutionType) ??
-            this.getConfiguredResolution("default", resolutionType) ??
-            this.getDefaultResolution(channel, resolutionType)
-        );
     }
 }

--- a/packages/core/src/view/containerView.js
+++ b/packages/core/src/view/containerView.js
@@ -2,18 +2,18 @@ import View, { VISIT_STOP, VISIT_SKIP } from "./view";
 
 /**
  * Compositor view represents a non-leaf node in the view hierarchy.
- * @typedef {import("../spec/view").ResolutionTarget} ResolutionTarget
  */
 export default class ContainerView extends View {
     /**
      *
      * @param {import("../spec/view").ContainerSpec} spec
      * @param {import("../types/viewContext").default} context
-     * @param {ContainerView} parent
+     * @param {ContainerView} layoutParent
+     * @param {import("./view").default} dataParent
      * @param {string} name
      */
-    constructor(spec, context, parent, name) {
-        super(spec, context, parent, name);
+    constructor(spec, context, layoutParent, dataParent, name) {
+        super(spec, context, layoutParent, dataParent, name);
 
         this.spec = spec;
     }
@@ -128,7 +128,7 @@ export default class ContainerView extends View {
 
     /**
      * @param {import("../spec/channel").Channel | "default"} channel
-     * @param {ResolutionTarget} resolutionType
+     * @param {import("../spec/view").ResolutionTarget} resolutionType
      * @returns {import("../spec/view").ResolutionBehavior}
      */
     getConfiguredResolution(channel, resolutionType) {
@@ -137,7 +137,7 @@ export default class ContainerView extends View {
 
     /**
      * @param {import("../spec/channel").Channel} channel
-     * @param {ResolutionTarget} resolutionType
+     * @param {import("../spec/view").ResolutionTarget} resolutionType
      * @returns {import("../spec/view").ResolutionBehavior}
      */
     getDefaultResolution(channel, resolutionType) {
@@ -146,7 +146,7 @@ export default class ContainerView extends View {
 
     /**
      * @param {import("../spec/channel").Channel} channel
-     * @param {ResolutionTarget} resolutionType
+     * @param {import("../spec/view").ResolutionTarget} resolutionType
      * @returns {import("../spec/view").ResolutionBehavior}
      */
     getConfiguredOrDefaultResolution(channel, resolutionType) {

--- a/packages/core/src/view/gridView.js
+++ b/packages/core/src/view/gridView.js
@@ -159,7 +159,7 @@ export default class GridView extends ContainerView {
      * @param {View[]} views
      */
     setChildren(views) {
-        //this.#children = []; // TODO: Check why this breaks summary track
+        this.#children = [];
         for (const view of views) {
             this.appendChild(view);
         }

--- a/packages/core/src/view/gridView.js
+++ b/packages/core/src/view/gridView.js
@@ -63,12 +63,13 @@ export default class GridView extends ContainerView {
      *
      * @param {import("../spec/view").AnyConcatSpec} spec
      * @param {import("../types/viewContext").default} context
-     * @param {ContainerView} parent
+     * @param {ContainerView} layoutParent
+     * @param {View} dataParent
      * @param {string} name
      * @param {number} columns
      */
-    constructor(spec, context, parent, name, columns) {
-        super(spec, context, parent, name);
+    constructor(spec, context, layoutParent, dataParent, name, columns) {
+        super(spec, context, layoutParent, dataParent, name);
         this.spec = spec;
 
         this.#spacing = spec.spacing ?? 10;
@@ -105,6 +106,7 @@ export default class GridView extends ContainerView {
                 const unitView = new UnitView(
                     createBackground(viewBackground),
                     this.context,
+                    this,
                     view,
                     "background" + this.#childSerial
                 );
@@ -118,6 +120,7 @@ export default class GridView extends ContainerView {
                 const unitView = new UnitView(
                     title,
                     this.context,
+                    this,
                     view,
                     "title" + this.#childSerial
                 );
@@ -134,7 +137,7 @@ export default class GridView extends ContainerView {
      * @param {View} view
      */
     appendChild(view) {
-        view.parent ??= this;
+        view.layoutParent ??= this;
         this.#children.push(this.#makeGridChild(view));
         this.#childSerial++;
     }
@@ -249,7 +252,7 @@ export default class GridView extends ContainerView {
                     props,
                     r.scaleResolution.type,
                     this.context,
-                    // Note: AxisView has a unit/layerView as parent so that scale/axis resolutions are inherited correctly
+                    this,
                     axisParent
                 );
 
@@ -258,7 +261,7 @@ export default class GridView extends ContainerView {
                         props,
                         r.scaleResolution.type,
                         this.context,
-                        // Note: AxisGridView has a unit/layerView as parent so that scale/axis resolutions are inherited correctly
+                        this,
                         axisParent
                     );
                 }
@@ -554,7 +557,7 @@ export default class GridView extends ContainerView {
             return;
         }
 
-        if (!this.parent) {
+        if (!this.layoutParent) {
             // Usually padding is applied by the parent GridView, but if this is the root view, we need to apply it here
             coords = coords.shrink(this.getPadding());
         }
@@ -747,7 +750,7 @@ export default class GridView extends ContainerView {
 
     /**
      * @param {import("../spec/channel").Channel} channel
-     * @param {import("./containerView").ResolutionTarget} resolutionType
+     * @param {import("../spec/view").ResolutionTarget} resolutionType
      * @returns {import("../spec/view").ResolutionBehavior}
      */
     getDefaultResolution(channel, resolutionType) {

--- a/packages/core/src/view/implicitRootView.js
+++ b/packages/core/src/view/implicitRootView.js
@@ -16,6 +16,8 @@ export default class ImplicitRootView extends GridView {
         );
 
         view.layoutParent = this;
+        view.dataParent = this;
+
         this.appendChild(view);
     }
 }

--- a/packages/core/src/view/implicitRootView.js
+++ b/packages/core/src/view/implicitRootView.js
@@ -6,9 +6,16 @@ export default class ImplicitRootView extends GridView {
      * @param {import("./view").default} view
      */
     constructor(context, view) {
-        super({ vconcat: [] }, context, undefined, "implicitRoot", 1);
+        super(
+            { vconcat: [] },
+            context,
+            undefined,
+            undefined,
+            "implicitRoot",
+            1
+        );
 
-        view.parent = this;
+        view.layoutParent = this;
         this.appendChild(view);
     }
 }

--- a/packages/core/src/view/importView.js
+++ b/packages/core/src/view/importView.js
@@ -9,12 +9,13 @@ export default class ImportView extends View {
      *
      * @param {import("../spec/view").ImportSpec} spec
      * @param {import("../types/viewContext").default} context
-     * @param {import("./view").default} parent
+     * @param {import("./containerView").default} layoutParent
+     * @param {import("./view").default} dataParent
      * @param {string} name
      */
-    constructor(spec, context, parent, name) {
+    constructor(spec, context, layoutParent, dataParent, name) {
         // @ts-expect-error TODO: Fix typing
-        super(spec, context, parent, name);
+        super(spec, context, layoutParent, dataParent, name);
 
         this.spec = spec; // Set here again to keep types happy
     }

--- a/packages/core/src/view/layerView.js
+++ b/packages/core/src/view/layerView.js
@@ -9,11 +9,12 @@ export default class LayerView extends ContainerView {
      *
      * @param {import("../spec/view").LayerSpec} spec
      * @param {import("../types/viewContext").default} context
-     * @param {ContainerView} parent
+     * @param {ContainerView} layoutParent
+     * @param {import("./view").default} dataParent
      * @param {string} name
      */
-    constructor(spec, context, parent, name) {
-        super(spec, context, parent, name);
+    constructor(spec, context, layoutParent, dataParent, name) {
+        super(spec, context, layoutParent, dataParent, name);
 
         this.spec = spec;
 
@@ -21,7 +22,7 @@ export default class LayerView extends ContainerView {
         // @ts-expect-error TODO: Fix typing
         this.children = (spec.layer || []).map((childSpec, i) => {
             if (isLayerSpec(childSpec) || isUnitSpec(childSpec)) {
-                return context.createView(childSpec, this, "layer" + i);
+                return context.createView(childSpec, this, this, "layer" + i);
             } else {
                 throw new Error(
                     "LayerView accepts only unit or layer specs as children!"

--- a/packages/core/src/view/scaleResolution.js
+++ b/packages/core/src/view/scaleResolution.js
@@ -728,7 +728,7 @@ export default class ScaleResolution {
             .filter(
                 (member) =>
                     !member.view
-                        .getAncestors()
+                        .getLayoutAncestors()
                         // TODO: Should check until the resolved scale resolution
                         .some((view) => !view.contributesToScaleDomain)
             )

--- a/packages/core/src/view/testUtils.js
+++ b/packages/core/src/view/testUtils.js
@@ -26,7 +26,7 @@ export function create(spec, viewClass, context = undefined) {
         },
     });
 
-    const view = c.createView(spec, null, "root");
+    const view = c.createView(spec, null, null, "root");
 
     if (!(view instanceof viewClass)) {
         throw new Error("ViewClass and the spec do not match!");

--- a/packages/core/src/view/unitView.js
+++ b/packages/core/src/view/unitView.js
@@ -47,11 +47,12 @@ export default class UnitView extends ContainerView {
      *
      * @param {import("../spec/view").UnitSpec} spec
      * @param {import("../types/viewContext").default} context
-     * @param {import("./containerView").default} parent
+     * @param {import("./containerView").default} layoutParent
+     * @param {import("./view").default} dataParent
      * @param {string} name
      */
-    constructor(spec, context, parent, name) {
-        super(spec, context, parent, name);
+    constructor(spec, context, layoutParent, dataParent, name) {
+        super(spec, context, layoutParent, dataParent, name);
 
         this.spec = spec; // Set here again to keep types happy
 
@@ -128,7 +129,7 @@ export default class UnitView extends ContainerView {
     }
 
     /**
-     * Pulls scales and axes up in the view hierarcy according to the resolution rules.
+     * Pulls scales and axes up in the view hierarcy according to the resolution rules, using dataParents.
      * TODO: legends
      *
      * @param {ResolutionTarget} type
@@ -160,9 +161,9 @@ export default class UnitView extends ContainerView {
             while (
                 (view.getConfiguredOrDefaultResolution(targetChannel, type) ==
                     "forced" ||
-                    (view.parent instanceof ContainerView &&
+                    (view.dataParent instanceof ContainerView &&
                         ["shared", "excluded", "forced"].includes(
-                            view.parent.getConfiguredOrDefaultResolution(
+                            view.dataParent.getConfiguredOrDefaultResolution(
                                 targetChannel,
                                 type
                             )
@@ -171,7 +172,7 @@ export default class UnitView extends ContainerView {
                     "excluded"
             ) {
                 // @ts-ignore
-                view = view.parent;
+                view = view.dataParent;
             }
 
             // Quite a bit of redundancy, but makes type checker happy.
@@ -351,6 +352,7 @@ export default class UnitView extends ContainerView {
             .reduce((a, c) => a * c, 1);
     }
 
+    // TODO: Move this to SampleView
     _initializeAggregateViews() {
         if (isAggregateSamplesSpec(this.spec)) {
             // TODO: Support multiple
@@ -369,7 +371,7 @@ export default class UnitView extends ContainerView {
                 };
 
                 const summaryView = /** @type { UnitView | LayerView } */ (
-                    this.context.createView(sumSpec, this, "summaryView")
+                    this.context.createView(sumSpec, this, this, "summaryView")
                 );
 
                 /**
@@ -391,7 +393,7 @@ export default class UnitView extends ContainerView {
 
     /**
      * @param {string} channel
-     * @param {import("./containerView").ResolutionTarget} resolutionType
+     * @param {ResolutionTarget} resolutionType
      * @returns {import("../spec/view").ResolutionBehavior}
      */
     getDefaultResolution(channel, resolutionType) {

--- a/packages/core/src/view/view.js
+++ b/packages/core/src/view/view.js
@@ -364,6 +364,18 @@ export default class View {
     }
 
     /**
+     * Get all descendants of this view in depth-first order.
+     */
+    getDescendants() {
+        /** @type {View[]} */
+        const descendants = [];
+        this.visit((view) => {
+            descendants.push(view);
+        });
+        return descendants;
+    }
+
+    /**
      * Called after all scales in the view hierarchy have been resolved.
      */
     onScalesResolved() {
@@ -487,6 +499,37 @@ export default class View {
         return this.getDataAncestors()
             .map((view) => view.resolutions.axis[primaryChannel])
             .find((resolution) => resolution);
+    }
+
+    /**
+     * @param {import("../spec/channel").Channel | "default"} channel
+     * @param {import("../spec/view").ResolutionTarget} resolutionType
+     * @returns {import("../spec/view").ResolutionBehavior}
+     */
+    getConfiguredResolution(channel, resolutionType) {
+        return this.spec.resolve?.[resolutionType]?.[channel];
+    }
+
+    /**
+     * @param {import("../spec/channel").Channel} channel
+     * @param {import("../spec/view").ResolutionTarget} resolutionType
+     * @returns {import("../spec/view").ResolutionBehavior}
+     */
+    getConfiguredOrDefaultResolution(channel, resolutionType) {
+        return (
+            this.getConfiguredResolution(channel, resolutionType) ??
+            this.getConfiguredResolution("default", resolutionType) ??
+            this.getDefaultResolution(channel, resolutionType)
+        );
+    }
+
+    /**
+     * @param {import("../spec/channel").Channel} channel
+     * @param {import("../spec/view").ResolutionTarget} resolutionType
+     * @returns {import("../spec/view").ResolutionBehavior}
+     */
+    getDefaultResolution(channel, resolutionType) {
+        return "independent";
     }
 
     /**

--- a/packages/core/src/view/view.js
+++ b/packages/core/src/view/view.js
@@ -537,7 +537,7 @@ export default class View {
      */
     getBaseUrl() {
         return appendToBaseUrl(
-            () => this.layoutParent?.getBaseUrl(),
+            () => this.dataParent?.getBaseUrl(),
             this.spec.baseUrl
         );
     }

--- a/packages/core/src/view/view.test.js
+++ b/packages/core/src/view/view.test.js
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "vitest";
 import UnitView from "./unitView";
-import LayerView from "./layerView";
 
 import { create, createAndInitialize } from "./testUtils";
 import { toRegularArray as r } from "../utils/domainArray";
 import ConcatView from "./concatView";
 import PointMark from "../marks/pointMark";
 import View from "./view";
+import LayerView from "./layerView";
 
 describe("Trivial creations and initializations", () => {
     test("Fails on empty spec", () => {

--- a/packages/core/src/view/viewFactory.js
+++ b/packages/core/src/view/viewFactory.js
@@ -17,10 +17,8 @@ export class ViewFactory {
      * @typedef {import("../spec/view").ConcatSpec} ConcatSpec
      *
      * @typedef {(spec: ViewSpec) => boolean} SpecGuard
-     * @typedef {(spec: ViewSpec, context: ViewContext, parent?: import("./containerView").default, defaultName?: string) => View} Factory
+     * @typedef {(spec: ViewSpec, context: ViewContext, layoutParent?: import("./containerView").default, dataParent?: import("./view").default, defaultName?: string) => View} Factory
      */
-
-    /** */
     constructor() {
         /** @type {{specGuard: SpecGuard, factory: Factory}[]} */
         this.types = [];
@@ -28,12 +26,13 @@ export class ViewFactory {
         const makeDefaultFactory =
             (/** @type {typeof View} */ ViewClass) =>
             /** @type {Factory} */
-            (spec, context, parent, defaultName) =>
+            (spec, context, layoutParent, dataParent, defaultName) =>
                 /** @type {View} */ (
                     new ViewClass(
                         spec,
                         context,
-                        parent,
+                        layoutParent,
+                        dataParent,
                         spec.name ?? defaultName
                     )
                 );
@@ -59,16 +58,18 @@ export class ViewFactory {
     /**
      * @param {ViewSpec} spec
      * @param {ViewContext} context
-     * @param {import("./containerView").default} [parent]
+     * @param {import("./containerView").default} [layoutParent]
+     * @param {import("./view").default} [dataParent]
      * @param {string} [defaultName]
      */
-    createView(spec, context, parent, defaultName) {
+    createView(spec, context, layoutParent, dataParent, defaultName) {
         const type = this.types.find((type) => type.specGuard(spec));
         if (type) {
             return type.factory(
                 spec,
                 context,
-                parent,
+                layoutParent,
+                dataParent,
                 defaultName ?? "unnamed"
             );
         } else {

--- a/packages/core/src/view/viewUtils.js
+++ b/packages/core/src/view/viewUtils.js
@@ -223,11 +223,12 @@ export async function processImports(viewRoot) {
         // TODO: Let importSpec have a name
         const importedView = context.createView(
             loadedSpec,
-            view.parent,
+            view.layoutParent,
+            view.dataParent,
             view.name
         );
         // @ts-expect-error TODO: Fix typing issue
-        view.parent.replaceChild(view, importedView);
+        view.layoutParent.replaceChild(view, importedView);
 
         // Import recursively
         await processImports(importedView);


### PR DESCRIPTION
View classes have now two parents: `layoutParent` and `dataParent`. However, view classes only keep track of their "layout" children. The two-parent design makes things more flexible, because layout is now decoupled from dataFlow, scale/axis resolutions, and encoding inheritance.

Relocated summary views to `SampleView` from `UnitView`. Thus, `UnitView` is no longer a `ContainerView`, which was very silly by definition. Fixing this also surprisingly solved some previous bugs, which had been difficult to track down.

Closes #159