### PR TITLE
feat: multi-point selection

### DIFF
--- a/docs/grammar/parameters.md
+++ b/docs/grammar/parameters.md
@@ -117,7 +117,8 @@ However, currently only single-point selections are supported.
 The following example has been adapted from Vega-Lite's [example
 gallery](https://vega.github.io/vega-lite/examples/interactive_bar_select_highlight.html)
 with slight modifications (GenomeSpy provides no `"bar"` mark). The
-specification below is fully compatible with Vega-Lite.
+specification below is fully compatible with Vega-Lite. You can select multiple
+bars by holding down the `Shift` key.
 
 <div><genome-spy-doc-embed height="250">
 

--- a/packages/core/src/gl/glslScaleGenerator.js
+++ b/packages/core/src/gl/glslScaleGenerator.js
@@ -16,7 +16,7 @@ import {
 } from "../encoder/encoder.js";
 import { asArray, peek } from "../utils/arrayUtils.js";
 import { InternMap } from "internmap";
-import { isExprRef, validateParameterName } from "../view/paramMediator.js";
+import { isExprRef } from "../view/paramMediator.js";
 import scaleNull from "../utils/scaleNull.js";
 
 export const ATTRIBUTE_PREFIX = "attr_";
@@ -27,6 +27,7 @@ export const SCALE_FUNCTION_PREFIX = "scale_";
 export const SCALED_FUNCTION_PREFIX = "getScaled_";
 export const RANGE_TEXTURE_PREFIX = "uRangeTexture_";
 export const PARAM_PREFIX = "uParam_";
+export const SELECTION_CHECKER_PREFIX = "checkSelection_";
 
 // https://stackoverflow.com/a/47543127
 const FLT_MAX = 3.402823466e38;
@@ -523,16 +524,8 @@ export function generateConditionalEncoderGlsl(channel, accessors) {
         const accessorFunctionName = makeAccessorFunctionName(channel, i);
         const { param, empty } = accessor.predicate;
 
-        const paramUniform = PARAM_PREFIX + validateParameterName(param);
-        const idAttribute = ATTRIBUTE_PREFIX + "uniqueId";
-
-        // Hardcoded condition for single point selection ... for now.
         conditions.push(
-            param
-                ? `${idAttribute} == ${paramUniform}${
-                      empty ? ` || ${paramUniform} == uint(0)` : ""
-                  }`
-                : null
+            param ? `${SELECTION_CHECKER_PREFIX}${param}(${!!empty})` : null
         );
 
         statements.push(

--- a/packages/core/src/gl/includes/common.glsl
+++ b/packages/core/src/gl/includes/common.glsl
@@ -38,6 +38,37 @@ float linearstep(float edge0, float edge1, float x) {
     return clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
 }
 
+bool isEmptyBinarySearchTexture(highp usampler2D s) {
+    // The minimum texture size is 1x1. Zero is a special value that indicates
+    // an empty selection. Unique ids never start at zero.
+    return textureSize(s, 0).x == 1 && texelFetch(s, ivec2(0, 0), 0).r == 0u;
+}
+
+bool binarySearchTexture(highp usampler2D s, uint value) {
+    int texSize = textureSize(s, 0).x;
+
+    int left = 0;
+    int right = texSize - 1;
+
+    while (left <= right) {
+        int mid = left + (right - left) / 2;
+
+        uint midValue = texelFetch(s, ivec2(mid, 0), 0).r;
+
+        if (midValue == value) {
+            return true;
+        }
+
+        if (midValue < value) {
+            left = mid + 1;
+        } else {
+            right = mid - 1;
+        }
+    }
+
+    return false;
+}
+
 /**
  * Calculates a gamma for antialiasing opacity based on the color.
  */

--- a/packages/core/src/gl/webGLHelper.js
+++ b/packages/core/src/gl/webGLHelper.js
@@ -401,9 +401,9 @@ export default class WebGLHelper {
             );
         }
 
-        const uniqueIds = Array.from(selection.data.keys()).sort(
-            (a, b) => a - b
-        );
+        const keys = Array.from(selection.data.keys());
+        // Zero is a special value for no selection. The minimum texture size is 1.
+        const uniqueIds = keys.length > 0 ? keys.sort((a, b) => a - b) : [0];
 
         const existingTexture = this.selectionTextures.get(selection);
 

--- a/packages/core/src/gl/webGLHelper.js
+++ b/packages/core/src/gl/webGLHelper.js
@@ -27,6 +27,7 @@ import {
     isDiscreteChannel,
 } from "../encoder/encoder.js";
 import { color } from "d3-color";
+import { isMultiPointSelection } from "../selection/selection.js";
 
 export default class WebGLHelper {
     /**
@@ -57,6 +58,11 @@ export default class WebGLHelper {
 
         /** @type {WeakMap<import("../view/scaleResolution.js").default, WebGLTexture>} */
         this.rangeTextures = new WeakMap();
+
+        /**
+         * @type {WeakMap<import("../types/selectionTypes.js").MultiPointSelection, WebGLTexture>}
+         */
+        this.selectionTextures = new WeakMap();
 
         // --------------------------------------------------------
 
@@ -383,6 +389,40 @@ export default class WebGLHelper {
                 );
             }
         }
+    }
+
+    /**
+     * @param {import("../types/selectionTypes.js").MultiPointSelection} selection
+     */
+    createSelectionTexture(selection, update = true) {
+        if (!isMultiPointSelection(selection)) {
+            throw new Error(
+                "Not a multi-point selection, cannot create texture"
+            );
+        }
+
+        const uniqueIds = Array.from(selection.data.keys()).sort(
+            (a, b) => a - b
+        );
+
+        const existingTexture = this.selectionTextures.get(selection);
+
+        const gl = this.gl;
+        const texture = createOrUpdateTexture(
+            this.gl,
+            {
+                level: 0,
+                minMag: gl.NEAREST,
+                format: gl.RED_INTEGER,
+                internalFormat: gl.R32UI,
+                height: 1,
+                width: uniqueIds.length,
+            },
+            new Uint32Array(uniqueIds),
+            update ? existingTexture : false
+        );
+
+        this.selectionTextures.set(selection, texture);
     }
 }
 

