### PR TITLE
feat(core): parameter-driven mark properties

### DIFF
--- a/packages/core/examples/rect_with_params.json
+++ b/packages/core/examples/rect_with_params.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
+
+  "params": [
+    {
+      "name": "cornerRadius",
+      "value": 20,
+      "bind": { "input": "range", "min": 0, "max": 100, "step": 1 }
+    },
+    {
+      "name": "strokeWidth",
+      "value": 5,
+      "bind": { "input": "range", "min": 0, "max": 50, "step": 0.5 }
+    },
+    {
+      "name": "fillOpacity",
+      "value": 1,
+      "bind": { "input": "range", "min": 0, "max": 1, "step": 0.01 }
+    },
+    {
+      "name": "redStroke",
+      "value": false,
+      "bind": { "input": "checkbox" }
+    },
+    {
+      "name": "fillColor",
+      "value": "navy",
+      "bind": {
+        "input": "select",
+        "options": ["navy", "purple"],
+        "labels": ["Navy", "Purple"]
+      }
+    }
+  ],
+
+  "data": {
+    "values": [
+      { "x": 0.2, "x2": 0.4 },
+      { "x": 0.6, "x2": 0.8 }
+    ]
+  },
+
+  "layer": [
+    {
+      "transform": [
+        { "type": "regexFold", "columnRegex": ["^(x.?)$"], "asValue": ["z"] }
+      ],
+
+      "layer": [
+        {
+          "mark": {
+            "type": "rule",
+            "strokeDash": [3, 3]
+          },
+
+          "encoding": {
+            "x": { "field": "z", "type": "quantitative" },
+            "color": { "value": "darkgray" }
+          }
+        },
+        {
+          "mark": {
+            "type": "rule",
+            "strokeDash": [1, 5, 3, 5]
+          },
+
+          "encoding": {
+            "y": { "field": "z", "type": "quantitative" },
+            "color": { "value": "darkgray" }
+          }
+        }
+      ]
+    },
+    {
+      "mark": {
+        "type": "rect",
+        "strokeWidth": { "expr": "strokeWidth" },
+        "cornerRadius": { "expr": "cornerRadius" },
+        "fillOpacity": { "expr": "fillOpacity" },
+        "stroke": { "expr": "redStroke ? 'firebrick' : 'black'" },
+        "fill": { "expr": "fillColor" }
+      },
+
+      "encoding": {
+        "x": {
+          "field": "x",
+          "type": "quantitative",
+          "scale": { "domain": [0, 1] }
+        },
+        "x2": { "field": "x2" },
+        "y": {
+          "field": "x",
+          "type": "quantitative",
+          "scale": { "domain": [0, 1] }
+        },
+        "y2": { "field": "x2" }
+      }
+    }
+  ]
+}

