### PR TITLE
feat(core): axisMeasure

### DIFF
--- a/docs/grammar/data/lazy.md
+++ b/docs/grammar/data/lazy.md
@@ -803,3 +803,286 @@ SCHEMA AxisGenomeData
 ```
 
 </div></genome-spy-doc-embed>
+
+## Axis measure
+
+The `"axisMeasure"` data source generates coordinates for a "measure" 
+for the specified channel, which can be used to create a visual clue ("measure") 
+for the current zoom level.
+
+This is particularly useful for genome axes, where the measure size, 
+combined with the measure label (e.g. "10kb") gives a sense of the zoom level
+for the current view, even when other features (e.g. genes, exons) are absent
+and the axis ticks labels are long, multiple digits numbers.
+
+The data source generates data objects with these fields:
+
+ - `startPos`: start coordinate of the measure, useful for "rule" or "rect" marks,
+ - `centerPos`: center coordinate of the measure, useful for "text" marks showing the measureLabel
+ - `endPos`: end coordinate of the measure, useful for "rule" or "rect" marks,
+ - `measureDomainSize`: size of the measure in domain units (e.g. linearized chromosomal coordinates),
+ - `measurePixelsSize`: size of the measure in pixels, useful for sizing other elements when embedded
+ - `measureLabel`: label for the measure, e.g. "10kb"
+
+### Parameters
+
+SCHEMA AxisMeasureData
+
+### Example 1
+
+The example below generates a discreet measure, centered on the `x` axis.
+
+<div><genome-spy-doc-embed height="120" spechidden="true">
+
+```json
+{
+  "genome": {
+    "name": "hg38"
+  },
+  "vconcat": [
+    {
+      "height": 40,
+      "data": {
+        "values": [
+          {
+            "chrom": "chr3",
+            "pos": 134567890
+          },
+          {
+            "chrom": "chr4",
+            "pos": 123456789
+          },
+          {
+            "chrom": "chr9",
+            "pos": 34567890
+          }
+        ]
+      },
+      "mark": "point",
+      "encoding": {
+        "x": {
+          "chrom": "chrom",
+          "pos": "pos",
+          "type": "locus",
+          "scale": {
+            "name": "genomeScale",
+            "domain": [
+              {
+                "chrom": "chr3"
+              },
+              {
+                "chrom": "chr9"
+              }
+            ]
+          }
+        },
+        "size": {
+          "value": 200
+        }
+      }
+    },
+    {
+      "name": "axis_measure",
+      "height": 20,
+      "data": {
+        "lazy": {
+          "type": "axisMeasure"
+        }
+      },
+      "layer": [
+        {
+          "mark": {
+            "type": "rule"
+          },
+          "encoding": {
+            "x": {
+              "field": "startPos",
+              "type": "locus",
+              "axis": null
+            },
+            "y": {
+              "value": 0.2
+            },
+            "y2": {
+              "value": 0.8
+            }
+          }
+        },
+        {
+          "mark": {
+            "type": "rule"
+          },
+          "encoding": {
+            "x": {
+              "field": "endPos",
+              "type": "locus",
+              "axis": null
+            },
+            "y": {
+              "value": 0.2
+            },
+            "y2": {
+              "value": 0.8
+            }
+          }
+        },
+        {
+          "mark": {
+            "type": "rule"
+          },
+          "encoding": {
+            "x": {
+              "field": "startPos",
+              "type": "locus",
+              "axis": null
+            },
+            "x2": {
+              "field": "endPos",
+              "type": "locus",
+              "axis": null
+            }
+          }
+        },
+        {
+          "mark": {
+            "type": "text",
+            "align": "center",
+            "baseline": "bottom",
+            "y": 0.5
+          },
+          "encoding": {
+            "x" : { 
+              "field": "centerPos",
+              "type": "locus",
+              "axis": null
+            },
+            "text": {
+              "field": "measureLabel"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+</genome-spy-doc-embed></div>
+
+### Example 2
+
+The example below generates a "bold" measure, aligned to the right edge of the `x` axis 
+and with a custom set of measures (5b, 50b, 500b, 5kb, 50kb, etc.).
+
+<div><genome-spy-doc-embed height="120" spechidden="true">
+
+```json
+{
+  "genome": {
+    "name": "hg38"
+  },
+  "vconcat": [
+    {
+      "height": 40,
+      "data": {
+        "values": [
+          {
+            "chrom": "chr3",
+            "pos": 134567890
+          },
+          {
+            "chrom": "chr4",
+            "pos": 123456789
+          },
+          {
+            "chrom": "chr9",
+            "pos": 34567890
+          }
+        ]
+      },
+      "mark": "point",
+      "encoding": {
+        "x": {
+          "chrom": "chrom",
+          "pos": "pos",
+          "type": "locus",
+          "scale": {
+            "name": "genomeScale",
+            "domain": [
+              {
+                "chrom": "chr3"
+              },
+              {
+                "chrom": "chr9"
+              }
+            ]
+          }
+        },
+        "size": {
+          "value": 200
+        }
+      }
+    },
+    {
+      "name": "axis_measure",
+      "height": 20,
+      "data": {
+        "lazy": {
+          "type": "axisMeasure",
+          "multiplierValue": 5,
+          "hideMeasureThreshold": 10,
+          "alignMeasure": "right"
+        }
+      },
+      "layer": [
+        {
+          "mark": {
+            "type": "rect",
+            "fill": "salmon",
+            "opacity": 0.75
+          },
+          "encoding": {
+            "x": {
+              "field": "startPos",
+              "type": "locus",
+              "axis": null
+            },
+            "x2": {
+              "field": "endPos",
+              "type": "locus",
+              "axis": null
+            },
+            "y": {
+              "value": 0.1
+            },
+            "y2": {
+              "value": 0.9
+            }
+          }
+        },
+        {
+          "mark": {
+            "type": "text",
+            "align": "center",
+            "baseline": "bottom",
+            "opacity": 0.75,
+            "y": 0.2
+          },
+          "encoding": {
+            "x" : { 
+              "field": "centerPos",
+              "type": "locus",
+              "axis": null
+            },
+            "text": {
+              "field": "measureLabel"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+</genome-spy-doc-embed></div>

--- a/packages/core/examples/axes/axisMeasure_bold.json
+++ b/packages/core/examples/axes/axisMeasure_bold.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
+  "description": "Adding a \"bold\" axis measure for a genome axis, with the custom parameters 'multiplierValue'=5, 'alignMeasure'='right'",
+  "genome": {
+    "name": "hg38"
+  },
+  "vconcat": [
+    {
+      "height": 40,
+      "data": {
+        "values": [
+          {
+            "chrom": "chr3",
+            "pos": 134567890
+          },
+          {
+            "chrom": "chr4",
+            "pos": 123456789
+          },
+          {
+            "chrom": "chr9",
+            "pos": 34567890
+          }
+        ]
+      },
+      "mark": "point",
+      "encoding": {
+        "x": {
+          "chrom": "chrom",
+          "pos": "pos",
+          "type": "locus",
+          "scale": {
+            "name": "genomeScale",
+            "domain": [
+              {
+                "chrom": "chr3"
+              },
+              {
+                "chrom": "chr9"
+              }
+            ]
+          }
+        },
+        "size": {
+          "value": 200
+        }
+      }
+    },
+    {
+      "name": "axis_measure",
+      "height": 20,
+      "data": {
+        "lazy": {
+          "type": "axisMeasure",
+          "multiplierValue": 5,
+          "hideMeasureThreshold": 10,
+          "alignMeasure": "right"
+        }
+      },
+      "layer": [
+        {
+          "mark": {
+            "type": "rect",
+            "fill": "salmon",
+            "opacity": 0.75
+          },
+          "encoding": {
+            "x": {
+              "field": "startPos",
+              "type": "locus",
+              "axis": null
+            },
+            "x2": {
+              "field": "endPos",
+              "type": "locus",
+              "axis": null
+            },
+            "y": {
+              "value": 0.1
+            },
+            "y2": {
+              "value": 0.9
+            }
+          }
+        },
+        {
+          "mark": {
+            "type": "text",
+            "align": "center",
+            "baseline": "bottom",
+            "opacity": 0.75,
+            "y": 0.2
+          },
+          "encoding": {
+            "x": {
+              "field": "centerPos",
+              "type": "locus",
+              "axis": null
+            },
+            "text": {
+              "field": "measureLabel"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core/examples/axes/axisMeasure_discreet.json
+++ b/packages/core/examples/axes/axisMeasure_discreet.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
+  "description": "Adding a \"discreet\" axis measure for a genome axis with default parameters",
+  "genome": {
+    "name": "hg38"
+  },
+  "vconcat": [
+    {
+      "height": 40,
+      "data": {
+        "values": [
+          {
+            "chrom": "chr3",
+            "pos": 134567890
+          },
+          {
+            "chrom": "chr4",
+            "pos": 123456789
+          },
+          {
+            "chrom": "chr9",
+            "pos": 34567890
+          }
+        ]
+      },
+      "mark": "point",
+      "encoding": {
+        "x": {
+          "chrom": "chrom",
+          "pos": "pos",
+          "type": "locus",
+          "scale": {
+            "name": "genomeScale",
+            "domain": [
+              {
+                "chrom": "chr3"
+              },
+              {
+                "chrom": "chr9"
+              }
+            ]
+          }
+        },
+        "size": {
+          "value": 200
+        }
+      }
+    },
+    {
+      "name": "axis_measure",
+      "height": 20,
+      "data": {
+        "lazy": {
+          "type": "axisMeasure"
+        }
+      },
+      "layer": [
+        {
+          "mark": {
+            "type": "rule"
+          },
+          "encoding": {
+            "x": {
+              "field": "startPos",
+              "type": "locus",
+              "axis": null
+            },
+            "y": {
+              "value": 0.2
+            },
+            "y2": {
+              "value": 0.8
+            }
+          }
+        },
+        {
+          "mark": {
+            "type": "rule"
+          },
+          "encoding": {
+            "x": {
+              "field": "endPos",
+              "type": "locus",
+              "axis": null
+            },
+            "y": {
+              "value": 0.2
+            },
+            "y2": {
+              "value": 0.8
+            }
+          }
+        },
+        {
+          "mark": {
+            "type": "rule"
+          },
+          "encoding": {
+            "x": {
+              "field": "startPos",
+              "type": "locus",
+              "axis": null
+            },
+            "x2": {
+              "field": "endPos",
+              "type": "locus",
+              "axis": null
+            }
+          }
+        },
+        {
+          "mark": {
+            "type": "text",
+            "align": "center",
+            "baseline": "bottom",
+            "y": 0.5
+          },
+          "encoding": {
+            "x": {
+              "field": "centerPos",
+              "type": "locus",
+              "axis": null
+            },
+            "text": {
+              "field": "measureLabel"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core/src/data/sources/dataSourceFactory.js
+++ b/packages/core/src/data/sources/dataSourceFactory.js
@@ -2,6 +2,7 @@ import InlineSource, { isInlineData } from "./inlineSource.js";
 import UrlSource, { isUrlData } from "./urlSource.js";
 import SequenceSource, { isSequenceGenerator } from "./sequenceSource.js";
 import AxisTickSource from "./lazy/axisTickSource.js";
+import AxisMeasureSource from "./lazy/axisMeasureSource.js";
 import AxisGenomeSource from "./lazy/axisGenomeSource.js";
 import IndexedFastaSource from "./lazy/indexedFastaSource.js";
 import BigWigSource from "./lazy/bigWigSource.js";
@@ -45,6 +46,15 @@ function isLazyData(params) {
  */
 function isAxisTickSource(params) {
     return params?.type == "axisTicks";
+}
+
+/**
+ *
+ * @param {import("../../spec/data.js").LazyDataParams} params
+ * @returns {params is import("../../spec/data.js").AxisMeasureData}
+ */
+function isAxisMeasureSource(params) {
+    return params?.type == "axisMeasure";
 }
 
 /**
@@ -107,6 +117,8 @@ function isGff3Source(params) {
 function createLazyDataSource(params, view) {
     if (isAxisTickSource(params)) {
         return new AxisTickSource(params, view);
+    } else if (isAxisMeasureSource(params)) {
+        return new AxisMeasureSource(params, view);
     } else if (isAxisGenomeSource(params)) {
         return new AxisGenomeSource(params, view);
     } else if (isIndexedFastaSource(params)) {

--- a/packages/core/src/data/sources/lazy/axisMeasureSource.js
+++ b/packages/core/src/data/sources/lazy/axisMeasureSource.js
@@ -1,0 +1,154 @@
+import SingleAxisLazySource from "./singleAxisLazySource.js";
+/**
+ * @typedef {import("../../../types/encoder.js").VegaScale} VegaScale
+ * @typedef {VegaScale & { props: import("../../../spec/scale.js").Scale }} ScaleWithProps
+ */
+
+/**
+ * Create measure data associated with the channel.
+ * Can be used to generate a visual clue ("measure") for the current zoom level.
+ */
+export default class AxisMeasureSource extends SingleAxisLazySource {
+    /** @type {number} */
+    startPos = 0;
+    /** @type {number} */
+    endPos = 0;
+    /** @type {number} */
+    centerPos = 0;
+    /** @type {string} */
+    measureLabel = "";
+    /** @type {number} */
+    measureDomainSize = 1;
+    /** @type {number[]} */
+    measureValues = [];
+    /** @type {string[]} */
+    measureLabels = [];
+    /** @type {(string | number)[][]} */
+    measureEntries = [];
+    /** @type {Object.<number, string>} */
+    measureLabeledValues = {};
+
+    updateSpanLabeledValues() {
+        this.measureValues = Array.from(
+            { length: Math.floor(Math.log10(this.genome.totalSize)) + 1 },
+            (_, i) => this.params.multiplierValue * 10 ** i
+        );
+        const units = ["b", "kb", "Mb", "Gb"]; // bases, kilobases, megabases, gigabases
+        this.measureLabels = this.measureValues.map((value, index) => {
+            // Determine the appropriate unit index
+            const unitIndex = Math.floor(index / 3); // Each unit corresponds to three values in measureValues
+            // Format the value according to its magnitude
+            const formattedValue = value / 10 ** (unitIndex * 3);
+            return `${formattedValue}${units[unitIndex]}`;
+        });
+        this.measureEntries = this.measureValues.map((value, index) => [
+            value,
+            this.measureLabels[index],
+        ]);
+        this.measureLabeledValues = Object.fromEntries(this.measureEntries);
+    }
+
+    /**
+     * @param {import("../../../spec/data.js").AxisMeasureData} params
+     * @param {import("../../../view/view.js").default} view
+     */
+    constructor(params, view) {
+        /** @type {import("../../../spec/data.js").AxisMeasureData} params */
+        const paramsWithDefaults = {
+            channel: "x",
+            minMeasureSize: 50,
+            hideMeasureThreshold: 10,
+            multiplierValue: 1,
+            alignMeasure: "center",
+            ...params,
+        };
+
+        super(view, paramsWithDefaults.channel);
+        this.params = paramsWithDefaults;
+        this.updateSpanLabeledValues();
+    }
+    /** Function that calculates the domain coordinates
+     * of the measure, given the alignment parameter,
+     * the current scale domain and the size of the
+     * measure in domain units
+     *
+     * @param {string} alignMeasure
+     * @param {ScaleWithProps} scale
+     * @param {number} measureDomainSize
+     */
+    calculateCoord(alignMeasure, scale, measureDomainSize) {
+        let coordLeft, coordCenter, coordRight;
+        switch (alignMeasure) {
+            case "left":
+            case "bottom": // Fall-through case for 'bottom' along with 'left'
+                coordLeft = scale.domain()[0];
+                coordRight = coordLeft + measureDomainSize;
+                coordCenter = Math.floor((coordLeft + coordRight) / 2);
+                break;
+            case "center":
+                // @ts-ignore
+                coordCenter = scale.invert(0.5);
+                coordLeft = coordCenter - Math.floor(measureDomainSize / 2);
+                coordRight = coordCenter + Math.floor(measureDomainSize / 2);
+                break;
+            case "right":
+            case "top": // Fall-through case for 'top' along with 'right'
+                coordRight = scale.domain()[1];
+                coordLeft = coordRight - measureDomainSize;
+                coordCenter = Math.floor((coordLeft + coordRight) / 2);
+                break;
+            default:
+                console.error("Invalid alignMeasure value");
+                return null; // Return null or handle as necessary for invalid inputs
+        }
+        return [coordLeft, coordCenter, coordRight];
+    }
+
+    onDomainChanged() {
+        /** @type {ScaleWithProps} scale */
+        const scale = this.scaleResolution.scale;
+        const axisLength = this.getAxisLength();
+        const minMeasureSize = this.params.minMeasureSize;
+        const alignMeasure = this.params.alignMeasure;
+        const hideMeasureThreshold = this.params.hideMeasureThreshold;
+        // Find the size (in domain units) of a measure
+        // that shows minMeasureSize pixels wide
+        const minValueSize = Math.floor(
+            // @ts-ignore
+            scale.invert(minMeasureSize / axisLength) - scale.invert(0)
+        );
+        // Find the first measure size (in domain units) that produces a range
+        // bigger than the minimum requested size measure in pixels
+        const measureDomainSize = this.measureValues.find(
+            (value) => value > minValueSize
+        );
+        const measureLabel = this.measureLabeledValues[measureDomainSize];
+        // Position the measure according to the alignMeasure parameter
+        const [startPos, centerPos, endPos] = this.calculateCoord(
+            alignMeasure,
+            scale,
+            measureDomainSize
+        );
+        const measurePixelsSize = Math.floor(
+            (scale(endPos) - scale(startPos)) * axisLength
+        );
+        if (measureDomainSize <= hideMeasureThreshold) {
+            this.publishData([]); // hide the measure by publishing an empty array
+        } else {
+            if (startPos != this.startPos || endPos != this.endPos) {
+                this.publishData([
+                    [
+                        {
+                            startPos: startPos,
+                            endPos: endPos,
+                            centerPos: centerPos,
+                            measureDomainSize: measureDomainSize,
+                            measurePixelsSize: measurePixelsSize,
+                            measureLabel: measureLabel,
+                        },
+                    ],
+                ]);
+            }
+        }
+    }
+}

--- a/packages/core/src/data/sources/lazy/axisMeasureSource.js
+++ b/packages/core/src/data/sources/lazy/axisMeasureSource.js
@@ -28,7 +28,7 @@ export default class AxisMeasureSource extends SingleAxisLazySource {
     /** @type {Object.<number, string>} */
     measureLabeledValues = {};
 
-    updateSpanLabeledValues() {
+    updateMeasureLabeledValues() {
         this.measureValues = Array.from(
             { length: Math.floor(Math.log10(this.genome.totalSize)) + 1 },
             (_, i) => this.params.multiplierValue * 10 ** i
@@ -65,7 +65,7 @@ export default class AxisMeasureSource extends SingleAxisLazySource {
 
         super(view, paramsWithDefaults.channel);
         this.params = paramsWithDefaults;
-        this.updateSpanLabeledValues();
+        this.updateMeasureLabeledValues();
     }
     /** Function that calculates the domain coordinates
      * of the measure, given the alignment parameter,

--- a/packages/core/src/spec/data.d.ts
+++ b/packages/core/src/spec/data.d.ts
@@ -197,6 +197,7 @@ export interface LazyData {
 export type LazyDataParams =
     | AxisTicksData
     | AxisGenomeData
+    | AxisMeasureData
     | IndexedFastaData
     | BigWigData
     | BigBedData
@@ -241,6 +242,58 @@ export interface AxisGenomeData {
 
     /** Which channel's scale domain to use */
     channel: PrimaryPositionalChannel;
+}
+
+export interface AxisMeasureData {
+    type: "axisMeasure";
+
+    /**
+     * Which channel's scale domain to monitor.
+     *
+     * __Default value:__ `"x"`
+     */
+    channel?: PrimaryPositionalChannel;
+
+    /**
+     * Optional min measure size in pixels.
+     * It has to be big enough to fit the measure/span label.
+     * The measure size in pixels will vary between this minimum value and
+     * 10 times this value, when it switches to the next smaller span value.
+     *
+     * __Default value:__ `50`
+     */
+    minMeasureSize?: number;
+
+    /**
+     * Optional value of threshold to hide measure.
+     * If measure size in domain units (e.g. DNA bases) is less than or equal
+     * to this threshold, hide the measure to avoid "flickering" caused
+     * by rounding.
+     * The measure is not really necessary at this zoom level,
+     * as the axis ticks are filling that need.
+     *
+     * __Default value:__ `10`
+     */
+    hideMeasureThreshold?: number;
+
+    /**
+     * Optional multiplier value which can be used to create a different set
+     * of measures from the powers of 10: 1, 100, 1000, etc.
+     * e.g. : 5, 500, 5000 for multiplierValue = 5
+     *
+     * __Default value:__ `1`
+     */
+    multiplierValue?: number;
+
+    /**
+     * Optional positioning of the measure on the current axis scale domain:
+     * 'left', 'center' or 'right'
+     * For "y" channel axes, these values can be:
+     * 'bottom', 'center' or 'top'
+     *
+     * __Default value:__ `center`
+     */
+    alignMeasure?: string;
 }
 
 export interface IndexedFastaData extends DebouncedData {


### PR DESCRIPTION
Implemented an axisMeasure lazy datasource which can be used to create a visual clue to the level of zoom, publishing the `startPos`, `endPos`, `centerPos`, `measureDomainSize`, `measurePixelSize` and `measureLabel` fields at each scale domain change. 
Its behavior can be changed by several parameters: `minMeasureSize`, `hideMeasureThreshold`, `multiplierValue` and `alignMeasure`.
The parameters and fields usage is shown in two examples in `packages/core/example/axes` and they are also documented in the `lazy.md` part of the documentation.
The range of measureValues and measureLabels is determined by querying `genome.totalSize`, so this feature works only on genomeAxes (to make it more general, the scale `#zoomExtent` might need to be made available for simple Axes).