--- a/packages/core/src/selection/selection.js
+++ b/packages/core/src/selection/selection.js
@@ -77,7 +77,7 @@ export function selectionTest(selection, datum, empty = true) {
     } else if (isMultiPointSelection(selection)) {
         return selection.data.size == 0
             ? empty
-            : selection.data.has(datum[UNIQUE_ID_KEY]);
+            : selection.data.has(datum[UNIQUE_ID_KEY]); // TODO: Binary search
     } else {
         throw new Error("Not a selection: " + JSON.stringify(selection));
     }
@@ -142,5 +142,8 @@ export function isPointSelectionConfig(config) {
  * @returns {boolean}
  */
 export function isTogglingEnabledInPointSelectionConfig(config) {
-    return isPointSelectionConfig(config) && config.toggle;
+    if (!isPointSelectionConfig(config)) {
+        return false;
+    }
+    return config.toggle ?? config.on === "click";
 }

--- a/packages/core/src/spec/parameter.d.ts
+++ b/packages/core/src/spec/parameter.d.ts
@@ -196,6 +196,8 @@ export interface BaseSelectionConfig<T extends SelectionType = SelectionType> {
 }
 
 export interface PointSelectionConfig extends BaseSelectionConfig<"point"> {
+    type: "point";
+
     /**
      * Controls whether data values should be toggled (inserted or removed from a point selection)
      * when clicking with the shift key pressed.
@@ -205,8 +207,7 @@ export interface PointSelectionConfig extends BaseSelectionConfig<"point"> {
      *
      * __Default value:__ `true`
      */
-    // TODO TODO TODO TODO TODO TODO TODO TODO
-    //toggle?: boolean;
+    toggle?: boolean;
     /**
      * A set of fields that uniquely identify a tuple. Used for bookmarking point selections
      * in the GenomeSpy App. Still work in progress.

--- a/packages/core/src/types/selectionTypes.d.ts
+++ b/packages/core/src/types/selectionTypes.d.ts
@@ -33,8 +33,8 @@ export interface SinglePointSelection extends SelectionBase {
 export interface MultiPointSelection extends SelectionBase {
     type: "multi";
 
-    data: Datum[];
-    uniqueIds: Set<number>;
+    /** Maps unique id to datum */
+    data: Map<number, Datum>;
 }
 
 export type Selection =

--- a/packages/core/src/view/paramMediator.js
+++ b/packages/core/src/view/paramMediator.js
@@ -1,6 +1,11 @@
 import { isString } from "vega-util";
 import createFunction from "../utils/expression.js";
-import { createSinglePointSelection } from "../selection/selection.js";
+import {
+    createMultiPointSelection,
+    createSinglePointSelection,
+    isPointSelectionConfig,
+    isTogglingEnabledInPointSelectionConfig,
+} from "../selection/selection.js";
 
 /**
  * A class that manages parameters and expressions.
@@ -100,13 +105,14 @@ export default class ParamMediator {
         }
 
         if ("select" in param) {
-            const type = isString(param.select)
-                ? param.select
-                : param.select.type;
-
-            // Set initial value so that production rules in shaders can be generated, etc.
-            if (type == "point") {
-                setter(createSinglePointSelection(null));
+            const select = param.select;
+            if (isPointSelectionConfig(select)) {
+                // Set initial value so that production rules in shaders can be generated, etc.
+                setter(
+                    isTogglingEnabledInPointSelectionConfig(select)
+                        ? createMultiPointSelection()
+                        : createSinglePointSelection(null)
+                );
             }
         }
 


### PR DESCRIPTION
This PR introduces the selection of multiple points by holding down the shift key.

![select_bars](https://github.com/user-attachments/assets/52bd1f88-ad3c-4a42-9694-fad3ab7590e0)

https://github.com/user-attachments/assets/62efb782-e340-4ac7-a8ef-de5f0c39e20f

The implementation uses a data texture for the unique ids of the data objects, sorted in an ascending order. The shader does the selection test using binary search.