--- a/packages/core/src/encoder/encoder.js
+++ b/packages/core/src/encoder/encoder.js
@@ -68,7 +68,14 @@ export function createEncoder(channelDef, scale, accessor, channel) {
     /** @type {Encoder} */
     let encoder;
 
-    if (isValueDef(channelDef)) {
+    if (isValueExprDef(channelDef)) {
+        // TODO: Should get the value expression as the accessor
+        encoder = /** @type {Encoder} */ ((datum) => undefined);
+        //encoder = /** @type {Encoder} */ (/** @type {any} */ (accessor));
+        encoder.constant = true;
+        encoder.constantValue = false;
+        encoder.accessor = accessor;
+    } else if (isValueDef(channelDef)) {
         const value = channelDef.value;
         encoder = /** @type {Encoder} */ ((datum) => value);
         encoder.constant = true;
@@ -154,6 +161,14 @@ export function createEncoder(channelDef, scale, accessor, channel) {
  */
 export function isValueDef(channelDef) {
     return channelDef && "value" in channelDef;
+}
+
+/**
+ * @param {import("../spec/channel.js").ChannelDef} channelDef
+ * @returns {channelDef is import("../spec/channel.js").ValueExprDef}
+ */
+export function isValueExprDef(channelDef) {
+    return channelDef && "valueExpr" in channelDef;
 }
 
 /**

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -36,6 +36,7 @@ import { VIEW_ROOT_NAME, ViewFactory } from "./view/viewFactory.js";
 import { reconfigureScales } from "./view/scaleResolution.js";
 import ParamBroker from "./paramBroker.js";
 import { debounce } from "./utils/debounce.js";
+import { tickStep } from "d3-array";
 
 /**
  * Events that are broadcasted to all views.
@@ -177,7 +178,8 @@ export default class GenomeSpy {
                                 type="range"
                                 min=${bind.min ?? 0}
                                 max=${bind.max ?? 100}
-                                step=${bind.step}
+                                step=${bind.step ??
+                                tickStep(bind.min, bind.max, 100)}
                                 .value=${value}
                                 @input=${(/** @type {any} */ e) =>
                                     debouncedSetter(e.target.valueAsNumber)}

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -35,6 +35,7 @@ import { invalidatePrefix } from "./utils/propertyCacher.js";
 import { VIEW_ROOT_NAME, ViewFactory } from "./view/viewFactory.js";
 import { reconfigureScales } from "./view/scaleResolution.js";
 import ParamBroker from "./paramBroker.js";
+import { debounce } from "./utils/debounce.js";
 
 /**
  * Events that are broadcasted to all views.
@@ -137,14 +138,7 @@ export default class GenomeSpy {
         this.viewRoot = undefined;
 
         this._paramBroker = new ParamBroker();
-        for (const { name, value } of spec.params ?? []) {
-            const setter = this._paramBroker.allocateSetter(name);
-            if (value != null) {
-                setter(value);
-            } else {
-                // TODO: Bindings
-            }
-        }
+        this.#initializeParameters();
 
         /**
          * Views that are currently loading data using lazy sources.
@@ -152,6 +146,110 @@ export default class GenomeSpy {
          * @type {Map<View, boolean>}
          */
         this._loadingViews = new Map();
+    }
+
+    #initializeParameters() {
+        /** @type {import("lit-html").TemplateResult[]} */
+        const inputs = [];
+
+        for (const param of this.spec.params ?? []) {
+            const { name, value, bind } = param;
+            const setter = this._paramBroker.allocateSetter(name);
+
+            if (value != null) {
+                setter(value);
+            }
+
+            // TODO: Implement two-way data binding, e.g. when an external agent changes
+            // the parameter value, the UI components should be updated.
+
+            if (bind && "input" in bind) {
+                const debouncedSetter = bind.debounce
+                    ? debounce(setter, bind.debounce, false)
+                    : setter;
+
+                if (bind.input == "range") {
+                    // TODO: Show the value next to the slider
+                    inputs.push(
+                        html`<label
+                            >${bind.name ?? name}
+                            <input
+                                type="range"
+                                min=${bind.min ?? 0}
+                                max=${bind.max ?? 100}
+                                step=${bind.step}
+                                .value=${value}
+                                @input=${(/** @type {any} */ e) =>
+                                    debouncedSetter(e.target.valueAsNumber)}
+                        /></label>`
+                    );
+                } else if (bind.input == "checkbox") {
+                    inputs.push(
+                        html`<label
+                            >${bind.name ?? name}
+                            <input
+                                type="checkbox"
+                                ?checked=${value}
+                                @input=${(/** @type {any} */ e) =>
+                                    debouncedSetter(e.target.checked)}
+                        /></label>`
+                    );
+                } else if (bind.input == "radio") {
+                    inputs.push(
+                        html`<span class="label">${bind.name ?? name}</span>
+                            ${bind.options.map(
+                                (option, i) => html`<label>
+                                    <input
+                                        type="radio"
+                                        name=${name}
+                                        value=${option}
+                                        .checked=${value == option}
+                                        @input=${(/** @type {any} */ e) =>
+                                            debouncedSetter(e.target.value)}
+                                    />${bind.labels?.[i] ?? option}</label
+                                >`
+                            )}`
+                    );
+                } else if (bind.input == "select") {
+                    inputs.push(
+                        html`<label
+                            >${bind.name ?? name}
+                            <select
+                                @input=${(/** @type {any} */ e) =>
+                                    debouncedSetter(e.target.value)}
+                            >
+                                ${bind.options.map(
+                                    (option, i) => html`<option
+                                        value=${option}
+                                        ?selected=${value == option}
+                                    >
+                                        ${bind.labels?.[i] ?? option}
+                                    </option>`
+                                )}
+                            </select></label
+                        >`
+                    );
+                } else {
+                    // TODO: Support other types: "text", "number", "color".
+                    throw new Error("Unsupported input type: " + bind.input);
+                }
+            }
+        }
+
+        if (inputs.length) {
+            const inputsDiv = document.createElement("div");
+            this.container.appendChild(inputsDiv);
+
+            // TODO: Move to css
+            // @ts-ignore
+            inputsDiv.style =
+                "position: absolute; bottom: 10px; right: 10px; background: rgba(255, 255, 255, 0.8); padding: 10px; z-index: 1; border: 1px solid lightgray";
+
+            render(
+                html`${inputs.map((input) => html`<div>${input}</div>`)}`,
+                inputsDiv
+            );
+        }
     }
 
     /**

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -137,6 +137,14 @@ export default class GenomeSpy {
         this.viewRoot = undefined;
 
         this._paramBroker = new ParamBroker();
+        for (const { name, value } of spec.params ?? []) {
+            const setter = this._paramBroker.allocateSetter(name);
+            if (value != null) {
+                setter(value);
+            } else {
+                // TODO: Bindings
+            }
+        }
 
         /**
          * Views that are currently loading data using lazy sources.

--- a/packages/core/src/gl/glslScaleGenerator.js
+++ b/packages/core/src/gl/glslScaleGenerator.js
@@ -54,7 +54,7 @@ function splitScaleType(type) {
  * @param {Channel} channel
  * @param {number | number[] | string | boolean} value
  */
