### PR TITLE
feat(core): interval selection

### DIFF
--- a/docs/grammar/parameters.md
+++ b/docs/grammar/parameters.md
@@ -112,7 +112,8 @@ parameters change.
 Parameters allow for defining interactive selections, which can be used in
 conditional encodings. GenomeSpy compiles the conditional encoding rules into
 efficient GPU shader code, enabling fast interactions in very large data sets.
-However, only point selections are currently supported.
+
+#### Point selection
 
 The following example has been adapted from Vega-Lite's [example
 gallery](https://vega.github.io/vega-lite/examples/interactive_bar_select_highlight.html)
@@ -168,6 +169,48 @@ bars by holding down the `Shift` key.
         { "param": "select", "value": 2, "empty": false },
         { "param": "highlight", "value": 1, "empty": false }
       ]
+    }
+  }
+}
+```
+
+</genome-spy-doc-embed></div>
+
+#### Interval selection
+
+Interval selections allow for selecting a range of data points along one or two axes.
+By default, the selection is done by holding down the `Shift` key and dragging
+the mouse cursor over the data points. The selection can be cleared by clicking
+outside the selected area.
+
+<div><genome-spy-doc-embed height="250">
+
+```json
+{
+  "params": [
+    {
+      "name": "brush",
+      "value": { "x": [2, 4] },
+      "select": {
+        "type": "interval",
+        "encodings": ["x"]
+      }
+    }
+  ],
+
+  "data": { "url": "sincos.csv" },
+
+  "mark": { "type": "point", "size": 100 },
+
+  "encoding": {
+    "x": { "field": "x", "type": "quantitative", "scale": { "zoom": true } },
+    "y": { "field": "sin", "type": "quantitative" },
+    "color": {
+      "condition": {
+        "param": "brush",
+        "value": "#38c"
+      },
+      "value": "#ddd"
     }
   }
 }

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -34,15 +34,14 @@ import { contextMenu, DIVIDER } from "../utils/ui/contextMenu.js";
 import { interactionToZoom } from "@genome-spy/core/view/zoom.js";
 import Rectangle from "@genome-spy/core/view/layout/rectangle.js";
 import { faArrowsAltV, faXmark } from "@fortawesome/free-solid-svg-icons";
-import {
+import GridChild, {
     createBackground,
     createBackgroundStroke,
-    GridChild,
-    translateAxisCoords,
-} from "@genome-spy/core/view/gridView.js";
+} from "@genome-spy/core/view/gridView/gridChild.js";
 import { isAggregateSamplesSpec } from "@genome-spy/core/view/viewFactory.js";
 import getViewAttributeInfo from "./viewAttributeInfoSource.js";
 import { locusOrNumberToString } from "@genome-spy/core/genome/locusFormat.js";
