### PR TITLE
feat(app): hierarchical metadata attributes

### DIFF
--- a/docs/sample-collections/visualizing.md
+++ b/docs/sample-collections/visualizing.md
@@ -167,6 +167,72 @@ the values on the metadata heatmap. The optional `barScale` property enables
 positional encoding, changing the heatmap cells into a horizontal bar chart. The
 `visible` property configures the default visibility for the attribute.
 
+### Hierarchical metadata attributes
+
+Metadata attributes can be grouped into hierarchical categories, which is
+practical when the number of attributes is large. You only need to define the
+data types and scales for the categories, and the attributes inherit these
+settings. Moreover, the user can easily toggle the visibility of the entire
+category with a single checkbox.
+
+Suppose you have the following metadata attributes that you would like to
+configure hierarchically:
+
+- patientId
+- Clinical data
+  - PFI
+  - OS
+- Mutational signatures
+  - HRD
+  - APOBEC
+
+To use hierarchical metadata attributes, the attribute names must have a
+(multi-level) group prefix, where a designated character separates the levels of
+the hierarchy. Use the `attributeGroupSeparator` property to delimit attribute
+names into groups. Then, specify settings for both individual attributes and
+groups if needed. The `visible` and `title` properties are not inherited; they
+only apply to the group itself.
+
+#### Example
+
+The above-mentioned metadata attributes could be named as follows:
+
+- `patientId`
+- `clinical.PFI`
+- `clinical.OS`
+- `signature.HRD`
+- `signature.APOBEC`
+
+... and configured as follows:
+
+```json title="Hierarchical metadata attributes"
+{
+  "samples": {
+    "data": { "url": "samples.tsv" },
+    "attributeGroupSeparator": ".",
+    "attributes": {
+      "patientId": {
+        "type": "nominal"
+      },
+      "clinical": {
+        "type": "quantitative",
+        "scale": {
+          "scheme": "blues"
+        }
+      },
+      "clinical.OS": {
+        "visible": false
+      },
+      "signature": {
+        "type": "quantitative",
+        "scale": { "scheme": "yelloworangered" },
+        "visible": false
+      }
+    }
+  }
+}
+```
+
 ### Adjusting font sizes, etc.
 
 The `samples` object can also be used to adjust the font sizes, etc. of the

--- a/packages/app/src/sampleView/metadataView.js
+++ b/packages/app/src/sampleView/metadataView.js
@@ -379,7 +379,9 @@ export class MetadataView extends ConcatView {
                             configurableVisibility: true,
                             title: attributeDef.title ?? node.part,
                             visible: attributeDef.visible ?? true,
-                            spacing: 1, // TODO: Configurable
+                            spacing:
+                                this.#sampleView.spec.samples
+                                    .attributeSpacing ?? 1,
                             resolve: {
                                 scale: { default: "independent" },
                                 axis: { default: "independent" },

--- a/packages/app/src/sampleView/metadataView.js
+++ b/packages/app/src/sampleView/metadataView.js
@@ -14,6 +14,7 @@ import { peek } from "@genome-spy/core/utils/arrayUtils.js";
 import { ActionCreators } from "redux-undo";
 import { contextMenu, DIVIDER } from "../utils/ui/contextMenu.js";
 import { checkForDuplicateScaleNames } from "@genome-spy/core/view/viewUtils.js";
+import { VISIT_STOP } from "@genome-spy/core/view/view.js";
 
 // TODO: Move to a more generic place
 /** @type {Record<string, import("@genome-spy/core/spec/channel.js").Type>} */
@@ -466,16 +467,6 @@ export class MetadataView extends ConcatView {
     }
 
     /**
-     * Returns the view that displays the given attribute.
-     *
-     * @param {string} attribute
-     */
-    #findViewForAttribute(attribute) {
-        // This is a bit fragile.. +1 is for skipping the sample label
-        return this.children[this.getAttributeNames().indexOf(attribute) + 1];
-    }
-
-    /**
      * @param {View} view
      * @returns {import("./types.js").AttributeInfo}
      */
@@ -506,9 +497,19 @@ export class MetadataView extends ConcatView {
      * @param {string} attribute
      */
     getAttributeInfo(attribute) {
-        return this.#getAttributeInfoFromView(
-            this.#findViewForAttribute(attribute)
-        );
+        const viewNameToFind = `attribute-${attribute}`;
+
+        /** @type {View} */
+        let attributeView;
+
+        this.visit((view) => {
+            if (view.name == viewNameToFind) {
+                attributeView = view;
+                return VISIT_STOP;
+            }
+        });
+
+        return this.#getAttributeInfoFromView(attributeView);
     }
 
     /**

--- a/packages/core/src/spec/sampleView.d.ts
+++ b/packages/core/src/spec/sampleView.d.ts
@@ -57,6 +57,11 @@ export interface SampleAttributeDef {
      * Whether the attribute is visible by default.
      */
     visible?: boolean;
+
+    /**
+     * The title of the attribute. Defaults to attribute name.
+     */
+    title?: string;
 }
 
 export interface SampleDef {
@@ -64,6 +69,12 @@ export interface SampleDef {
      * Optional metadata about the samples.
      */
     data?: Data;
+
+    /**
+     * If attributes form a hierarchy, specify the separator character to
+     * split the attribute names into paths.
+     */
+    attributeGroupSeparator?: string;
 
     /**
      * Explicitly specify the sample attributes.

--- a/packages/core/src/spec/sampleView.d.ts
+++ b/packages/core/src/spec/sampleView.d.ts
@@ -35,7 +35,7 @@ export interface SampleAttributeDef {
     /**
      * The attribute type. One of `"nominal"`, `"ordinal"`, or `"quantitative"`.
      */
-    type: Type; // TODO: Omit index/locus from available types
+    type?: Type; // TODO: Omit index/locus from available types
 
     /**
      * Scale definition for the (default) color channel


### PR DESCRIPTION
This PR adds support for hierarchical metadata attributes. When the number of attributes is large, it may be useful to have them stratified into an hierarchy. For instance, clinical data could form one group, technical data form another group, etc. This has two benefits:

1. The user can toggle the visibility of a category with a single checkbox
2. All attributes within a group can be configured at the same time, with much less typing

Closes #251 