-export function generateValueGlsl(channel, value) {
+export function generateConstantValueGlsl(channel, value) {
     /** @type {VectorizedValue} */
     let vec;
     if (isDiscreteChannel(channel)) {

--- a/packages/core/src/gl/glslScaleGenerator.js
+++ b/packages/core/src/gl/glslScaleGenerator.js
@@ -50,6 +50,7 @@ function splitScaleType(type) {
 }
 
 /**
+ * Generates GLSL code for a constant value.
  *
  * @param {Channel} channel
  * @param {number | number[] | string | boolean} value
@@ -81,8 +82,6 @@ export function generateConstantValueGlsl(channel, value) {
         vec = vectorize(value);
     }
 
-    // These could also be passed as uniforms because GPU drivers often handle
-    // uniforms as constants and recompile the shader to eliminate dead code etc.
     let glsl = `
 #define ${channel}_DEFINED
 ${vec.type} ${SCALED_FUNCTION_PREFIX}${channel}() {
@@ -90,6 +89,42 @@ ${vec.type} ${SCALED_FUNCTION_PREFIX}${channel}() {
     return ${vec};
 }`;
     return glsl;
+}
+
+/**
+ * Generates GLSL code for a dynamic, parameter-driven values. These are mainly
+ * used as dynamic mark properties that map to encoding channels.
+ *
+ * @param {Channel} channel
+ */
+export function generateDynamicValueGlslAndUniform(channel) {
+    let dataType = "float";
+    /** @type {(x: any) => any} */
+    let adjuster = (x) => x;
+
+    if (isColorChannel(channel)) {
+        dataType = "vec3";
+        adjuster = (x) => cssColorToArray(x);
+    }
+
+    const uniformName = `u${capitalize(channel)}`;
+
+    const uniformGlsl = `    // Dynamic value\n    uniform ${dataType} ${uniformName};`;
+
+    let scaleGlsl = `
+#define ${channel}_DEFINED
+${dataType} ${SCALED_FUNCTION_PREFIX}${channel}() {
+    // Dynamic value
+    return ${uniformName};
+}`;
+
+    return {
+        channel,
+        uniformName,
+        uniformGlsl,
+        scaleGlsl,
+        adjuster,
+    };
 }
 
 /**
@@ -443,9 +478,16 @@ function vectorize(value) {
 /**
  * @param {string} color
  */
-function vectorizeCssColor(color) {
+function cssColorToArray(color) {
     const rgb = d3color(color).rgb();
-    return vectorize([rgb.r, rgb.g, rgb.b].map((x) => x / 255));
+    return [rgb.r, rgb.g, rgb.b].map((x) => x / 255);
+}
+
+/**
+ * @param {string} color
+ */
+function vectorizeCssColor(color) {
+    return vectorize(cssColorToArray(color));
 }
 
 /**
@@ -590,4 +632,11 @@ export function dedupeEncodingFields(encoders) {
  */
 export function makeAttributeName(channel) {
     return asArray(channel).join("_");
+}
+
+/**
+ * @param {string} str
+ */
+function capitalize(str) {
+    return str[0].toUpperCase() + str.slice(1);
 }

--- a/packages/core/src/marks/link.vertex.glsl
+++ b/packages/core/src/marks/link.vertex.glsl
@@ -15,6 +15,8 @@ uniform Mark {
     uniform float uMaxChordLength;
     // In pixels
     uniform vec2 uArcFadingDistance;
+
+#pragma markUniforms
 };
 
 in vec2 strip;

--- a/packages/core/src/marks/mark.js
+++ b/packages/core/src/marks/mark.js
@@ -583,6 +583,7 @@ export default class Mark {
             const set = () => {
                 uniformSetter(adjuster(fn(null)));
                 this.markUniformsAltered = true;
+                this.unitView.context.animator.requestRender();
             };
 
             // Register a listener ...

--- a/packages/core/src/marks/mark.js
+++ b/packages/core/src/marks/mark.js
@@ -62,7 +62,7 @@ export const SAMPLE_FACET_TEXTURE = "SAMPLE_FACET_TEXTURE";
  */
 export default class Mark {
     /**
-     * @typedef {import("../spec/mark.js").MarkConfig} MarkConfig
+     * @typedef {import("../spec/mark.js").MarkProps} MarkProps
      * @typedef {import("../spec/channel.js").Channel} Channel
      * @typedef {import("../spec/channel.js").Encoding} Encoding
      * @typedef {import("../spec/channel.js").ValueDef} ValueDef
@@ -121,7 +121,7 @@ export default class Mark {
         this.rangeMap = new RangeMap();
 
         // TODO: Implement https://vega.github.io/vega-lite/docs/config.html
-        /** @type {MarkConfig} */
+        /** @type {MarkProps} */
         this.defaultProperties = {
             get clip() {
                 // TODO: Cache once the scales have been resolved
@@ -151,13 +151,13 @@ export default class Mark {
          *
          * TODO: Proper and comprehensive typings for mark properties
          *
-         * @type {Partial<MarkConfig>}
+         * @type {Partial<MarkProps>}
          * @readonly
          */
         this.properties = coalesceProperties(
             typeof this.unitView.spec.mark == "object"
-                ? () => /** @type {MarkConfig} */ (this.unitView.spec.mark)
-                : () => /** @type {MarkConfig} */ ({}),
+                ? () => /** @type {MarkProps} */ (this.unitView.spec.mark)
+                : () => /** @type {MarkProps} */ ({}),
             () => this.defaultProperties
         );
     }
@@ -237,7 +237,7 @@ export default class Mark {
             /** @type {(property: string) => ValueDef | ValueExprDef } */
             const propToValueDef = (property) => {
                 const value =
-                    this.properties[/** @type {keyof MarkConfig} */ (property)];
+                    this.properties[/** @type {keyof MarkProps} */ (property)];
                 return isScalar(value)
                     ? { value }
                     : isExprRef(value)

--- a/packages/core/src/marks/mark.js
+++ b/packages/core/src/marks/mark.js
@@ -19,7 +19,7 @@ import createEncoders, {
 } from "../encoder/encoder.js";
 import {
     DOMAIN_PREFIX,
-    generateValueGlsl,
+    generateConstantValueGlsl,
     generateScaleGlsl,
     RANGE_TEXTURE_PREFIX,
     ATTRIBUTE_PREFIX,
@@ -369,7 +369,9 @@ export default class Mark {
             }
 
             if (isValueDef(channelDef)) {
-                scaleCode.push(generateValueGlsl(channel, channelDef.value));
+                scaleCode.push(
+                    generateConstantValueGlsl(channel, channelDef.value)
+                );
             } else {
                 const resolutionChannel =
                     (isChannelDefWithScale(channelDef) &&

--- a/packages/core/src/marks/point.common.glsl
+++ b/packages/core/src/marks/point.common.glsl
@@ -19,4 +19,6 @@ uniform Mark {
     uniform highp float uSemanticThreshold;
 
     uniform mediump float uGradientStrength;
+
+#pragma markUniforms
 };

--- a/packages/core/src/marks/rect.common.glsl
+++ b/packages/core/src/marks/rect.common.glsl
@@ -1,0 +1,15 @@
+uniform Mark {
+    /** Minimum size (width, height) of the displayed rectangle in pixels */
+    uniform float uMinWidth;
+    uniform float uMinHeight;
+
+    /** Minimum opacity for the size clamping */
+    uniform float uMinOpacity;
+
+    uniform float uCornerRadiusTopRight;
+    uniform float uCornerRadiusBottomRight;
+    uniform float uCornerRadiusTopLeft;
+    uniform float uCornerRadiusBottomLeft;
+
+#pragma markUniforms
+};

--- a/packages/core/src/marks/rect.js
+++ b/packages/core/src/marks/rect.js
@@ -1,6 +1,7 @@
 import { drawBufferInfo, setBuffersAndAttributes } from "twgl.js";
 import VERTEX_SHADER from "./rect.vertex.glsl";
 import FRAGMENT_SHADER from "./rect.fragment.glsl";
+import COMMON_SHADER from "./rect.common.glsl";
 import { RectVertexBuilder } from "../gl/dataToVertices.js";
 
 import Mark from "./mark.js";
@@ -140,11 +141,10 @@ export default class RectMark extends Mark {
             defines.push("STROKED");
         }
 
-        this.createAndLinkShaders(
-            VERTEX_SHADER,
-            FRAGMENT_SHADER,
-            defines.map((d) => "#define " + d)
-        );
+        this.createAndLinkShaders(VERTEX_SHADER, FRAGMENT_SHADER, [
+            COMMON_SHADER,
+            ...defines.map((d) => "#define " + d),
+        ]);
     }
 
     finalizeGraphicsInitialization() {

--- a/packages/core/src/marks/rect.vertex.glsl
+++ b/packages/core/src/marks/rect.vertex.glsl
@@ -1,17 +1,3 @@
-uniform Mark {
-    /** Minimum size (width, height) of the displayed rectangle in pixels */
-    uniform float uMinWidth;
-    uniform float uMinHeight;
-
-    /** Minimum opacity for the size clamping */
-    uniform float uMinOpacity;
-
-    uniform float uCornerRadiusTopRight;
-    uniform float uCornerRadiusBottomRight;
-    uniform float uCornerRadiusTopLeft;
-    uniform float uCornerRadiusBottomLeft;
-};
-
 out lowp vec4 vFillColor;
 out lowp vec4 vStrokeColor;
 out float vHalfStrokeWidth;

--- a/packages/core/src/marks/rule.common.glsl
+++ b/packages/core/src/marks/rule.common.glsl
@@ -5,4 +5,6 @@ uniform Mark {
     uniform mediump float uDashTextureSize;
     uniform lowp int uStrokeCap;
     uniform mediump float uStrokeDashOffset;
+
+#pragma markUniforms
 };

--- a/packages/core/src/marks/text.common.glsl
+++ b/packages/core/src/marks/text.common.glsl
@@ -17,4 +17,6 @@ uniform Mark {
     uniform bool uFlushX;
     uniform mediump float uPaddingY;
     uniform bool uFlushY;
+
+#pragma markUniforms
 };

--- a/packages/core/src/spec/channel.d.ts
+++ b/packages/core/src/spec/channel.d.ts
@@ -342,13 +342,6 @@ export interface XIndexDef {
     buildIndex?: boolean;
 }
 
-/**
- * @internal
- */
-export interface ValueExprDef {
-    valueExpr: string;
-}
-
 export interface Encoding<F extends Field = string> {
     /**
      * X coordinates of the marks.

--- a/packages/core/src/spec/channel.d.ts
+++ b/packages/core/src/spec/channel.d.ts
@@ -154,6 +154,21 @@ export interface ValueDefBase<V extends Value = Scalar> {
 
 export type ValueDef<V extends Value = Scalar> = ValueDefBase<V> & TitleMixins;
 
+/**
+ * @internal
+ */
+export interface ValueExprDefBase {
+    /**
+     * An expression that evaluates as a value in visual domain (e.g., `"red"` / `"#0099ff"`, values between `0` to `1` for opacity).
+     */
+    valueExpr: string;
+}
+
+/**
+ * @internal
+ */
+export type ValueExprDef = ValueExprDefBase & TitleMixins;
+
 export interface DatumDefBase {
     /**
      * A constant value in data domain.
@@ -325,6 +340,13 @@ export interface XIndexDef {
      * on the `x` channel.
      */
     buildIndex?: boolean;
+}
+
+/**
+ * @internal
+ */
+export interface ValueExprDef {
+    valueExpr: string;
 }
 
 export interface Encoding<F extends Field = string> {

--- a/packages/core/src/spec/mark.d.ts
+++ b/packages/core/src/spec/mark.d.ts
@@ -15,21 +15,21 @@ export type MarkType = "rect" | "point" | "rule" | "text" | "link";
 
 export interface FillAndStrokeProps {
     /** The fill color */
-    fill?: string;
+    fill?: string | ExprRef;
 
     /** The fill opacity. Value between [0, 1]. */
-    fillOpacity?: number;
+    fillOpacity?: number | ExprRef;
 
     /** The stroke color */
-    stroke?: string;
+    stroke?: string | ExprRef;
 
     /** The stroke opacity. Value between [0, 1]. */
-    strokeOpacity?: number;
+    strokeOpacity?: number | ExprRef;
 }
 
 export interface SecondaryPositionProps {
-    x2?: number;
-    y2?: number;
+    x2?: number | ExprRef;
+    y2?: number | ExprRef;
 }
 
 export interface AngleProps {
@@ -38,7 +38,7 @@ export interface AngleProps {
      *
      * **Default value:** `0`
      */
-    angle?: number;
+    angle?: number | ExprRef;
 }
 
 /**
@@ -177,7 +177,7 @@ export interface TextProps
      *
      * **Default value:** `11`
      */
-    size?: number;
+    size?: number | ExprRef;
 
     /**
      * The font typeface. GenomeSpy uses [SDF](https://github.com/Chlumsky/msdfgen)

--- a/packages/core/src/spec/mark.d.ts
+++ b/packages/core/src/spec/mark.d.ts
@@ -414,7 +414,7 @@ export interface LinkProps extends SecondaryPositionProps {
 }
 
 // TODO: Mark-specific configs
-export interface MarkConfig
+export interface MarkProps
     extends PointProps,
         RectProps,
         TextProps,
@@ -422,11 +422,11 @@ export interface MarkConfig
         LinkProps,
         FillAndStrokeProps {
     // Channels.
-    x?: number;
-    y?: number;
-    color?: string;
-    opacity?: number;
-    size?: number;
+    x?: number | ExprRef;
+    y?: number | ExprRef;
+    color?: string | ExprRef;
+    opacity?: number | ExprRef;
+    size?: number | ExprRef;
 
     /**
      * Whether the `color` represents the `fill` color (`true`) or the `stroke` color (`false`).
@@ -463,7 +463,7 @@ export interface MarkConfig
     /**
      * The stroke width in pixels.
      */
-    strokeWidth?: number;
+    strokeWidth?: number | ExprRef;
 
     /**
      * Minimum size for WebGL buffers (number of data items).
@@ -474,6 +474,6 @@ export interface MarkConfig
     minBufferSize?: number;
 }
 
-export interface MarkConfigAndType extends MarkConfig {
+export interface MarkConfigAndType extends MarkProps {
     type: MarkType;
 }

--- a/packages/core/src/spec/parameter.d.ts
+++ b/packages/core/src/spec/parameter.d.ts
@@ -15,4 +15,102 @@ export interface VariableParameter {
      * __Default value:__ `undefined`
      */
     value?: any;
+
+    /**
+     * Binds the parameter to an external input element such as a slider, selection list or radio button group.
+     */
+    bind?: Binding;
 }
+
+// ----------------------------------------------------------------------------
+// Adapted from: https://github.com/vega/vega/blob/main/packages/vega-typings/types/spec/bind.d.ts
+
+export type Element = string;
+
+export interface BindBase {
+    /**
+     * An optional CSS selector string indicating the parent element to which
+     * the input element should be added. By default, all input elements are
+     * added within the parent container of the Vega view.
+     */
+    element?: Element;
+
+    /**
+     * If defined, delays event handling until the specified milliseconds have
+     * elapsed since the last event was fired.
+     */
+    debounce?: number;
+
+    /**
+     * By default, the parameter name is used to label input elements.
+     * This `name` property can be used instead to specify a custom
+     * label for the bound parameter.
+     */
+    name?: string;
+}
+
+export interface BindCheckbox extends BindBase {
+    input: "checkbox";
+}
+
+export interface BindRadioSelect extends BindBase {
+    input: "radio" | "select";
+    /**
+     * An array of options to select from.
+     */
+    options: any[];
+
+    /**
+     * An array of label strings to represent the `options` values. If
+     * unspecified, the `options` value will be coerced to a string and
+     * used as the label.
+     */
+    labels?: string[];
+}
+
+export interface BindRange extends BindBase {
+    input: "range";
+
+    /**
+     * Sets the minimum slider value. Defaults to the smaller of the signal value and `0`.
+     */
+    min?: number;
+
+    /**
+     * Sets the maximum slider value. Defaults to the larger of the signal value and `100`.
+     */
+    max?: number;
+
+    /**
+     * Sets the minimum slider increment. If undefined, the step size will be
+     * automatically determined based on the `min` and `max` values.
+     */
+    step?: number;
+}
+
+export interface BindDirect {
+    /**
+     * An input element that exposes a _value_ property and supports the
+     * [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
+     * interface, or a CSS selector string to such an element. When the element
+     * updates and dispatches an event, the _value_ property will be used as the
+     * new, bound signal value. When the signal updates independent of the
+     * element, the _value_ property will be set to the signal value and a new
+     * event will be dispatched on the element.
+     */
+    element: Element | EventTarget;
+
+    /**
+     * The event (default `"input"`) to listen for to track changes on the
+     * external element.
+     */
+    event?: string;
+
+    /**
+     * If defined, delays event handling until the specified milliseconds have
+     * elapsed since the last event was fired.
+     */
+    debounce?: number;
+}
+
+export type Binding = BindCheckbox | BindRadioSelect | BindRange;

--- a/packages/core/src/spec/parameter.d.ts
+++ b/packages/core/src/spec/parameter.d.ts
@@ -1,0 +1,18 @@
+// Adapted from: https://github.com/vega/vega-lite/blob/main/src/parameter.ts
+
+export interface VariableParameter {
+    /**
+     * A unique name for the variable parameter. Parameter names should be valid
+     * JavaScript identifiers: they should contain only alphanumeric characters
+     * (or "$", or "_") and may not start with a digit. Reserved keywords that
+     * may not be used as parameter names are: "datum".
+     */
+    name: ParameterName;
+
+    /**
+     * The [initial value](http://vega.github.io/vega-lite/docs/value.html) of the parameter.
+     *
+     * __Default value:__ `undefined`
+     */
+    value?: any;
+}

--- a/packages/core/src/spec/parameter.d.ts
+++ b/packages/core/src/spec/parameter.d.ts
@@ -7,7 +7,7 @@ export interface VariableParameter {
      * (or "$", or "_") and may not start with a digit. Reserved keywords that
      * may not be used as parameter names are: "datum".
      */
-    name: ParameterName;
+    name: string;
 
     /**
      * The [initial value](http://vega.github.io/vega-lite/docs/value.html) of the parameter.

--- a/packages/core/src/spec/root.d.ts
+++ b/packages/core/src/spec/root.d.ts
@@ -16,6 +16,9 @@ interface RootConfig {
 
     /**
      * Dynamic variables that parameterize a visualization.
+     *
+     * For now, these are only supported in mark properties, i.e.,
+     * they are not supported in the filter and formula transforms (yet).
      */
     params?: VariableParameter[];
 

--- a/packages/core/src/spec/root.d.ts
+++ b/packages/core/src/spec/root.d.ts
@@ -1,4 +1,5 @@
 import { GenomeConfig } from "./genome.js";
+import { VariableParameter } from "./parameter.js";
 import { ViewSpec } from "./view.js";
 
 interface RootConfig {
@@ -12,6 +13,11 @@ interface RootConfig {
      * Background color of the canvas.
      */
     background?: string;
+
+    /**
+     * Dynamic variables that parameterize a visualization.
+     */
+    params?: VariableParameter[];
 
     /**
      * https://vega.github.io/vega-lite/docs/data.html#datasets

--- a/packages/core/src/view/axisView.js
+++ b/packages/core/src/view/axisView.js
@@ -459,7 +459,7 @@ export function createGenomeAxis(axisProps, type) {
      * @return {import("../spec/view.js").UnitSpec}
      */
     const createChromosomeLabels = () => {
-        /** @type {Partial<import("../spec/mark.js").MarkConfig>} */
+        /** @type {Partial<import("../spec/mark.js").MarkProps>} */
         let chromLabelMarkProps;
         switch (ap.orient) {
             case "top":
@@ -594,7 +594,7 @@ export function createGenomeAxis(axisProps, type) {
         if (axisProps.chromLabels) {
             chromLayerSpec.layer.push(createChromosomeLabels());
 
-            /** @type {import("../spec/mark.js").MarkConfig} */
+            /** @type {import("../spec/mark.js").MarkProps} */
             let labelMarkSpec;
 
             // TODO: Simplify the following mess
@@ -608,7 +608,7 @@ export function createGenomeAxis(axisProps, type) {
                                 /** @type {import("../spec/view.js").UnitSpec} */ view
                             ) => {
                                 labelMarkSpec =
-                                    /** @type {import("../spec/mark.js").MarkConfig} */ (
+                                    /** @type {import("../spec/mark.js").MarkProps} */ (
                                         view.mark
                                     );
                             }


### PR DESCRIPTION
Also introduces a preliminary parameter binding, similar to Vega. It will be refined further, as the sliders, select boxes, etc. should be shown in the "view visibility" menu in the App's toolbar.

https://github.com/genome-spy/genome-spy/assets/399972/7d1fc7c7-331d-4a85-af77-b3dffc1c86ac

Closes #211