+import { translateAxisCoords } from "@genome-spy/core/view/gridView/gridView.js";
 
 const VALUE_AT_LOCUS = "VALUE_AT_LOCUS";
 

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -754,6 +754,11 @@ export default class SampleView extends ContainerView {
 
         if (this.childCoords.containsPoint(event.point.x, event.point.y)) {
             this.#gridChild.view.propagateInteractionEvent(event);
+
+            if (event.stopped) {
+                return;
+            }
+
             // Hmm. Perhaps this could be attached to the child
             interactionToZoom(
                 event,

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -540,6 +540,8 @@ export default class SampleView extends ContainerView {
                 firstFacet: i == 0,
             });
         }
+
+        gridChild.selectionRect?.render(context, coords, options);
     }
 
     /**

--- a/packages/core/examples/selection/bars.json
+++ b/packages/core/examples/selection/bars.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "description": "A bar chart with highlighting on hover and selecting on click. (Inspired by Tableau's interaction style.)",
+
+  "width": 200,
+  "height": 200,
+
+  "data": {
+    "values": [
+      { "a": "A", "b": 28 },
+      { "a": "B", "b": 55 },
+      { "a": "C", "b": 43 },
+      { "a": "D", "b": 91 },
+      { "a": "E", "b": 81 },
+      { "a": "F", "b": 53 },
+      { "a": "G", "b": 19 },
+      { "a": "H", "b": 87 },
+      { "a": "I", "b": 52 }
+    ]
+  },
+  "params": [
+    {
+      "name": "highlight",
+      "select": { "type": "point", "on": "pointerover" }
+    },
+    { "name": "select", "select": "point" }
+  ],
+  "mark": {
+    "type": "rect",
+    "fill": "#4C78A8",
+    "stroke": "black"
+  },
+  "encoding": {
+    "x": {
+      "field": "a",
+      "type": "ordinal",
+      "scale": { "type": "band", "padding": 0.2 }
+    },
+    "y": { "field": "b", "type": "quantitative" },
+    "fillOpacity": {
+      "value": 0.3,
+      "condition": { "param": "select", "value": 1 }
+    },
+    "strokeWidth": {
+      "value": 0,
+      "condition": [
+        { "param": "select", "value": 2, "empty": false },
+        { "param": "highlight", "value": 1, "empty": false }
+      ]
+    }
+  }
+}

--- a/packages/core/examples/selection/click_point.json
+++ b/packages/core/examples/selection/click_point.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
+
+  "params": [
+    {
+      "name": "pointSelection"
+    }
+  ],
+
+  "vconcat": [
+    {
+      "data": { "values": [{}] },
+
+      "mark": {
+        "type": "text",
+        "size": { "expr": "pointSelection.datum ? 250 : 30" },
+        "font": "Lobster",
+        "text": {
+          "expr": "pointSelection.datum ? pointSelection.datum.y : 'Click a point!'"
+        }
+      }
+    },
+    {
+      "params": [
+        {
+          "name": "pointSelection",
+          "push": "outer",
+          "select": {
+            "type": "point",
+            "on": "click",
+            "keyFields": ["x"]
+          }
+        }
+      ],
+
+      "data": {
+        "values": [
+          { "x": 1, "y": "How" },
+          { "x": 2, "y": "are" },
+          { "x": 3, "y": "you?" }
+        ]
+      },
+
+      "transform": [{ "type": "identifier" }],
+
+      "mark": {
+        "type": "point",
+        "size": 1600
+      },
+
+      "encoding": {
+        "x": { "field": "x", "type": "ordinal" }
+      }
+    }
+  ]
+}

--- a/packages/core/examples/selection/condition.json
+++ b/packages/core/examples/selection/condition.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
+
+  "params": [
+    {
+      "name": "pointSelection",
+      "select": {
+        "type": "point",
+        "on": "mouseover"
+      }
+    }
+  ],
+
+  "data": {
+    "values": [
+      { "x": 1, "y": "How" },
+      { "x": 2, "y": "are" },
+      { "x": 3, "y": "you?" }
+    ]
+  },
+
+  "transform": [{ "type": "identifier" }],
+
+  "mark": {
+    "type": "point",
+    "size": 1600
+  },
+
+  "encoding": {
+    "x": { "field": "x", "type": "ordinal" },
+    "color": {
+      "value": "gray",
+      "condition": {
+        "param": "pointSelection",
+        "value": "#33f070"
+      }
+    }
+  }
+}

--- a/packages/core/examples/selection/interval_concat.json
+++ b/packages/core/examples/selection/interval_concat.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
+
+  "description": [
+    "Using interval selection to brush across concatenated views.",
+    "The views must have a shared scale."
+  ],
+
+  "data": {
+    "sequence": { "start": 0, "stop": 51, "as": "x" }
+  },
+
+  "encoding": {
+    "x": {
+      "field": "x",
+      "type": "quantitative"
+    },
+    "size": {
+      "condition": {
+        "param": "brush",
+        "value": 80,
+        "empty": false
+      },
+      "value": 10
+    }
+  },
+
+  "resolve": { "scale": { "x": "shared" } },
+
+  "params": [
+    {
+      "name": "brush",
+      "select": {
+        "type": "interval",
+        "encodings": ["x"]
+      }
+    }
+  ],
+
+  "vconcat": [{ "mark": "point" }, { "mark": "point" }]
+}

--- a/packages/core/examples/selection/interval_genome.json
+++ b/packages/core/examples/selection/interval_genome.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
+  "genome": { "name": "hg38" },
+
+  "params": [
+    {
+      "name": "brush",
+      "select": { "type": "interval", "encodings": ["x"] }
+    }
+  ],
+
+  "data": {
+    "values": [
+      { "chrom": "chr3", "pos": 134567890 },
+      { "chrom": "chr4", "pos": 123456789 },
+      { "chrom": "chr9", "pos": 34567890 }
+    ]
+  },
+  "mark": "point",
+  "encoding": {
+    "x": {
+      "chrom": "chrom",
+      "pos": "pos",
+      "type": "locus"
+    },
+    "size": { "value": 200 },
+    "color": {
+      "condition": {
+        "param": "brush",
+        "value": "red"
+      },
+      "value": "#aaa"
+    }
+  }
+}

--- a/packages/core/examples/selection/interval_points.json
+++ b/packages/core/examples/selection/interval_points.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
+  "description": "2D scatter plot with normally distributed random data",
+
+  "params": [
+    {
+      "name": "brush",
+      "select": {
+        "type": "interval",
+        "encodings": ["x", "y"]
+      }
+    }
+  ],
+
+  "data": {
+    "sequence": { "start": 0, "stop": 100000, "as": "z" }
+  },
+
+  "transform": [
+    { "type": "formula", "expr": "sqrt(-2 * log(random()))", "as": "_u" },
+    { "type": "formula", "expr": "random()", "as": "_v" },
+    {
+      "type": "formula",
+      "expr": "datum._u * cos(2 * PI * datum._v)",
+      "as": "x"
+    },
+    {
+      "type": "formula",
+      "expr": "datum._u * sin(2 * PI * datum._v)",
+      "as": "y"
+    }
+  ],
+
+  "mark": {
+    "type": "point",
+    "size": 9,
+    "opacity": 0.3
+  },
+
+  "encoding": {
+    "x": { "field": "x", "type": "quantitative", "scale": { "zoom": true } },
+    "y": { "field": "y", "type": "quantitative", "scale": { "zoom": true } },
+    "color": {
+      "condition": {
+        "param": "brush",
+        "value": "#38c"
+      },
+      "value": "#aaa"
+    },
+    "size": {
+      "condition": {
+        "param": "brush",
+        "value": 10,
+        "empty": true
+      },
+      "value": 2
+    }
+  }
+}

--- a/packages/core/examples/selection/interval_points.json
+++ b/packages/core/examples/selection/interval_points.json
@@ -5,6 +5,7 @@
   "params": [
     {
       "name": "brush",
+      "value": { "x": [-2, -1], "y": [-2, -1] },
       "select": {
         "type": "interval",
         "encodings": ["x", "y"]

--- a/packages/core/examples/selection/interval_ranged.json
+++ b/packages/core/examples/selection/interval_ranged.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
+
+  "title": "Select elements when they intersect with the brush",
+
+  "params": [
+    {
+      "name": "brush",
+      "select": { "type": "interval", "encodings": ["x"] }
+    }
+  ],
+
+  "data": {
+    "values": ["A", "B", "C", "D", "E", "F", "G"]
+  },
+  "transform": [
+    { "type": "formula", "expr": "round(random() * 100)", "as": "a" },
+    { "type": "formula", "expr": "datum.a + round(random() * 60)", "as": "b" }
+  ],
+  "encoding": {
+    "x": {
+      "field": "a",
+      "type": "quantitative",
+      "scale": { "zoom": true },
+      "buildIndex": false
+    },
+    "x2": { "field": "b" },
+    "y": {
+      "field": "data",
+      "type": "nominal",
+      "scale": { "padding": 0.3 }
+    }
+  },
+  "layer": [
+    {
+      "mark": "rect",
+      "encoding": {
+        "color": {
+          "condition": { "param": "brush", "value": "#588157", "empty": false },
+          "value": "#eaeaea"
+        }
+      }
+    },
+    {
+      "mark": {
+        "type": "text",
+        "align": "center",
+        "baseline": "middle",
+        "paddingX": 5
+      },
+      "encoding": {
+        "text": {
+          "expr": "'Hello ' + floor(datum.a)"
+        },
+        "size": { "value": 12 },
+        "color": {
+          "condition": { "param": "brush", "value": "white", "empty": false },
+          "value": "black"
+        }
+      }
+    }
+  ]
+}

--- a/packages/core/examples/selection/interval_ranged.json
+++ b/packages/core/examples/selection/interval_ranged.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
 
-  "title": "Select elements when they intersect with the brush",
+  "description": "Select elements when they intersect with the brush",
 
   "params": [
     {

--- a/packages/core/examples/selection/interval_ranged_test.json
+++ b/packages/core/examples/selection/interval_ranged_test.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
+
+  "description": [
+    "Select elements when they intersect with the brush",
+    "Also shows how to use a brush to filter data in a second chart."
+  ],
+
+  "params": [{ "name": "brush" }],
+
+  "data": {
+    "values": ["A", "B", "C", "D", "E", "F", "G"]
+  },
+  "transform": [
+    { "type": "formula", "expr": "round(random() * 100)", "as": "a" },
+    {
+      "type": "formula",
+      "expr": "datum.a + round(random() * 60)",
+      "as": "b"
+    },
+    {
+      "type": "formula",
+      "expr": "'Hello ' + floor(datum.a)",
+      "as": "text"
+    }
+  ],
+
+  "resolve": {
+    "scale": { "y": "shared" },
+    "axis": { "y": "shared" }
+  },
+
+  "hconcat": [
+    {
+      "params": [
+        {
+          "name": "brush",
+          "push": "outer",
+          "select": { "type": "interval", "encodings": ["x"] }
+        }
+      ],
+
+      "encoding": {
+        "x": {
+          "field": "a",
+          "type": "quantitative",
+          "scale": { "zoom": true },
+          "buildIndex": false
+        },
+        "x2": { "field": "b" },
+        "y": {
+          "field": "data",
+          "type": "ordinal",
+          "scale": { "padding": 0.3 }
+        }
+      },
+      "layer": [
+        {
+          "mark": "rect",
+          "encoding": {
+            "color": {
+              "condition": {
+                "param": "brush",
+                "value": "#588157",
+                "empty": false
+              },
+              "value": "#eaeaea"
+            }
+          }
+        },
+        {
+          "mark": {
+            "type": "text",
+            "align": "center",
+            "baseline": "middle",
+            "paddingX": 5
+          },
+          "encoding": {
+            "text": { "field": "text" },
+            "size": { "value": 12 },
+            "color": {
+              "condition": {
+                "param": "brush",
+                "value": "white",
+                "empty": false
+              },
+              "value": "black"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "view": {
+        "stroke": "lightgray"
+      },
+      "width": 40,
+      "mark": "text",
+      "transform": [
+        {
+          "type": "collect"
+        },
+        {
+          "type": "filter",
+          "expr": "brush.intervals.x ? (datum.a <= brush.intervals.x[1] && datum.b >= brush.intervals.x[0]) : true"
+        }
+      ],
+      "encoding": {
+        "text": { "field": "data" },
+        "y": { "field": "data", "type": "ordinal" },
+        "size": { "value": 20 }
+      }
+    }
+  ]
+}

--- a/packages/core/examples/selection/interval_ranged_test.json
+++ b/packages/core/examples/selection/interval_ranged_test.json
@@ -40,6 +40,8 @@
         }
       ],
 
+      "view": { "stroke": "lightgray" },
+
       "encoding": {
         "x": {
           "field": "a",
@@ -91,20 +93,19 @@
       ]
     },
     {
-      "view": {
-        "stroke": "lightgray"
-      },
+      "view": { "stroke": "lightgray" },
       "width": 40,
+
       "mark": "text",
+
       "transform": [
-        {
-          "type": "collect"
-        },
+        { "type": "collect" },
         {
           "type": "filter",
           "expr": "brush.intervals.x ? (datum.a <= brush.intervals.x[1] && datum.b >= brush.intervals.x[0]) : true"
         }
       ],
+
       "encoding": {
         "text": { "field": "data" },
         "y": { "field": "data", "type": "ordinal" },

--- a/packages/core/examples/selection/selection_test.json
+++ b/packages/core/examples/selection/selection_test.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
+
+  "params": [
+    {
+      "name": "pointSelection"
+    }
+  ],
+
+  "data": {
+    "values": [
+      { "x": 1, "y": "How" },
+      { "x": 2, "y": "are" },
+      { "x": 3, "y": "you?" }
+    ]
+  },
+
+  "transform": [{ "type": "identifier" }],
+
+  "encoding": {
+    "x": { "field": "x", "type": "ordinal" },
+    "text": { "field": "y" }
+  },
+
+  "resolve": { "scale": { "x": "shared" }, "axis": { "x": "shared" } },
+
+  "vconcat": [
+    {
+      "params": [
+        {
+          "name": "pointSelection",
+          "push": "outer",
+          "select": {
+            "type": "point",
+            "on": "mouseover",
+            "keyFields": ["x"]
+          }
+        }
+      ],
+
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "selectionTest(pointSelection, datum, false)",
+          "as": "selected"
+        }
+      ],
+
+      "encoding": {
+        "strokeWidth": {
+          "field": "selected",
+          "type": "nominal",
+          "scale": {
+            "type": "ordinal",
+            "domain": [false, true],
+            "range": [0, 4]
+          }
+        }
+      },
+
+      "mark": {
+        "type": "point",
+        "size": 3000,
+        "stroke": "black"
+      }
+    },
+
+    {
+      "transform": [{ "type": "filter", "param": "pointSelection" }],
+      "mark": { "type": "text", "size": 30 }
+    },
+
+    {
+      "transform": [
+        { "type": "filter", "expr": "selectionTest(pointSelection, datum)" }
+      ],
+      "mark": { "type": "text", "size": 30 }
+    }
+  ]
+}

--- a/packages/core/src/data/sources/inlineSource.js
+++ b/packages/core/src/data/sources/inlineSource.js
@@ -33,6 +33,7 @@ export default class InlineSource extends DataSource {
 
     /**
      * Returns true if the data source emits a single dummy datum.
+     * The behavior is unspecified if `updateDynamicData` is used.
      */
     isTrivial() {
         const values = this.params.values;
@@ -45,9 +46,24 @@ export default class InlineSource extends DataSource {
         );
     }
 
