### PR TITLE
feat(core): support segment features in `filterScoredLabels` transform

### DIFF
--- a/docs/grammar/transform/filter-scored-labels.md
+++ b/docs/grammar/transform/filter-scored-labels.md
@@ -1,7 +1,7 @@
 # Filter Scored Lables
 
 The `"filterScoredLables"` transform fits prioritized labels into the available
-space, and dynamically reflows the data when the scale domain is adjusted (i.e.,
+space, and dynamically reflows the data when the scale domain is changed (i.e.,
 zoomed).
 
 For an usage example, check the [Annotation

--- a/docs/grammar/transform/filter-scored-labels.md
+++ b/docs/grammar/transform/filter-scored-labels.md
@@ -1,13 +1,61 @@
 # Filter Scored Lables
 
-The `"filterScoredLables"` transform fits prioritized labels into the available
-space, and dynamically reflows the data when the scale domain is changed (i.e.,
-zoomed).
+The `"filterScoredLabels"` transform fits prioritized elements such as labels
+into the available space, dynamically adjusting as the scale domain changes
+(such as during zooming). It is particularly suited for gene annotation tracks,
+where genes have an associated importance or score, such as their popularity or
+relevance, and only the most significant labels should be displayed when space
+is limited. This transform is typically used in conjunction with the
+[`measureText`](measure-text.md) transform to calculate the width of each label.
 
 For an usage example, check the [Annotation
 Tracks](https://observablehq.com/@tuner/annotation-tracks?collection=@tuner/genomespy)
-notebook.
+notebook or the [example](#example) below.
 
 ## Parameters
 
 SCHEMA FilterScoredLabelsParams
+
+## Example
+
+Zoom in to see how the labels are filtered based on their score and the available
+space.
+
+<div><genome-spy-doc-embed height="100">
+
+```json
+{
+  "data": { "sequence": { "start": 0, "stop": 100000, "step": 1, "as": "_z" } },
+
+  "transform": [
+    { "type": "formula", "expr": "floor(random() * 10000000)", "as": "x" },
+    { "type": "formula", "expr": "floor(random() * 100000)", "as": "score" },
+    { "type": "formula", "expr": "'' + datum.score", "as": "label" },
+    {
+      "type": "measureText",
+      "fontSize": 16,
+      "field": "label",
+      "as": "textWidth"
+    },
+    {
+      "type": "filterScoredLabels",
+      "score": "score",
+      "width": "textWidth",
+      "pos": "x",
+      "padding": 5
+    }
+  ],
+
+  "mark": {
+    "type": "text",
+    "size": 16
+  },
+
+  "encoding": {
+    "x": { "field": "x", "type": "index", "scale": { "domain": [0, 1000000] } },
+    "text": { "field": "label" }
+  }
+}
+```
+
+</genome-spy-doc-embed></div>

--- a/docs/grammar/transform/measure-text.md
+++ b/docs/grammar/transform/measure-text.md
@@ -1,7 +1,8 @@
 # Measure Text
 
 The `"measureText"` transforms measures the length of a string in pixels. The
-measurement can be used in downstream layout computations.
+measurement can be used in downstream layout computations with the
+[filterScoredLabels](./filter-scored-labels.md) transform.
 
 For an usage example, check the [Annotation
 Tracks](https://observablehq.com/@tuner/annotation-tracks?collection=@tuner/genomespy)

--- a/packages/core/src/data/transforms/filterScoredLabels.js
+++ b/packages/core/src/data/transforms/filterScoredLabels.js
@@ -107,33 +107,33 @@ export default class FilterScoredLabelsTransform extends Transform {
             const span = endPos - startPos;
             const width = this.widthAccessor(datum) + this.padding * 2;
 
-            let centroid = (startPos + endPos) / 2;
+            let midpoint = (startPos + endPos) / 2;
 
             // How much extra space we have for adjusting the position so that the
             // text stays inside the range.
             const extra = Math.max(0.0, (span - width) / 2.0);
             if (extra > 0.0) {
-                const leftOver = Math.max(0.0, width / 2 - centroid);
-                centroid += Math.min(leftOver, extra);
+                const leftOver = Math.max(0.0, width / 2 - midpoint);
+                midpoint += Math.min(leftOver, extra);
 
                 const rightOver = Math.max(
                     0.0,
-                    width / 2 + centroid - rangeSpan
+                    width / 2 + midpoint - rangeSpan
                 );
-                centroid -= Math.min(rightOver, extra);
+                midpoint -= Math.min(rightOver, extra);
             }
 
             if (
                 this.reservationMaps
                     .get(this.laneAccessor(datum))
-                    .reserve(centroid - width / 2, centroid + width / 2)
+                    .reserve(midpoint - width / 2, midpoint + width / 2)
             ) {
-                if (this.params.centroidAs) {
+                if (this.params.midpointAs) {
                     // Clone the datum to avoid side effects
                     const clonedDatum = Object.assign({}, datum);
                     // @ts-ignore
-                    clonedDatum[this.params.centroidAs] = scale.invert(
-                        centroid / rangeSpan
+                    clonedDatum[this.params.midpointAs] = scale.invert(
+                        midpoint / rangeSpan
                     );
                     this._propagate(clonedDatum);
                 } else {

--- a/packages/core/src/data/transforms/filterScoredLabels.js
+++ b/packages/core/src/data/transforms/filterScoredLabels.js
@@ -128,11 +128,11 @@ export default class FilterScoredLabelsTransform extends Transform {
                     .get(this.laneAccessor(datum))
                     .reserve(midpoint - width / 2, midpoint + width / 2)
             ) {
-                if (this.params.midpointAs) {
+                if (this.params.asMidpoint) {
                     // Clone the datum to avoid side effects
                     const clonedDatum = Object.assign({}, datum);
                     // @ts-ignore
-                    clonedDatum[this.params.midpointAs] = scale.invert(
+                    clonedDatum[this.params.asMidpoint] = scale.invert(
                         midpoint / rangeSpan
                     );
                     this._propagate(clonedDatum);

--- a/packages/core/src/data/transforms/filterScoredLabels.js
+++ b/packages/core/src/data/transforms/filterScoredLabels.js
@@ -29,8 +29,10 @@ export default class FilterScoredLabelsTransform extends Transform {
             throw new Error("Invalid channel: " + this.channel);
         }
 
-        this.posAccessor = field(this.params.pos);
-        this.posBisector = bisector(this.posAccessor);
+        this.startPosAccessor = field(this.params.pos);
+        this.endPosAccessor = field(this.params.pos2 ?? this.params.pos);
+        this.startPosBisector = bisector(this.startPosAccessor);
+        this.endPosBisector = bisector(this.endPosAccessor);
         this.scoreAccessor = field(this.params.score);
         this.widthAccessor = field(this.params.width);
         /** @type {function(any):any} */
@@ -59,8 +61,8 @@ export default class FilterScoredLabelsTransform extends Transform {
     }
 
     complete() {
-        const posAccessor = this.posAccessor;
-        this._data.sort((a, b) => posAccessor(a) - posAccessor(b));
+        const startPosAccessor = this.startPosAccessor;
+        this._data.sort((a, b) => startPosAccessor(a) - startPosAccessor(b));
 
         for (const lane of new Set(this._data.map(this.laneAccessor))) {
             this.reservationMaps.set(lane, new ReservationMap(200));
@@ -93,21 +95,50 @@ export default class FilterScoredLabelsTransform extends Transform {
             this._data,
             k,
             this.scoreAccessor,
-            this.posBisector.left(this._data, domain[0]),
-            this.posBisector.right(this._data, domain[1])
+            this.endPosBisector.left(this._data, domain[0]),
+            this.startPosBisector.right(this._data, domain[1])
         );
 
         // Try to fit the elements on the available lanes and propagate if there was room
         for (const datum of topElements) {
-            const pos = scale(this.posAccessor(datum)) * rangeSpan;
-            const halfWidth = this.widthAccessor(datum) / 2 + this.padding;
+            let startPos = scale(this.startPosAccessor(datum)) * rangeSpan;
+            let endPos = scale(this.endPosAccessor(datum)) * rangeSpan;
+
+            const span = endPos - startPos;
+            const width = this.widthAccessor(datum) + this.padding * 2;
+
+            let centroid = (startPos + endPos) / 2;
+
+            // How much extra space we have for adjusting the position so that the
+            // text stays inside the range.
+            const extra = Math.max(0.0, (span - width) / 2.0);
+            if (extra > 0.0) {
+                const leftOver = Math.max(0.0, width / 2 - centroid);
+                centroid += Math.min(leftOver, extra);
+
+                const rightOver = Math.max(
+                    0.0,
+                    width / 2 + centroid - rangeSpan
+                );
+                centroid -= Math.min(rightOver, extra);
+            }
 
             if (
                 this.reservationMaps
                     .get(this.laneAccessor(datum))
-                    .reserve(pos - halfWidth, pos + halfWidth)
+                    .reserve(centroid - width / 2, centroid + width / 2)
             ) {
-                this._propagate(datum);
+                if (this.params.centroidAs) {
+                    // Clone the datum to avoid side effects
+                    const clonedDatum = Object.assign({}, datum);
+                    // @ts-ignore
+                    clonedDatum[this.params.centroidAs] = scale.invert(
+                        centroid / rangeSpan
+                    );
+                    this._propagate(clonedDatum);
+                } else {
+                    this._propagate(datum);
+                }
             }
         }
 

--- a/packages/core/src/spec/transform.d.ts
+++ b/packages/core/src/spec/transform.d.ts
@@ -484,7 +484,7 @@ export interface FilterScoredLabelsParams extends TransformParamsBase {
     score: Field;
 
     /**
-     * The field representing element's width in pixels
+     * The field representing element's width in pixels.
      */
     width: Field;
 
@@ -497,7 +497,7 @@ export interface FilterScoredLabelsParams extends TransformParamsBase {
      * The field representing element's end position on the domain.
      * If not specified, the `pos` field is used.
      */
-    pos2: Field;
+    pos2?: Field;
 
     /**
      * Outputs the average of pos and pos2 as the midpoint of the element.
@@ -508,7 +508,7 @@ export interface FilterScoredLabelsParams extends TransformParamsBase {
 
     /**
      * An optional field representing element's lane, e.g., if transcripts
-     * are shown using a piled up layout.
+     * are shown using a piled up layout. Each line is processed separately.
      */
     lane?: Field;
 

--- a/packages/core/src/spec/transform.d.ts
+++ b/packages/core/src/spec/transform.d.ts
@@ -489,9 +489,22 @@ export interface FilterScoredLabelsParams extends TransformParamsBase {
     width: Field;
 
     /**
-     * The field representing element's position on the domain.
+     * The field representing element's start position on the domain.
      */
     pos: Field;
+
+    /**
+     * The field representing element's end position on the domain.
+     * If not specified, the `pos` field is used.
+     */
+    pos2: Field;
+
+    /**
+     * Outputs the average of pos and pos2 as the centroid of the element.
+     * This is useful for elements that have a width, such as transcripts.
+     * The centroid is clamped to the visible region of the element.
+     */
+    centroidAs?: string;
 
     /**
      * An optional field representing element's lane, e.g., if transcripts

--- a/packages/core/src/spec/transform.d.ts
+++ b/packages/core/src/spec/transform.d.ts
@@ -500,11 +500,11 @@ export interface FilterScoredLabelsParams extends TransformParamsBase {
     pos2: Field;
 
     /**
-     * Outputs the average of pos and pos2 as the centroid of the element.
+     * Outputs the average of pos and pos2 as the midpoint of the element.
      * This is useful for elements that have a width, such as transcripts.
-     * The centroid is clamped to the visible region of the element.
+     * The midpoint is clamped to the visible region of the element.
      */
-    centroidAs?: string;
+    midpointAs?: string;
 
     /**
      * An optional field representing element's lane, e.g., if transcripts

--- a/packages/core/src/spec/transform.d.ts
+++ b/packages/core/src/spec/transform.d.ts
@@ -504,7 +504,7 @@ export interface FilterScoredLabelsParams extends TransformParamsBase {
      * This is useful for elements that have a width, such as transcripts.
      * The midpoint is clamped to the visible region of the element.
      */
-    midpointAs?: string;
+    asMidpoint?: string;
 
     /**
      * An optional field representing element's lane, e.g., if transcripts

--- a/packages/core/src/utils/topK.js
+++ b/packages/core/src/utils/topK.js
@@ -1,64 +1,34 @@
 import FlatQueue from "flatqueue";
 
 /**
- * Finds the top k
- *
- * Based on ideas at https://lemire.me/blog/2017/06/21/top-speed-for-top-k-queries/
+ * Finds the top k elements in a slice of the data array, using a priority accessor.
  *
  * @param {T[]} data
  * @param {number} k
  * @param {(datum: T) => number} priorityAccessor
- * @template T
- */
-export function topK(data, k, priorityAccessor) {
-    /** @type {FlatQueue<number>} */
-    const queue = new FlatQueue();
-
-    let i;
-    for (i = 0; i < k && i < data.length; i++) {
-        queue.push(i, priorityAccessor(data[i]));
-    }
-
-    for (; i < data.length; i++) {
-        const p = priorityAccessor(data[i]);
-        if (p >= queue.peekValue()) {
-            queue.push(i, p);
-            queue.pop();
-        }
-    }
-
-    const result = [];
-
-    let index;
-    while ((index = queue.pop()) !== undefined) {
-        result.push(data[index]);
-    }
-
-    return result.reverse();
-}
-
-/**
- * Takes an array of priorities and returns the top k indices from the
- * specified slice
- *
- * @param {number[]} priorities An array of priorities
- * @param {number} k
  * @param {number} [start] Default: 0
- * @param {number} [end] Exclusive. Default: priorities.length
+ * @param {number} [end] Exclusive. Default: data.length
+ * @template T
+ * @returns {T[]}
  */
-export function topKSlice(priorities, k, start = 0, end = priorities.length) {
+export function topK(
+    data,
+    k,
+    priorityAccessor = (x) => +x,
+    start = 0,
+    end = data.length
+) {
     /** @type {FlatQueue<number>} */
     const queue = new FlatQueue();
-
     const sliceLength = end - start;
 
     let i;
     for (i = 0; i < k && i < sliceLength; i++) {
-        queue.push(i, priorities[start + i]);
+        queue.push(i, priorityAccessor(data[start + i]));
     }
 
     for (; i < sliceLength; i++) {
-        const p = priorities[start + i];
+        const p = priorityAccessor(data[start + i]);
         if (p >= queue.peekValue()) {
             queue.push(i, p);
             queue.pop();
@@ -66,10 +36,9 @@ export function topKSlice(priorities, k, start = 0, end = priorities.length) {
     }
 
     const result = [];
-
     let index;
     while ((index = queue.pop()) !== undefined) {
-        result.push(start + index);
+        result.push(data[start + index]);
     }
 
     return result.reverse();

--- a/packages/core/src/utils/topK.test.js
+++ b/packages/core/src/utils/topK.test.js
@@ -1,6 +1,5 @@
 import { expect, test } from "vitest";
-import { range } from "d3-array";
-import { topK, topKSlice } from "./topK.js";
+import { topK } from "./topK.js";
 
 test("topK returns top k numbers in priority order", () => {
     /** @param {number} x */
@@ -16,49 +15,40 @@ test("topK returns top k numbers in priority order", () => {
     expect(topK([1, 1, 1], 3, priorityAccessor)).toEqual([1, 1, 1]);
 });
 
-test("topK returns top k objects in priority order", () => {
-    /** @param {{priority: number}} d */
-    const priorityAccessor = (d) => d.priority;
+test("topK returns top k objects in priority order within a start-end range", () => {
+    const arr = [0, 9, 1, 8, 2, 7, 3, 6, 4, 5].map((x) => ({ priority: x }));
+    const priorityAccessor = (/** @type {{priority: number}} */ d) =>
+        d.priority;
 
-    expect(
-        topK(
-            [0, 9, 1, 8, 2, 7, 3, 6, 4, 5].map((x) => ({ priority: x })),
-            3,
-            priorityAccessor
-        )
-    ).toEqual([9, 8, 7].map((x) => ({ priority: x })));
-});
-
-test("topK returns top k objects in priority order with large datasets", () => {
-    /** @param {number} x */
-    const priorityAccessor = (x) => x;
-
-    const n = 10000;
-    const bigArray = range(n).map((x) => Math.floor(Math.random() * 100));
-    const sortedBigArray = bigArray.slice().sort((a, b) => b - a);
-
-    for (let k = 0; k < 13000; k += 1000) {
-        expect(topK(bigArray, k, priorityAccessor)).toEqual(
-            sortedBigArray.slice(0, k)
-        );
-    }
-});
-
-test("topKSlice returns top k indexes in priority order", () => {
-    expect(topKSlice([0, 1, 2], 3)).toEqual([2, 1, 0]);
-    expect(topKSlice([1, 2, 3], 3)).toEqual([2, 1, 0]);
-    expect(topKSlice([0, 1, 2], 1)).toEqual([2]);
-    expect(topKSlice([0, 1, 2], 6)).toEqual([2, 1, 0]);
-    expect(topKSlice([0, 1, 2, 3, 4, 5], 3)).toEqual([5, 4, 3]);
-    expect(topKSlice([0, 9, 1, 8, 2, 7, 3, 6, 4, 5], 3)).toEqual([1, 3, 5]);
-    expect(new Set(topKSlice([1, 1, 1, 2, 2, 2], 3))).toEqual(
-        new Set([3, 4, 5])
-    );
-});
-
-test("topKSlice returns top k indexes from a slice in priority order", () => {
-    expect(topKSlice([0, 1, 2, 3, 4, 5], 2, 1, 5)).toEqual([4, 3]);
-    expect(topKSlice([0, 9, 1, 8, 2, 7, 3, 6, 4, 5], 3, 1, 5)).toEqual([
-        1, 3, 4,
+    // Range: indices 2 to 8 (1,8,2,7,3,6)
+    expect(topK(arr, 2, priorityAccessor, 2, 8)).toEqual([
+        { priority: 8 },
+        { priority: 7 },
     ]);
+
+    // Range: indices 4 to 10 (2,7,3,6,4,5)
+    expect(topK(arr, 3, priorityAccessor, 4, 10)).toEqual([
+        { priority: 7 },
+        { priority: 6 },
+        { priority: 5 },
+    ]);
+
+    // Range: indices 0 to 3 (0,9,1)
+    expect(topK(arr, 2, priorityAccessor, 0, 3)).toEqual([
+        { priority: 9 },
+        { priority: 1 },
+    ]);
+});
+
+test("topK returns empty array if start >= end", () => {
+    const arr = [1, 2, 3, 4, 5];
+    expect(topK(arr, 3, (x) => x, 4, 4)).toEqual([]);
+    expect(topK(arr, 3, (x) => x, 5, 5)).toEqual([]);
+    expect(topK(arr, 3, (x) => x, 6, 6)).toEqual([]);
+});
+
+test("topK works with negative and zero priorities in a range", () => {
+    const arr = [-10, 0, 5, -2, 3, 0, -1];
+    expect(topK(arr, 2, (x) => x, 1, 6)).toEqual([5, 3]);
+    expect(topK(arr, 3, (x) => x, 0, 4)).toEqual([5, 0, -2]);
 });


### PR DESCRIPTION
Adds `pos2` and `midpointAs` properties. Midpoint is calculated as an average of pos and pos2 but clamped into the domain so that it remains visible if the range (pos, pos2) and the domain intersect.

A similar effect could be achieved using the `x2` or `y2` channels of the `"text"` mark, but it wouldn't help in adjusting the placement of strand triangles in the gene annotation track.

Result:

https://github.com/user-attachments/assets/f2618a2f-2129-4271-98b8-76dab3fc538c

Closes #216 