-    loadSynchronously() {
-        const values = this.params.values;
+    /**
+     * Programmatically updates the inline-provided data with new data.
+     *
+     * @param {import("../flowNode.js").Datum[]} data
+     */
+    updateDynamicData(data) {
+        this.#loadValuesSynchronously(data);
+    }
 
+    loadSynchronously() {
+        this.#loadValuesSynchronously(this.params.values);
+    }
+
+    /**
+     *
+     * @param {import("../../spec/data.js").InlineDataset} values
+     */
+    #loadValuesSynchronously(values) {
         let data = [];
 
         /** @type {(x: any) => import("../flowNode.js").Datum} */

--- a/packages/core/src/marks/link.js
+++ b/packages/core/src/marks/link.js
@@ -54,6 +54,14 @@ export default class LinkMark extends Mark {
     }
 
     /**
+     * Returns the default hit test mode for this mark.
+     * @returns {import("./mark.js").HitTestMode}
+     */
+    get defaultHitTestMode() {
+        return "endpoints";
+    }
+
+    /**
      * @returns {import("../spec/channel.js").Channel[]}
      */
     getAttributes() {

--- a/packages/core/src/marks/mark.js
+++ b/packages/core/src/marks/mark.js
@@ -568,7 +568,10 @@ export default class Mark {
                     selectionParameterUniforms.set(param, "interval");
 
                     /** @type {string[]} */
-                    const snippets = [];
+                    const testSnippets = [];
+
+                    /** @type {string[]} */
+                    const emptySnippets = [];
 
                     // Handle both channels separately
                     for (const channel of Object.keys(selection.intervals)) {
@@ -598,14 +601,17 @@ export default class Mark {
                                     ]
                             );
                         });
-                        snippets.push(
+                        testSnippets.push(
                             `(${uniformName}[0] <= ${ATTRIBUTE_PREFIX}${channel} && ${ATTRIBUTE_PREFIX}${channel} <= ${uniformName}[1])`
+                        );
+                        emptySnippets.push(
+                            `(${uniformName}[0] > ${uniformName}[1])`
                         );
                     }
 
                     scaleCode.push(
                         `bool ${SELECTION_CHECKER_PREFIX}${param}(bool empty) {\n` +
-                            `    return ${snippets.join(" && ")};\n` +
+                            `    return ${testSnippets.join(" && ")} || (empty && (${emptySnippets.join(" || ")}));\n` +
                             `}`
                     );
                 }

--- a/packages/core/src/marks/mark.js
+++ b/packages/core/src/marks/mark.js
@@ -472,7 +472,7 @@ export default class Mark {
         for (const predicate of paramPredicates) {
             const param = predicate.param;
             const paramMediator = this.unitView.paramMediator;
-            const selection = paramMediator.getValue(param);
+            const selection = paramMediator.findValue(param);
 
             // The selection is supposed to have an empty value at this point
             // so that we can figure out the type of the selection.

--- a/packages/core/src/marks/mark.js
+++ b/packages/core/src/marks/mark.js
@@ -595,9 +595,15 @@ export default class Mark {
                             validateParameterName(param) +
                             `_${channel}`;
 
+                        // TODO: High precision scales
+                        const { attributeType } = getAttributeAndArrayTypes(
+                            this.unitView.getScaleResolution(channel).scale,
+                            channel
+                        );
+
                         dynamicMarkUniforms.push(`    // Selection parameter`);
                         dynamicMarkUniforms.push(
-                            `    uniform highp vec2 ${uniformName};`
+                            `    uniform highp ${attributeType}[2] ${uniformName};`
                         );
                         this.#callAfterShaderCompilation.push(() => {
                             this.registerMarkUniformValue(

--- a/packages/core/src/selection/selection.js
+++ b/packages/core/src/selection/selection.js
@@ -33,7 +33,9 @@ export function createMultiPointSelection(data) {
 export function createIntervalSelection(channels) {
     return {
         type: "interval",
-        intervals: new Map(channels.map((c) => [c, null])),
+        intervals: Object.fromEntries(
+            channels.map((c) => [c, /** @type {number[]} */ (null)])
+        ),
     };
 }
 

--- a/packages/core/src/selection/selection.js
+++ b/packages/core/src/selection/selection.js
@@ -26,6 +26,18 @@ export function createMultiPointSelection(data) {
 }
 
 /**
+ *
+ * @param {import("../spec/channel.js").ChannelWithScale[]} channels
+ * @returns {import("../types/selectionTypes.js").IntervalSelection}
+ */
+export function createIntervalSelection(channels) {
+    return {
+        type: "interval",
+        intervals: new Map(channels.map((c) => [c, null])),
+    };
+}
+
+/**
  * Updates the backing data and returns a new instance of the selection object.
  * A new instance is required to trigger reactivity in parameters.
  *
@@ -78,6 +90,8 @@ export function selectionTest(selection, datum, empty = true) {
         return selection.data.size == 0
             ? empty
             : selection.data.has(datum[UNIQUE_ID_KEY]); // TODO: Binary search
+    } else if (isIntervalSelection(selection)) {
+        throw new Error("TODO: Implement interval selection test");
     } else {
         throw new Error("Not a selection: " + JSON.stringify(selection));
     }
@@ -94,10 +108,10 @@ export function makeSelectionTestExpression(params) {
 
 /**
  * @param {import("../types/selectionTypes.js").Selection} selection
- * @returns {selection is import("../types/selectionTypes.js").RangeSelection}
+ * @returns {selection is import("../types/selectionTypes.js").IntervalSelection}
  */
-export function isRangeSelection(selection) {
-    return selection.type === "range";
+export function isIntervalSelection(selection) {
+    return selection.type === "interval";
 }
 
 /**
@@ -151,4 +165,13 @@ export function asSelectionConfig(typeOrConfig) {
  */
 export function isPointSelectionConfig(config) {
     return config && config.type == "point";
+}
+
+/**
+ *
+ * @param {import("../spec/parameter.js").SelectionConfig} config
+ * @returns {config is import("../spec/parameter.js").IntervalSelectionConfig}
+ */
+export function isIntervalSelectionConfig(config) {
+    return config && config.type == "interval";
 }

--- a/packages/core/src/spec/parameter.d.ts
+++ b/packages/core/src/spec/parameter.d.ts
@@ -229,8 +229,51 @@ export interface IntervalSelectionConfig
      * An array of encoding channels that define the interval selection.
      */
     encodings?: PrimaryPositionalChannel[];
+
+    /**
+     * Interval selections display a rectangle mark to show the selected range.
+     * Use the `mark` property to adjust the appearance of this rectangle.
+     */
+    mark?: BrushConfig;
 }
 
+export interface BrushConfig {
+    /**
+     * The fill color of the interval mark.
+     *
+     * __Default value:__ `"#808080"`
+     *
+     */
+    fill?: Color;
+
+    /**
+     * The fill opacity of the interval mark (a value between `0` and `1`).
+     *
+     * __Default value:__ `0.05`
+     */
+    fillOpacity?: number;
+
+    /**
+     * The stroke color of the interval mark.
+     *
+     * __Default value:__ `"black"`
+     */
+    stroke?: Color;
+
+    /**
+     * The stroke opacity of the interval mark (a value between `0` and `1`).
+     *
+     * __Default value:__ `0.2`
+     */
+    strokeOpacity?: number;
+
+    /**
+     * The stroke width of the interval mark.
+     *
+     * __Default value:__ `1`
+     */
+    strokeWidth?: number;
+}
 export interface SelectionParameter<T extends SelectionType = SelectionType>
     extends ParameterBase {
     /**

--- a/packages/core/src/spec/parameter.d.ts
+++ b/packages/core/src/spec/parameter.d.ts
@@ -181,22 +181,6 @@ export interface BaseSelectionConfig<T extends SelectionType = SelectionType> {
     /**
      */
     on?: "click" | "mouseover" | "pointerover";
-
-    /**
-     * An array of encoding channels. The corresponding data field values
-     * must match for a data tuple to fall within the selection.
-     *
-     * __See also:__ The [projection with `encodings` and `fields` section](https://vega.github.io/vega-lite/docs/selection.html#project) in the documentation.
-     */
-    encodings?: ChannelWithScale[];
-
-    /**
-     * An array of field names whose values must match for a data tuple to
-     * fall within the selection.
-     *
-     * __See also:__ The [projection with `encodings` and `fields` section](https://vega.github.io/vega-lite/docs/selection.html#project) in the documentation.
-     */
-    fields?: string[];
 }
 
 export interface PointSelectionConfig extends BaseSelectionConfig<"point"> {
@@ -290,20 +274,15 @@ export interface SelectionParameter<T extends SelectionType = SelectionType>
                 ? IntervalSelectionConfig
                 : never);
 
-    /*
-     * Initialize the selection with a mapping between [projected channels or field names](https://vega.github.io/vega-lite/docs/selection.html#project) and initial values.
-     *
-     * __See also:__ [`init`](https://vega.github.io/vega-lite/docs/value.html) documentation.
+    /**
+     * Initial value for the selection.
      */
-    /*
-    // TODO TODO TODO TODO TODO TODO TODO TODO 
-    value?: T extends "point"
-        ? SelectionInit | SelectionInitMapping[]
-        : T extends "interval"
-        ? SelectionInitIntervalMapping
-        : never;
-        */
+    value?: T extends "interval" ? SelectionInitIntervalMapping : never;
 }
+
+export type SelectionInitIntervalMapping = Partial<
+    Record<PrimaryPositionalChannel, [number, number]>
+>;
 
 export type SelectionConfig = PointSelectionConfig | IntervalSelectionConfig;
 export type SelectionTypeOrConfig = SelectionType | SelectionConfig;

--- a/packages/core/src/spec/parameter.d.ts
+++ b/packages/core/src/spec/parameter.d.ts
@@ -109,7 +109,7 @@ export interface BindRadioSelect extends BindBase {
 }
 
 export interface BindRange extends BindBase {
-    input: "interval";
+    input: "range";
 
     /**
      * Sets the minimum slider value. Defaults to the smaller of the signal value and `0`.
@@ -244,7 +244,7 @@ export interface BrushConfig {
      * __Default value:__ `"#808080"`
      *
      */
-    fill?: Color;
+    fill?: string;
 
     /**
      * The fill opacity of the interval mark (a value between `0` and `1`).
@@ -258,7 +258,7 @@ export interface BrushConfig {
      *
      * __Default value:__ `"black"`
      */
-    stroke?: Color;
+    stroke?: string;
 
     /**
      * The stroke opacity of the interval mark (a value between `0` and `1`).

--- a/packages/core/src/spec/parameter.d.ts
+++ b/packages/core/src/spec/parameter.d.ts
@@ -1,4 +1,8 @@
-import { ChannelWithScale, Scalar } from "./channel.js";
+import {
+    ChannelWithScale,
+    PrimaryPositionalChannel,
+    Scalar,
+} from "./channel.js";
 
 export interface ExprRef {
     /**
@@ -105,7 +109,7 @@ export interface BindRadioSelect extends BindBase {
 }
 
 export interface BindRange extends BindBase {
-    input: "range";
+    input: "interval";
 
     /**
      * Sets the minimum slider value. Defaults to the smaller of the signal value and `0`.
@@ -219,7 +223,12 @@ export interface PointSelectionConfig extends BaseSelectionConfig<"point"> {
 
 export interface IntervalSelectionConfig
     extends BaseSelectionConfig<"interval"> {
-    // TODO
+    type: "interval";
+
+    /**
+     * An array of encoding channels that define the interval selection.
+     */
+    encodings?: PrimaryPositionalChannel[];
 }
 
 export interface SelectionParameter<T extends SelectionType = SelectionType>

--- a/packages/core/src/styles/genome-spy.css.js
+++ b/packages/core/src/styles/genome-spy.css.js
@@ -16,6 +16,9 @@ const css = `
   opacity: 1;
   transition: transform 0.6s, opacity 0.6s;
 }
+.genome-spy canvas:focus, .genome-spy canvas:focus-visible {
+  outline: none;
+}
 .genome-spy .loading-message {
   position: absolute;
   inset: 0;

--- a/packages/core/src/styles/genome-spy.scss
+++ b/packages/core/src/styles/genome-spy.scss
@@ -26,6 +26,11 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
         transition:
             transform 0.6s,
             opacity 0.6s;
+
+        &:focus,
+        &:focus-visible {
+            outline: none;
+        }
     }
 
     .loading-message {

--- a/packages/core/src/types/selectionTypes.d.ts
+++ b/packages/core/src/types/selectionTypes.d.ts
@@ -8,7 +8,7 @@ export interface SelectionBase {
 export interface IntervalSelection extends SelectionBase {
     type: "interval";
 
-    intervals: Map<ChannelWithScale, number[] | null>;
+    intervals: Partial<Record<ChannelWithScale, number[] | null>>;
 }
 
 export interface ProjectedSelection extends SelectionBase {

--- a/packages/core/src/types/selectionTypes.d.ts
+++ b/packages/core/src/types/selectionTypes.d.ts
@@ -5,13 +5,10 @@ export interface SelectionBase {
     type: string;
 }
 
-export interface RangeSelection extends SelectionBase {
-    type: "range";
+export interface IntervalSelection extends SelectionBase {
+    type: "interval";
 
-    fields?: string[];
-    channels?: ChannelWithScale[];
-
-    ranges: number[][];
+    intervals: Map<ChannelWithScale, number[] | null>;
 }
 
 export interface ProjectedSelection extends SelectionBase {
@@ -38,7 +35,7 @@ export interface MultiPointSelection extends SelectionBase {
 }
 
 export type Selection =
-    | RangeSelection
+    | IntervalSelection
     | ProjectedSelection
     | SinglePointSelection
     | MultiPointSelection;

--- a/packages/core/src/view/concatView.js
+++ b/packages/core/src/view/concatView.js
@@ -1,5 +1,5 @@
 import { isConcatSpec, isHConcatSpec, isVConcatSpec } from "./viewFactory.js";
-import GridView from "./gridView.js";
+import GridView from "./gridView/gridView.js";
 
 /**
  * Creates a vertically or horizontally concatenated layout for children.

--- a/packages/core/src/view/gridView/gridChild.js
+++ b/packages/core/src/view/gridView/gridChild.js
@@ -1,5 +1,6 @@
 import {
     asSelectionConfig,
+    createIntervalSelection,
     isIntervalSelectionConfig,
 } from "../../selection/selection.js";
 import AxisGridView from "../axisGridView.js";
@@ -146,6 +147,9 @@ export default class GridChild {
                 view.addInteractionEventListener(
                     "mousedown",
                     (coords, event) => {
+                        // Clear existing selection
+                        setter(createIntervalSelection(select.encodings));
+
                         const start = invertPoint(event.point);
 
                         /** @type {import("../view.js").InteractionEventListener} */

--- a/packages/core/src/view/gridView/gridChild.js
+++ b/packages/core/src/view/gridView/gridChild.js
@@ -213,7 +213,14 @@ export default class GridChild {
                 } else {
                     // Clear existing selection
                     setter(createIntervalSelection(select.encodings));
+
+                    if (!(/** @type {MouseEvent} */ (event.uiEvent).shiftKey)) {
+                        return;
+                    }
                 }
+
+                // Prevent panning interaction
+                event.stopPropagation();
 
                 const start = event.point;
 
@@ -222,14 +229,9 @@ export default class GridChild {
                     const current = event.point;
 
                     if (translatedRectangle) {
-                        // Translate the rectangle
-                        const delta = {
-                            x: current.x - start.x,
-                            y: current.y - start.y,
-                        };
                         const newRect = translatedRectangle.translate(
-                            delta.x,
-                            delta.y
+                            current.x - start.x,
+                            current.y - start.y
                         );
 
                         setter({

--- a/packages/core/src/view/gridView/gridChild.js
+++ b/packages/core/src/view/gridView/gridChild.js
@@ -244,10 +244,28 @@ export default class GridChild {
                 if (translatedRectangle) {
                     setCursor("grabbing");
                 } else {
-                    // Clear existing selection
-                    setter(createIntervalSelection(channels));
+                    const mouseDownPoint = event.point;
+                    if (/** @type {MouseEvent} */ (event.uiEvent).shiftKey) {
+                        // Clear existing selection
+                        setter(createIntervalSelection(channels));
+                    } else {
+                        /** @type {import("../view.js").InteractionEventListener} */
+                        const listener = (coords, event) => {
+                            view.removeInteractionEventListener(
+                                "mouseup",
+                                listener
+                            );
+                            const mouseUpPoint = event.point;
 
-                    if (!(/** @type {MouseEvent} */ (event.uiEvent).shiftKey)) {
+                            // Retain selection if the viewport is panned by dragging
+                            if (
+                                mouseDownPoint.subtract(mouseUpPoint).length < 2
+                            ) {
+                                // Clear existing selection
+                                setter(createIntervalSelection(channels));
+                            }
+                        };
+                        view.addInteractionEventListener("mouseup", listener);
                         return;
                     }
                 }

--- a/packages/core/src/view/gridView/gridChild.js
+++ b/packages/core/src/view/gridView/gridChild.js
@@ -275,17 +275,17 @@ export default class GridChild {
 
                 const start = event.point;
 
-                /** @type {import("../view.js").InteractionEventListener} */
-                const mouseMoveListener = (coords, event) => {
-                    const current = event.point;
+                const mouseMoveListener = (/** @type {MouseEvent} */ event) => {
+                    const current = Point.fromMouseEvent(event);
 
                     /** @type {ReturnType<typeof pointsToIntervals>} */
                     let intervals;
 
                     if (translatedRectangle) {
+                        const offset = current.subtract(start);
                         const newRect = translatedRectangle.translate(
-                            current.x - start.x,
-                            current.y - start.y
+                            offset.x,
+                            offset.y
                         );
 
                         intervals = pointsToIntervals(
@@ -337,25 +337,23 @@ export default class GridChild {
                 };
 
                 const mouseUpListener = () => {
-                    view.removeInteractionEventListener(
+                    document.removeEventListener(
                         "mousemove",
                         mouseMoveListener
                     );
-                    window.removeEventListener("mouseup", mouseUpListener);
+                    document.removeEventListener("mouseup", mouseUpListener);
 
                     if (translatedRectangle) {
                         setCursor("move");
                         translatedRectangle = null;
                     }
                 };
-                view.addInteractionEventListener(
-                    "mousemove",
-                    mouseMoveListener
-                );
+                document.addEventListener("mousemove", mouseMoveListener);
 
-                window.addEventListener("mouseup", mouseUpListener);
+                document.addEventListener("mouseup", mouseUpListener);
             });
 
+            // Handle mouse cursor changes
             view.addInteractionEventListener("mousemove", (coords, event) => {
                 const currentSelection =
                     /** @type {import("../../types/selectionTypes.js").IntervalSelection}) */ (

--- a/packages/core/src/view/gridView/gridChild.js
+++ b/packages/core/src/view/gridView/gridChild.js
@@ -110,7 +110,7 @@ export default class GridChild {
     #setupIntervalSelection() {
         const view = this.view;
 
-        for (const [, param] of view.paramMediator.paramConfigs) {
+        for (const [name, param] of view.paramMediator.paramConfigs) {
             if (!("select" in param)) {
                 continue;
             }
@@ -118,7 +118,12 @@ export default class GridChild {
             const select = asSelectionConfig(param.select);
 
             if (isIntervalSelectionConfig(select)) {
-                this.selectionRect = new SelectionRect(this, select.encodings);
+                const selectionExpr = view.paramMediator.createExpression(name);
+                //const initialSelection = selectionExpr();
+
+                const setter = view.paramMediator.getSetter(name);
+
+                this.selectionRect = new SelectionRect(this, selectionExpr);
 
                 const invertPoint = (
                     /** @type {import("../layout/point.js").default} */ point
@@ -147,17 +152,25 @@ export default class GridChild {
                         const mouseMoveListener = (coords, event) => {
                             const current = invertPoint(event.point);
 
-                            // TODO: Should be updated when the selection param changes
-                            this.selectionRect.update(
-                                [start.x, current.x],
-                                [start.y, current.y]
-                            );
+                            setter({
+                                type: "interval",
+                                intervals: {
+                                    x: [
+                                        Math.min(start.x, current.x),
+                                        Math.max(start.x, current.x),
+                                    ],
+                                    y: [
+                                        Math.min(start.y, current.y),
+                                        Math.max(start.y, current.y),
+                                    ],
+                                },
+                            });
                         };
 
                         const mouseUpListener =
                             /** @type {function(MouseEvent)} */
                             (event) => {
-                                this.selectionRect.clear();
+                                //this.selectionRect.clear();
 
                                 view.removeInteractionEventListener(
                                     "mousemove",

--- a/packages/core/src/view/gridView/gridChild.js
+++ b/packages/core/src/view/gridView/gridChild.js
@@ -149,7 +149,11 @@ export default class GridChild {
             const setter = view.paramMediator.getSetter(name);
 
             // TODO: What if there are multiple interval selection parameters?
-            this.selectionRect = new SelectionRect(this, selectionExpr);
+            this.selectionRect = new SelectionRect(
+                this,
+                selectionExpr,
+                select.mark
+            );
 
             /** @type {Rectangle} */
             let translatedRectangle = null;

--- a/packages/core/src/view/gridView/gridChild.js
+++ b/packages/core/src/view/gridView/gridChild.js
@@ -173,6 +173,10 @@ export default class GridChild {
             const selectionExpr = view.paramMediator.createExpression(name);
             const setter = view.paramMediator.getSetter(name);
 
+            if (param.value) {
+                setter({ type: "interval", intervals: param.value });
+            }
+
             this.selectionRect = new SelectionRect(
                 this,
                 selectionExpr,
@@ -310,8 +314,6 @@ export default class GridChild {
                         }
                         interval[1] = Math.min(zoomExtent[1], interval[1]);
                     }
-
-                    console.log("Intervals:", JSON.stringify(intervals));
 
                     setter({ type: "interval", intervals });
                 };

--- a/packages/core/src/view/gridView/gridChild.js
+++ b/packages/core/src/view/gridView/gridChild.js
@@ -1,0 +1,396 @@
+import AxisGridView from "../axisGridView.js";
+import AxisView, { CHANNEL_ORIENTS } from "../axisView.js";
+import LayerView from "../layerView.js";
+import Padding from "../layout/padding.js";
+import Rectangle from "../layout/rectangle.js";
+import createTitle from "../title.js";
+import UnitView from "../unitView.js";
+import Scrollbar from "./scrollbar.js";
+
+export default class GridChild {
+    /**
+     * @param {import("../view.js").default} view
+     * @param {import("../containerView.js").default} layoutParent
+     * @param {number} serial
+     */
+    constructor(view, layoutParent, serial) {
+        this.layoutParent = layoutParent;
+        this.view = view;
+        this.serial = serial;
+
+        /** @type {UnitView} */
+        this.background = undefined;
+
+        /** @type {UnitView} */
+        this.backgroundStroke = undefined;
+
+        /** @type {Partial<Record<import("../../spec/axis.js").AxisOrient, AxisView>>} axes */
+        this.axes = {};
+
+        /** @type {Partial<Record<import("../../spec/axis.js").AxisOrient, AxisGridView>>} gridLines */
+        this.gridLines = {};
+
+        /** @type {Partial<Record<import("./scrollbar.js").ScrollDirection, Scrollbar>>} */
+        this.scrollbars = {};
+
+        /** @type {UnitView} */
+        this.selectionRect = undefined;
+
+        /** @type {UnitView} */
+        this.title = undefined;
+
+        /** @type {Rectangle} */
+        this.coords = Rectangle.ZERO;
+
+        if (view.needsAxes.x || view.needsAxes.y) {
+            const spec = view.spec;
+            const viewBackground = "view" in spec ? spec?.view : undefined;
+
+            const backgroundSpec = createBackground(viewBackground);
+            if (backgroundSpec) {
+                this.background = new UnitView(
+                    backgroundSpec,
+                    layoutParent.context,
+                    layoutParent,
+                    view,
+                    "background" + serial,
+                    {
+                        blockEncodingInheritance: true,
+                    }
+                );
+            }
+
+            const backgroundStrokeSpec = createBackgroundStroke(viewBackground);
+            if (backgroundStrokeSpec) {
+                this.backgroundStroke = new UnitView(
+                    backgroundStrokeSpec,
+                    layoutParent.context,
+                    layoutParent,
+                    view,
+                    "backgroundStroke" + serial,
+                    {
+                        blockEncodingInheritance: true,
+                    }
+                );
+            }
+
+            const title = createTitle(view.spec.title);
+            if (title) {
+                const unitView = new UnitView(
+                    title,
+                    layoutParent.context,
+                    layoutParent,
+                    view,
+                    "title" + serial,
+                    {
+                        blockEncodingInheritance: true,
+                    }
+                );
+                this.title = unitView;
+            }
+        }
+
+        // TODO: More specific getter for this
+        if (view.spec.viewportWidth != null) {
+            this.scrollbars.horizontal = new Scrollbar(this, "horizontal");
+        }
+
+        if (view.spec.viewportHeight != null) {
+            this.scrollbars.vertical = new Scrollbar(this, "vertical");
+        }
+    }
+
+    *getChildren() {
+        if (this.background) {
+            yield this.background;
+        }
+        if (this.backgroundStroke) {
+            yield this.backgroundStroke;
+        }
+        if (this.title) {
+            yield this.title;
+        }
+        yield* Object.values(this.axes);
+        yield* Object.values(this.gridLines);
+        yield this.view;
+        yield* Object.values(this.scrollbars);
+        if (this.selectionRect) {
+            yield this.selectionRect;
+        }
+    }
+
+    /**
+     * Create view decorations, grid lines, axes, etc.
+     */
+    async createAxes() {
+        const { view, axes, gridLines } = this;
+
+        /**
+         * @param {import("../axisResolution.js").default} r
+         * @param {import("../../spec/channel.js").PrimaryPositionalChannel} channel
+         */
+        const getAxisPropsWithDefaults = (r, channel) => {
+            const propsWithoutDefaults = r.getAxisProps();
+            if (propsWithoutDefaults === null) {
+                return;
+            }
+
+            const props = propsWithoutDefaults
+                ? { ...propsWithoutDefaults }
+                : {};
+
+            // Pick a default orient based on what is available.
+            // This logic is needed for layer views that have independent axes.
+            if (!props.orient) {
+                for (const orient of CHANNEL_ORIENTS[channel]) {
+                    if (!axes[orient]) {
+                        props.orient = orient;
+                        break;
+                    }
+                }
+                if (!props.orient) {
+                    throw new Error(
+                        "No slots available for an axis! Perhaps a LayerView has more than two children?"
+                    );
+                }
+            }
+
+            props.title ??= r.getTitle();
+
+            if (!CHANNEL_ORIENTS[channel].includes(props.orient)) {
+                throw new Error(
+                    `Invalid axis orientation "${props.orient}" on channel "${channel}"!`
+                );
+            }
+
+            return props;
+        };
+
+        /**
+         * @param {import("../axisResolution.js").default} r
+         * @param {import("../../spec/channel.js").PrimaryPositionalChannel} channel
+         * @param {import("../view.js").default} axisParent
+         */
+        const createAxis = async (r, channel, axisParent) => {
+            const props = getAxisPropsWithDefaults(r, channel);
+
+            if (props) {
+                if (axes[props.orient]) {
+                    throw new Error(
+                        `An axis with the orient "${props.orient}" already exists!`
+                    );
+                }
+
+                const axisView = new AxisView(
+                    props,
+                    r.scaleResolution.type,
+                    this.layoutParent.context,
+                    this.layoutParent,
+                    axisParent
+                );
+                axes[props.orient] = axisView;
+                await axisView.initializeChildren();
+            }
+        };
+
+        /**
+         * @param {import("../axisResolution.js").default} r
+         * @param {import("../../spec/channel.js").PrimaryPositionalChannel} channel
+         * @param {import("../view.js").default} axisParent
+         */
+        const createAxisGrid = async (r, channel, axisParent) => {
+            const props = getAxisPropsWithDefaults(r, channel);
+
+            if (props && (props.grid || props.chromGrid)) {
+                const axisGridView = new AxisGridView(
+                    props,
+                    r.scaleResolution.type,
+                    this.layoutParent.context,
+                    this.layoutParent,
+                    axisParent
+                );
+                gridLines[props.orient] = axisGridView;
+                await axisGridView.initializeChildren();
+            }
+        };
+
+        // Handle children that have caught axis resolutions. Create axes for them.
+        for (const channel of /** @type {import("../../spec/channel.js").PrimaryPositionalChannel[]} */ ([
+            "x",
+            "y",
+        ])) {
+            if (view.needsAxes[channel]) {
+                const r = view.resolutions.axis[channel];
+                if (!r) {
+                    continue;
+                }
+
+                await createAxis(r, channel, view);
+            }
+        }
+
+        // Handle gridlines of children. Note: children's axis resolution may be caught by
+        // this view or some of this view's ancestors.
+        for (const channel of /** @type {import("../../spec/channel.js").PrimaryPositionalChannel[]} */ ([
+            "x",
+            "y",
+        ])) {
+            if (
+                view.needsAxes[channel] &&
+                // Handle a special case where the child view has an excluded resolution
+                // but no scale or axis, e.g., when only values are used on a channel.
+                view.getConfiguredOrDefaultResolution(channel, "axis") !=
+                    "excluded"
+            ) {
+                const r = view.getAxisResolution(channel);
+                if (!r) {
+                    continue;
+                }
+
+                await createAxisGrid(r, channel, view);
+            }
+        }
+
+        // Handle LayerView's possible independent axes
+        if (view instanceof LayerView) {
+            // First create axes that have an orient preference
+            for (const layerChild of view) {
+                for (const [channel, r] of Object.entries(
+                    layerChild.resolutions.axis
+                )) {
+                    const props = r.getAxisProps();
+                    if (props && props.orient) {
+                        await createAxis(r, channel, layerChild);
+                    }
+                }
+            }
+
+            // Then create axes in a priority order
+            for (const layerChild of view) {
+                for (const [channel, r] of Object.entries(
+                    layerChild.resolutions.axis
+                )) {
+                    const props = r.getAxisProps();
+                    if (props && !props.orient) {
+                        await createAxis(r, channel, layerChild);
+                    }
+                }
+            }
+
+            // TODO: Axis grid
+        }
+
+        // Axes are created after scales are resolved, so we need to resolve possible new scales here
+        [...Object.values(axes), ...Object.values(gridLines)].forEach((v) =>
+            v.visit((view) => {
+                if (view instanceof UnitView) {
+                    view.resolve("scale");
+                }
+            })
+        );
+    }
+
+    getOverhang() {
+        const calculate = (
+            /** @type {import("../../spec/axis.js").AxisOrient} */ orient
+        ) => {
+            const axisView = this.axes[orient];
+            return axisView
+                ? Math.max(
+                      axisView.getPerpendicularSize() +
+                          (axisView.axisProps.offset ?? 0),
+                      0
+                  )
+                : 0;
+        };
+
+        // Axes and overhang should be mutually exclusive, so we can just add them together
+        return new Padding(
+            calculate("top"),
+            calculate("right"),
+            calculate("bottom"),
+            calculate("left")
+        ).add(this.view.getOverhang());
+    }
+
+    getOverhangAndPadding() {
+        return this.getOverhang().add(this.view.getPadding());
+    }
+}
+
+/**
+ * @param {import("../../spec/view.js").ViewBackground} viewBackground
+ * @returns {import("../../spec/view.js").UnitSpec}
+ */
+export function createBackground(viewBackground) {
+    if (
+        !viewBackground ||
+        !viewBackground.fill ||
+        viewBackground.fillOpacity === 0
+    ) {
+        return;
+    }
+
+    return {
+        configurableVisibility: false,
+        data: { values: [{}] },
+        mark: {
+            color: viewBackground.fill,
+            opacity: viewBackground.fillOpacity ?? 1.0,
+            type: "rect",
+            clip: false, // Shouldn't be needed
+            tooltip: null,
+            minHeight: 1,
+            minOpacity: 0,
+        },
+    };
+}
+
+/**
+ * @param {import("../../spec/view.js").ViewBackground} viewBackground
+ * @returns {import("../../spec/view.js").UnitSpec}
+ */
+export function createBackgroundStroke(viewBackground) {
+    if (
+        !viewBackground ||
+        !viewBackground.stroke ||
+        viewBackground.strokeWidth === 0 ||
+        viewBackground.strokeOpacity === 0
+    ) {
+        return;
+    }
+
+    // Using rules to draw a non-filled rectangle.
+    // We are not using a rect mark because it is not optimized for outlines.
+    // TODO: Implement "hollow" mesh for non-filled rectangles
+    return {
+        configurableVisibility: false,
+        resolve: {
+            scale: { x: "excluded", y: "excluded" },
+            axis: { x: "excluded", y: "excluded" },
+        },
+        data: {
+            values: [
+                { x: 0, y: 0, x2: 1, y2: 0 },
+                { x: 1, y: 0, x2: 1, y2: 1 },
+                { x: 1, y: 1, x2: 0, y2: 1 },
+                { x: 0, y: 1, x2: 0, y2: 0 },
+            ],
+        },
+        mark: {
+            size: viewBackground.strokeWidth ?? 1.0,
+            color: viewBackground.stroke ?? "lightgray",
+            strokeCap: "square",
+            opacity: viewBackground.strokeOpacity ?? 1.0,
+            type: "rule",
+            clip: false,
+            tooltip: null,
+        },
+        encoding: {
+            x: { field: "x", type: "quantitative", scale: null },
+            y: { field: "y", type: "quantitative", scale: null },
+            x2: { field: "x2" },
+            y2: { field: "y2" },
+        },
+    };
+}

--- a/packages/core/src/view/gridView/gridView.js
+++ b/packages/core/src/view/gridView/gridView.js
@@ -699,6 +699,12 @@ export default class GridView extends ContainerView {
         if (pointedView) {
             pointedView.propagateInteractionEvent(event);
 
+            if (event.stopped) {
+                return;
+            }
+
+            // Hmm, maybe this should be registered when needed and not include
+            // as a hardcoded interaction?
             if (
                 pointedView instanceof UnitView ||
                 pointedView instanceof LayerView

--- a/packages/core/src/view/gridView/gridView.js
+++ b/packages/core/src/view/gridView/gridView.js
@@ -480,6 +480,7 @@ export default class GridView extends ContainerView {
                 background,
                 backgroundStroke,
                 title,
+                selectionRect,
             } = gridChild;
 
             const [col, row] = grid.getCellCoords(i);
@@ -657,6 +658,8 @@ export default class GridView extends ContainerView {
             if (!clipped) {
                 view.render(context, viewCoords, options);
             }
+
+            selectionRect?.render(context, viewCoords, options);
 
             for (const scrollbar of Object.values(gridChild.scrollbars)) {
                 scrollbar.updateScrollbar(viewportCoords, viewCoords);

--- a/packages/core/src/view/gridView/scrollbar.js
+++ b/packages/core/src/view/gridView/scrollbar.js
@@ -1,0 +1,186 @@
+import clamp from "../../utils/clamp.js";
+import { makeLerpSmoother } from "../../utils/animator.js";
+import Rectangle from "../layout/rectangle.js";
+import UnitView from "../unitView.js";
+
+/**
+ * @typedef {"horizontal" | "vertical"} ScrollDirection
+ */
+export default class Scrollbar extends UnitView {
+    /** @type {ScrollDirection} */
+    #scrollDirection;
+
+    #scrollbarCoords = Rectangle.ZERO;
+
+    #maxScrollOffset = 0;
+
+    #maxViewportOffset = 0;
+
+    // This is the actual state of the scrollbar. It's better to keep track of
+    // the viewport offset rather than the scrollbar offset because the former
+    // is more stable when the viewport size changes.
+    viewportOffset = 0;
+
+    /**
+     * @param {import("./gridChild.js").default} gridChild
+     * @param {ScrollDirection} scrollDirection
+     */
+    constructor(gridChild, scrollDirection) {
+        // TODO: Configurable
+        const config = {
+            scrollbarSize: 8,
+            scrollbarPadding: 2,
+            // TODO: inside/outside view
+        };
+
+        super(
+            {
+                data: { values: [{}] },
+                mark: {
+                    type: "rect",
+                    fill: "#b0b0b0",
+                    fillOpacity: 0.6,
+                    stroke: "white",
+                    strokeWidth: 1,
+                    strokeOpacity: 1,
+                    cornerRadius: 5,
+                    clip: false,
+                },
+                configurableVisibility: false,
+            },
+            gridChild.layoutParent.context,
+            gridChild.layoutParent,
+            gridChild.view,
+            "scrollbar-" + scrollDirection, // TODO: Serial
+            {
+                blockEncodingInheritance: true,
+            }
+        );
+
+        this.config = config;
+        this.#scrollDirection = scrollDirection;
+
+        // Make it smooth!
+        this.interpolateViewportOffset = makeLerpSmoother(
+            this.context.animator,
+            (value) => {
+                this.viewportOffset = value.x;
+            },
+            50,
+            0.4,
+            { x: this.viewportOffset }
+        );
+
+        this.addInteractionEventListener("mousedown", (coords, event) => {
+            event.stopPropagation();
+
+            if (this.#maxScrollOffset <= 0) {
+                return;
+            }
+
+            const getMouseOffset = (/** @type {MouseEvent} */ mouseEvent) =>
+                scrollDirection == "vertical"
+                    ? mouseEvent.clientY
+                    : mouseEvent.clientX;
+
+            const mouseEvent = /** @type {MouseEvent} */ (event.uiEvent);
+            mouseEvent.preventDefault();
+
+            const initialScrollOffset = this.scrollOffset;
+            const initialOffset = getMouseOffset(mouseEvent);
+
+            const onMousemove = /** @param {MouseEvent} moveEvent */ (
+                moveEvent
+            ) => {
+                const scrollOffset = clamp(
+                    getMouseOffset(moveEvent) -
+                        initialOffset +
+                        initialScrollOffset,
+                    0,
+                    this.#maxScrollOffset
+                );
+
+                this.interpolateViewportOffset({
+                    x:
+                        (scrollOffset / this.#maxScrollOffset) *
+                        this.#maxViewportOffset,
+                });
+            };
+
+            const onMouseup = () => {
+                document.removeEventListener("mousemove", onMousemove);
+                document.removeEventListener("mouseup", onMouseup);
+            };
+
+            document.addEventListener("mouseup", onMouseup, false);
+            document.addEventListener("mousemove", onMousemove, false);
+        });
+    }
+
+    get scrollOffset() {
+        return (
+            (this.viewportOffset / this.#maxViewportOffset) *
+            this.#maxScrollOffset
+        );
+    }
+
+    /**
+     * @param {import("../renderingContext/viewRenderingContext.js").default} context
+     * @param {import("../layout/rectangle.js").default} coords
+     * @param {import("../../types/rendering.js").RenderingOptions} [options]
+     */
+    render(context, coords, options) {
+        super.render(context, this.#scrollbarCoords, options);
+    }
+
+    /**
+     *
+     * @param {Rectangle} viewportCoords
+     * @param {Rectangle} coords
+     */
+    updateScrollbar(viewportCoords, coords) {
+        const sPad = this.config.scrollbarPadding;
+        const sSize = this.config.scrollbarSize;
+
+        const dimension =
+            this.#scrollDirection == "horizontal" ? "width" : "height";
+
+        const visibleFraction = Math.min(
+            1,
+            viewportCoords[dimension] / coords[dimension]
+        );
+        const maxScrollLength = viewportCoords[dimension] - 2 * sPad;
+        const scrollLength = visibleFraction * maxScrollLength;
+
+        this.#maxScrollOffset = maxScrollLength - scrollLength;
+        this.#maxViewportOffset = coords[dimension] - viewportCoords[dimension];
+        this.viewportOffset = clamp(
+            this.viewportOffset,
+            0,
+            this.#maxViewportOffset
+        );
+
+        this.#scrollbarCoords =
+            this.#scrollDirection == "vertical"
+                ? new Rectangle(
+                      () =>
+                          viewportCoords.x +
+                          viewportCoords.width -
+                          sSize -
+                          sPad,
+                      () => viewportCoords.y + sPad + this.scrollOffset,
+                      () => sSize,
+                      () => scrollLength
+                  )
+                : new Rectangle(
+                      () => viewportCoords.x + sPad + this.scrollOffset,
+                      () =>
+                          viewportCoords.y +
+                          viewportCoords.height -
+                          sSize -
+                          sPad,
+                      () => scrollLength,
+                      () => sSize
+                  );
+    }
+}

--- a/packages/core/src/view/gridView/selectionRect.js
+++ b/packages/core/src/view/gridView/selectionRect.js
@@ -33,7 +33,7 @@ export default class SelectionRect extends UnitView {
                         y: "forced",
                     },
                 },
-                data: { values: [] },
+                data: { values: selectionToData(selectionExpr()) },
                 mark: {
                     type: "rect",
                     clip: true,
@@ -77,35 +77,34 @@ export default class SelectionRect extends UnitView {
                 /** @type {import("../../types/selectionTypes.js").IntervalSelection} */ (
                     selectionExpr()
                 );
-            const x = selection.intervals.x;
-            const y = selection.intervals.y;
 
-            this.update(x, y);
+            const datasource =
+                /** @type {import("../../data/sources/inlineSource.js").default} */ (
+                    this.context.dataFlow.findDataSourceByKey(this)
+                );
+
+            datasource.updateDynamicData(selectionToData(selection));
         });
     }
+}
 
-    /**
-     *
-     * @param {number[]} x
-     * @param {number[]} y
-     */
-    update(x, y) {
-        const datasource =
-            /** @type {import("../../data/sources/inlineSource.js").default} */ (
-                this.context.dataFlow.findDataSourceByKey(this)
-            );
+/**
+ *  @param {import("../../types/selectionTypes.js").IntervalSelection} selection
+ */
+function selectionToData(selection) {
+    const x = selection.intervals.x;
+    const y = selection.intervals.y;
 
-        if (!x && !y) {
-            datasource.updateDynamicData([]);
-        } else {
-            datasource.updateDynamicData([
-                {
-                    x: x?.[0],
-                    x2: x?.[1],
-                    y: y?.[0],
-                    y2: y?.[1],
-                },
-            ]);
-        }
+    if (!x && !y) {
+        return [];
+    } else {
+        return [
+            {
+                x: x?.[0],
+                x2: x?.[1],
+                y: y?.[0],
+                y2: y?.[1],
+            },
+        ];
     }
 }

--- a/packages/core/src/view/gridView/selectionRect.js
+++ b/packages/core/src/view/gridView/selectionRect.js
@@ -1,0 +1,79 @@
+import UnitView from "../unitView.js";
+
+export default class SelectionRect extends UnitView {
+    /**
+     * @param {import("./gridChild.js").default} gridChild
+     * @param {import("../../spec/channel.js").PrimaryPositionalChannel[]} channels
+     */
+    constructor(gridChild, channels) {
+        super(
+            {
+                configurableVisibility: false,
+                resolve: {
+                    scale: {
+                        x: "forced",
+                        y: "forced",
+                    },
+                },
+                data: { values: [] },
+                mark: {
+                    type: "rect",
+                    fill: "#80f080",
+                    fillOpacity: 0.05,
+                    stroke: "black",
+                    strokeWidth: 1,
+                    clip: true,
+                    tooltip: null,
+                },
+                encoding: {
+                    // TODO: Consider using Exprs instead
+                    ...(channels.includes("x")
+                        ? {
+                              x: { field: "x", type: null },
+                              x2: { field: "x2" },
+                          }
+                        : {}),
+                    ...(channels.includes("y")
+                        ? {
+                              y: { field: "y", type: "quantitative" },
+                              y2: { field: "y2" },
+                          }
+                        : {}),
+                },
+            },
+            gridChild.layoutParent.context,
+            gridChild.layoutParent,
+            gridChild.view,
+            "selectionRect", // TODO: Serial
+            {
+                blockEncodingInheritance: true,
+            }
+        );
+    }
+
+    get #datasource() {
+        return /** @type {import("../../data/sources/inlineSource.js").default} */ (
+            this.context.dataFlow.findDataSourceByKey(this)
+        );
+    }
+
+    /**
+     *
+     * @param {number[]} x
+     * @param {number[]} y
+     */
+    update(x, y) {
+        const datum = {
+            x: x?.[0],
+            x2: x?.[1],
+            y: y?.[0],
+            y2: y?.[1],
+        };
+
+        this.#datasource.updateDynamicData([datum]);
+    }
+
+    clear() {
+        this.#datasource.updateDynamicData([]);
+    }
+}

--- a/packages/core/src/view/gridView/selectionRect.js
+++ b/packages/core/src/view/gridView/selectionRect.js
@@ -40,7 +40,7 @@ export default class SelectionRect extends UnitView {
                     stroke: "black",
                     strokeWidth: 1,
                     strokeOpacity: 0.3,
-                    clip: false,
+                    clip: true,
                     tooltip: null,
                 },
                 encoding: {

--- a/packages/core/src/view/gridView/selectionRect.js
+++ b/packages/core/src/view/gridView/selectionRect.js
@@ -4,8 +4,9 @@ export default class SelectionRect extends UnitView {
     /**
      * @param {import("./gridChild.js").default} gridChild
      * @param {import("../paramMediator.js").ExprRefFunction} selectionExpr
+     * @param {import("../../spec/parameter.js").BrushConfig} [brushConfig]
      */
-    constructor(gridChild, selectionExpr) {
+    constructor(gridChild, selectionExpr, brushConfig = {}) {
         const initialSelection =
             /** @type {import("../../types/selectionTypes.js").IntervalSelection} */ (
                 selectionExpr()
@@ -35,13 +36,16 @@ export default class SelectionRect extends UnitView {
                 data: { values: [] },
                 mark: {
                     type: "rect",
-                    fill: "#808080",
-                    fillOpacity: 0.05,
-                    stroke: "black",
-                    strokeWidth: 1,
-                    strokeOpacity: 0.3,
                     clip: true,
                     tooltip: null,
+                    ...{
+                        fill: "#808080",
+                        fillOpacity: 0.05,
+                        stroke: "black",
+                        strokeWidth: 1,
+                        strokeOpacity: 0.2,
+                        ...brushConfig,
+                    },
                 },
                 encoding: {
                     // TODO: Consider using Exprs instead. Handling scoping is tricky, however.

--- a/packages/core/src/view/gridView/selectionRect.js
+++ b/packages/core/src/view/gridView/selectionRect.js
@@ -47,13 +47,13 @@ export default class SelectionRect extends UnitView {
                     // TODO: Consider using Exprs instead. Handling scoping is tricky, however.
                     ...(channels.includes("x")
                         ? {
-                              x: { field: "x", type: null },
+                              x: { field: "x", type: null, title: null },
                               x2: { field: "x2" },
                           }
                         : {}),
                     ...(channels.includes("y")
                         ? {
-                              y: { field: "y", type: null },
+                              y: { field: "y", type: null, title: null },
                               y2: { field: "y2" },
                           }
                         : {}),

--- a/packages/core/src/view/gridView/selectionRect.js
+++ b/packages/core/src/view/gridView/selectionRect.js
@@ -12,6 +12,17 @@ export default class SelectionRect extends UnitView {
             );
         const channels = Object.keys(initialSelection.intervals);
 
+        if (
+            /** @type {import("../../spec/channel.js").ChannelWithScale[]} */ ([
+                "x",
+                "y",
+            ]).every((c) => !channels.includes(c))
+        ) {
+            throw new Error(
+                "SelectionRect requires at least one of the channels 'x' or 'y' to be present in the selection."
+            );
+        }
+
         super(
             {
                 configurableVisibility: false,
@@ -24,11 +35,12 @@ export default class SelectionRect extends UnitView {
                 data: { values: [] },
                 mark: {
                     type: "rect",
-                    fill: "#80f080",
+                    fill: "#808080",
                     fillOpacity: 0.05,
                     stroke: "black",
                     strokeWidth: 1,
-                    clip: true,
+                    strokeOpacity: 0.3,
+                    clip: false,
                     tooltip: null,
                 },
                 encoding: {

--- a/packages/core/src/view/layout/rectangle.js
+++ b/packages/core/src/view/layout/rectangle.js
@@ -294,11 +294,31 @@ export default class Rectangle {
      *
      * @param {number} x
      * @param {number} y
+     * @param {boolean} [flipY]
      */
-    normalizePoint(x, y) {
-        return {
+    normalizePoint(x, y, flipY = false) {
+        const point = {
             x: (x - this.x) / this.width,
             y: (y - this.y) / this.height,
+        };
+        if (flipY) {
+            point.y = 1 - point.y;
+        }
+        return point;
+    }
+
+    /**
+     * @param {number} x
+     * @param {number} y
+     * @param {boolean} flipY
+     */
+    denormalizePoint(x, y, flipY = false) {
+        if (flipY) {
+            y = 1 - y;
+        }
+        return {
+            x: this.x + x * this.width,
+            y: this.y + y * this.height,
         };
     }
 

--- a/packages/core/src/view/layout/rectangle.test.js
+++ b/packages/core/src/view/layout/rectangle.test.js
@@ -177,4 +177,16 @@ test("normalizePoint", () => {
     expect(r.normalizePoint(1, 2)).toEqual({ x: 0, y: 0 });
     expect(r.normalizePoint(7, 2)).toEqual({ x: 1, y: 0 });
     expect(r.normalizePoint(4, 4)).toEqual({ x: 0.5, y: 0.5 });
+
+    expect(r.normalizePoint(1, 6, true)).toEqual({ x: 0, y: 0 });
+});
+
+test("denormalizePoint", () => {
+    const r = Rectangle.create(1, 2, 6, 4);
+
+    expect(r.denormalizePoint(0, 0)).toEqual({ x: 1, y: 2 });
+    expect(r.denormalizePoint(1, 0)).toEqual({ x: 7, y: 2 });
+    expect(r.denormalizePoint(0.5, 0.5)).toEqual({ x: 4, y: 4 });
+
+    expect(r.denormalizePoint(0, 0, true)).toEqual({ x: 1, y: 6 });
 });

--- a/packages/core/src/view/paramMediator.js
+++ b/packages/core/src/view/paramMediator.js
@@ -2,8 +2,10 @@ import { isString } from "vega-util";
 import createFunction from "../utils/expression.js";
 import {
     asSelectionConfig,
+    createIntervalSelection,
     createMultiPointSelection,
     createSinglePointSelection,
+    isIntervalSelectionConfig,
     isPointSelectionConfig,
 } from "../selection/selection.js";
 
@@ -113,6 +115,13 @@ export default class ParamMediator {
                         ? createMultiPointSelection()
                         : createSinglePointSelection(null)
                 );
+            } else if (isIntervalSelectionConfig(select)) {
+                if (!select.encodings) {
+                    throw new Error(
+                        `Interval selection "${name}" must have encodings defined!`
+                    );
+                }
+                setter(createIntervalSelection(select.encodings));
             }
         }
 

--- a/packages/core/src/view/scaleResolution.js
+++ b/packages/core/src/view/scaleResolution.js
@@ -170,11 +170,17 @@ export default class ScaleResolution {
     addMember(newMember) {
         const { channel, channelDef } = newMember;
 
+        // A convenience hack for cases where the new member should adapt
+        // the scale type to the existing one. For example: SelectionRect
+        // TODO: Add test
+        const adapt = channelDef.type == null && this.type;
+
         if (
             // @ts-expect-error "sample" is not really a channel with scale
             channel != "sample" &&
             !channelDef.type &&
-            !isSecondaryChannel(channel)
+            !isSecondaryChannel(channel) &&
+            !adapt
         ) {
             throw new Error(
                 `The "type" property must be defined in channel definition: "${channel}": ${JSON.stringify(
@@ -198,15 +204,17 @@ export default class ScaleResolution {
             this.name = name;
         }
 
-        if (!this.type) {
-            this.type = type;
-        } else if (type !== this.type && !isSecondaryChannel(channel)) {
-            // TODO: Include a reference to the layer
-            throw new Error(
-                `Can not use shared scale for different data types: ${this.type} vs. ${type}. Use "resolve: independent" for channel ${this.channel}`
-            );
-            // Actually, point scale could be changed into band scale
-            // TODO: Use the same merging logic as in: https://github.com/vega/vega-lite/blob/master/src/scale.ts
+        if (!adapt) {
+            if (!this.type) {
+                this.type = type;
+            } else if (type !== this.type && !isSecondaryChannel(channel)) {
+                // TODO: Include a reference to the layer
+                throw new Error(
+                    `Can not use shared scale for different data types: ${this.type} vs. ${type}. Use "resolve: independent" for channel ${this.channel}`
+                );
+                // Actually, point scale could be changed into band scale
+                // TODO: Use the same merging logic as in: https://github.com/vega/vega-lite/blob/master/src/scale.ts
+            }
         }
 
         this.members.push(newMember);

--- a/packages/core/src/view/scaleResolution.js
+++ b/packages/core/src/view/scaleResolution.js
@@ -133,9 +133,11 @@ export default class ScaleResolution {
     }
 
     get zoomExtent() {
-        return this.#scale && isContinuous(this.#scale.type)
-            ? this.#getZoomExtent()
-            : [-Infinity, Infinity];
+        return (
+            (this.#scale &&
+                isContinuous(this.#scale.type) &&
+                this.#getZoomExtent()) ?? [-Infinity, Infinity]
+        );
     }
 
     /**
@@ -782,6 +784,9 @@ export default class ScaleResolution {
             : 0;
     }
 
+    /**
+     * @returns {number[]}
+     */
     #getZoomExtent() {
         const props = this.scale.props;
         const zoom = props.zoom;
@@ -796,11 +801,11 @@ export default class ScaleResolution {
             if (props.type == "locus") {
                 return this.getGenome().getExtent();
             }
-
-            // TODO: Perhaps this should be "domain" for index scale and nothing for quantitative.
-            // Would behave similarly to Vega-Lite, which doesn't have constraints.
-            return this.#initialDomain;
         }
+
+        // TODO: Perhaps this should be "domain" for index scale and nothing for quantitative.
+        // Would behave similarly to Vega-Lite, which doesn't have constraints.
+        return this.#initialDomain;
     }
 
     /**

--- a/packages/core/src/view/view.js
+++ b/packages/core/src/view/view.js
@@ -453,6 +453,24 @@ export default class View {
     }
 
     /**
+     * @param {string} type
+     * @param {InteractionEventListener} listener
+     * @param {boolean} [useCapture]
+     */
+    removeInteractionEventListener(type, listener, useCapture) {
+        const listenersByType = useCapture
+            ? this.#capturingInteractionEventListeners
+            : this.#nonCapturingInteractionEventListeners;
+        let listeners = listenersByType?.[type];
+        if (listeners) {
+            const index = listeners.indexOf(listener);
+            if (index >= 0) {
+                listeners.splice(index, 1);
+            }
+        }
+    }
+
+    /**
      * Visits child views in depth-first order. Visitor's return value
      * controls the traversal.
      *

--- a/packages/core/src/view/view.js
+++ b/packages/core/src/view/view.js
@@ -150,6 +150,7 @@ export default class View {
 
         if (spec.params) {
             for (const param of spec.params) {
+                // TODO: If interval selection, validate `encodings` or provides defaults
                 this.paramMediator.registerParam(param);
             }
         }

--- a/packages/core/src/view/viewFactory.js
+++ b/packages/core/src/view/viewFactory.js
@@ -8,6 +8,8 @@ import { isArray, isObject, isString } from "vega-util";
 import { loadExternalViewSpec } from "./viewUtils.js";
 import ContainerView from "./containerView.js";
 import ViewError from "./viewError.js";
+import { isSelectionParameter } from "./paramMediator.js";
+import { asSelectionConfig } from "../selection/selection.js";
 
 export const VIEW_ROOT_NAME = "viewRoot";
 
@@ -179,11 +181,21 @@ export class ViewFactory {
             viewSpec = spec;
         }
 
+        // A view with an interval selection always needs a parent.
+        const hasIntervalSelection = (/** @type {ViewSpec} */ spec) =>
+            spec?.params?.some(
+                (param) =>
+                    isSelectionParameter(param) &&
+                    asSelectionConfig(param.select).type == "interval"
+            );
+
         // Wrap a unit spec at root into a grid view to get axes, etc.
         if (
             !dataParent &&
             this.options.wrapRoot &&
-            (isUnitSpec(viewSpec) || isLayerSpec(viewSpec)) &&
+            (isUnitSpec(viewSpec) ||
+                isLayerSpec(viewSpec) ||
+                hasIntervalSelection(viewSpec)) &&
             defaultName === VIEW_ROOT_NAME
         ) {
             viewSpec = {


### PR DESCRIPTION
This PR introduces interval selections. They are based on *selection parameters* like in Vega-Lite. However, their behavior is slightly different, as selections in GenomeSpy must support concurrent selection of multiple layers or concatenated views (like tracks). The selections are not projected on the dataset fields—instead, they solely represent an interval on the data domain.

This is currently an "MVP", and several features are incomplete or missing:
* Filtering data based on the selection works, but is undocumented as I'm still unsure about how it should be expressed in the grammar
* Brushing and linking is unlikely to work yet, as parameter-driven scale domains need some further work. In addition, two-way binding is necessary for any serious use case.

Some examples below:

https://github.com/user-attachments/assets/885541ab-7e23-4a2e-97f0-b78004fe443f

https://github.com/user-attachments/assets/54812037-1426-448e-9fbc-03484eb64b63

https://github.com/user-attachments/assets/20b7c82e-d2f1-4cf0-8a65-8b11fb4a7577


