### PR TITLE
feat(app): save as PNG button

### DIFF
--- a/packages/app/src/components/toolbar.js
+++ b/packages/app/src/components/toolbar.js
@@ -5,6 +5,7 @@ import {
     faQuestionCircle,
     faExpandArrowsAlt,
     faBug,
+    faFileImage,
 } from "@fortawesome/free-solid-svg-icons";
 import { findGenomeScaleResolution } from "./searchField.js";
 import { asArray } from "@genome-spy/core/utils/arrayUtils.js";
@@ -17,6 +18,7 @@ import "./viewSettingsButton.js";
 import "./provenanceToolbar.js";
 import "./bookmarkButton.js";
 import { showDataflowInspectorDialog } from "../dataflowInspector.js";
+import showSaveImageDialog from "../saveImageDialog.js";
 
 export default class Toolbar extends LitElement {
     constructor() {
@@ -107,17 +109,9 @@ export default class Toolbar extends LitElement {
             <button
                 class="tool-btn"
                 title="Download PNG"
-                @click=${() => {
-                    const dataURL = this.app.genomeSpy.exportCanvas();
-                    const link = document.createElement("a");
-                    link.href = dataURL;
-                    link.download = "genomespy-visualization.png";
-                    document.body.appendChild(link);
-                    link.click();
-                    document.body.removeChild(link);
-                }}
+                @click=${() => showSaveImageDialog(this.app.genomeSpy)}
             >
-                PNG
+                ${icon(faFileImage).node[0]}
             </button>
 
             ${this.app.options.showInspectorButton

--- a/packages/app/src/components/toolbar.js
+++ b/packages/app/src/components/toolbar.js
@@ -104,6 +104,22 @@ export default class Toolbar extends LitElement {
                 >v${packageJson.version}</a
             >
 
+            <button
+                class="tool-btn"
+                title="Download PNG"
+                @click=${() => {
+                    const dataURL = this.app.genomeSpy.exportCanvas();
+                    const link = document.createElement("a");
+                    link.href = dataURL;
+                    link.download = "genomespy-visualization.png";
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+                }}
+            >
+                PNG
+            </button>
+
             ${this.app.options.showInspectorButton
                 ? html` <button
                       class="tool-btn"

--- a/packages/app/src/saveImageDialog.js
+++ b/packages/app/src/saveImageDialog.js
@@ -1,0 +1,231 @@
+import { html, LitElement, nothing } from "lit";
+import { createRef, ref } from "lit/directives/ref.js";
+import { messageBox } from "./utils/ui/modal.js";
+import { icon } from "@fortawesome/fontawesome-svg-core";
+import {
+    faDownload,
+    faInfoCircle,
+    faXmark,
+} from "@fortawesome/free-solid-svg-icons";
+
+/** @param {number} num */
+function roundToEven(num) {
+    return Math.round(num / 2) * 2;
+}
+
+/**
+ *
+ * @param {import("@genome-spy/core/genomeSpy.js").default} genomeSpy
+ */
+export default function showSaveImageDialog(genomeSpy) {
+    // TODO: Make canvas size available through the official API
+    let { width, height } = genomeSpy._glHelper.getLogicalCanvasSize();
+
+    // Ensure that 0.5 scale factors behave nicely
+    width = roundToEven(width);
+    height = roundToEven(height);
+
+    /** @type {import("lit/directives/ref.js").Ref<ImageSettingsForm>} */
+    const formRef = createRef();
+
+    const template = html`
+        <div class="gs-alert info">
+            ${icon(faInfoCircle).node[0]}
+            <span>
+                <span
+                    style="float: right; cursor: pointer;"
+                    @click=${(/** @type {UIEvent} */ event) => {
+                        /** @type {HTMLElement} */ (
+                            /** @type {HTMLElement} */ (event.target).closest(
+                                ".gs-alert"
+                            )
+                        ).style.display = "none";
+                    }}
+                    >${icon(faXmark).node[0]}</span
+                >
+                To create publication-quality images:
+                <ol>
+                    <li>
+                        Adjust the GenomeSpy window so the visualization and
+                        labels appear as you want them.
+                    </li>
+                    <li>
+                        Use the scale factor slider below to increase
+                        resolution.
+                    </li>
+                    <li>
+                        Note: Smaller image dimensions with a higher scale
+                        factor will produce relatively larger and clearer labels
+                        and elements.
+                    </li>
+                </ol>
+            </span>
+        </div>
+
+        <genome-spy-image-settings-form
+            ${ref(formRef)}
+            .logicalWidth=${width}
+            .logicalHeight=${height}
+        ></genome-spy-image-settings-form>
+    `;
+
+    messageBox(template, {
+        title: "Save as PNG",
+        okLabel: html`${icon(faDownload).node[0]} Save`,
+        cancelButton: true,
+    }).then((result) => {
+        if (!result) {
+            return;
+        }
+
+        const form = formRef.value;
+        const dataURL = genomeSpy.exportCanvas(
+            width,
+            height,
+            form.devicePixelRatio,
+            form.transparentBackground ? null : form.backgroundColor
+        );
+        const link = document.createElement("a");
+        link.href = dataURL;
+        link.download = "genomespy-visualization.png";
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+    });
+}
+
+/**
+ * Utility to cast event.target to HTMLInputElement
+ * @param {Event} event
+ * @returns {HTMLInputElement}
+ */
+function getInputElement(event) {
+    return /** @type {HTMLInputElement} */ (event.target);
+}
+
+class ImageSettingsForm extends LitElement {
+    static properties = {
+        logicalWidth: { type: Number },
+        logicalHeight: { type: Number },
+        devicePixelRatio: { type: Number },
+        imageWidth: { type: Number },
+        imageHeight: { type: Number },
+        transparentBackground: { type: Boolean },
+        backgroundColor: { type: String },
+    };
+
+    constructor() {
+        super();
+        this.devicePixelRatio = 2;
+        this.logicalWidth = 800; // Default logical width
+        this.logicalHeight = 600; // Default logical height
+        this.imageWidth = 0;
+        this.imageHeight = 0;
+        this.transparentBackground = false; // Default to opaque background
+        this.backgroundColor = "#ffffff"; // Default background color
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.#updateImageDimensions();
+    }
+
+    firstUpdated() {
+        /** @type {HTMLElement} */ (
+            this.renderRoot.querySelector("#pngDevicePixelRatio")
+        ).focus();
+    }
+
+    createRenderRoot() {
+        return this;
+    }
+
+    render() {
+        return html`
+            <div class="gs-form-group">
+                <label for="canvasDimensions">Visualization dimensions</label>
+                <input
+                    type="text"
+                    id="canvasDimensions"
+                    .value=${`${this.logicalWidth} x ${this.logicalHeight}`}
+                    disabled
+                />
+            </div>
+
+            <div class="gs-form-group">
+                <label for="pngDevicePixelRatio">Scale factor</label>
+                <div style="display: flex">
+                    <input
+                        type="range"
+                        id="pngDevicePixelRatio"
+                        min="0.5"
+                        max="4"
+                        step="0.5"
+                        .value=${"" + this.devicePixelRatio}
+                        @input=${this.#updateDPR}
+                    />
+                    <span style="width: 2em; margin-left: 0.5em"
+                        >${this.devicePixelRatio}</span
+                    >
+                </div>
+            </div>
+
+            <div class="gs-form-group">
+                <label for="pngDimensions">Image dimensions</label>
+                <input
+                    type="text"
+                    id="pngDimensions"
+                    .value=${`${this.imageWidth} x ${this.imageHeight}`}
+                    disabled
+                />
+            </div>
+
+            <div class="gs-form-group">
+                <div class="label">Background</div>
+                <div style="display: flex; align-items: center">
+                    <label class="checkbox" style="margin-bottom: 0"
+                        ><input
+                            type="checkbox"
+                            ?checked=${this.transparentBackground}
+                            @change=${(/** @type {Event} */ event) => {
+                                this.transparentBackground =
+                                    getInputElement(event).checked;
+                            }}
+                        />
+                        Transparent</label
+                    >
+                    ${!this.transparentBackground
+                        ? html`<input
+                              type="color"
+                              id="pngBackground"
+                              style="margin-left: 1em"
+                              .value=${this.backgroundColor}
+                              @change=${(/** @type {Event} */ event) => {
+                                  this.backgroundColor =
+                                      getInputElement(event).value;
+                              }}
+                          />`
+                        : nothing}
+                </div>
+            </div>
+        `;
+    }
+
+    /**
+     *
+     * @param {InputEvent} event
+     */
+    #updateDPR(event) {
+        this.devicePixelRatio = getInputElement(event).valueAsNumber;
+        this.#updateImageDimensions();
+    }
+
+    #updateImageDimensions() {
+        this.imageWidth = Math.round(this.logicalWidth * this.devicePixelRatio);
+        this.imageHeight = Math.round(
+            this.logicalHeight * this.devicePixelRatio
+        );
+    }
+}
+
+customElements.define("genome-spy-image-settings-form", ImageSettingsForm);

--- a/packages/app/src/styles/_generic.scss
+++ b/packages/app/src/styles/_generic.scss
@@ -481,9 +481,15 @@ $form-control-border: 1px solid $form-control-border-color;
         margin-top: 0.5em;
     }
 
-    label {
+    label,
+    div.label {
         display: inline-block;
         margin-bottom: 0.5em;
+    }
+
+    input[type="range"] {
+        display: block;
+        width: 100%;
     }
 
     input[type="text"],

--- a/packages/app/src/utils/ui/modal.js
+++ b/packages/app/src/utils/ui/modal.js
@@ -107,7 +107,7 @@ export function createModal(type = "default", container = document.body) {
 /**
  * @typedef {object} MessageBoxOptions
  * @prop {string} [title]
- * @prop {string} [okLabel]
+ * @prop {string | import("lit").TemplateResult } [okLabel]
  * @prop {boolean} [cancelButton]
  */
 
@@ -138,7 +138,7 @@ export function messageBox(content, options = {}) {
                         options.cancelButton
                             ? html`
                                   <button
-                                      class="btn"
+                                      class="btn btn-cancel"
                                       @click=${() => {
                                           modal.close();
                                           resolve(false);

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -992,7 +992,8 @@ export default class GenomeSpy {
             {
                 picking: true,
             },
-            this._glHelper
+            this._glHelper,
+            this._glHelper._pickingBufferInfo
         );
 
         root.render(

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -13,7 +13,7 @@ import {
 } from "./view/viewUtils.js";
 import UnitView from "./view/unitView.js";
 
-import WebGLHelper from "./gl/webGLHelper.js";
+import WebGLHelper, { readPickingPixel } from "./gl/webGLHelper.js";
 import Rectangle from "./view/layout/rectangle.js";
 import BufferedViewRenderingContext from "./view/renderingContext/bufferedViewRenderingContext.js";
 import CompositeViewRenderingContext from "./view/renderingContext/compositeViewRenderingContext.js";
@@ -877,13 +877,15 @@ export default class GenomeSpy {
      * @param {number} y
      */
     _handlePicking(x, y) {
-        const pixelValue = this._glHelper.readPickingPixel(x, y);
+        const dpr = this._glHelper.dpr;
+        const pp = readPickingPixel(
+            this._glHelper.gl,
+            this._glHelper._pickingBufferInfo,
+            x * dpr,
+            y * dpr
+        );
 
-        const uniqueId =
-            pixelValue[0] |
-            (pixelValue[1] << 8) |
-            (pixelValue[2] << 16) |
-            (pixelValue[3] << 24);
+        const uniqueId = pp[0] | (pp[1] << 8) | (pp[2] << 16) | (pp[3] << 24);
 
         if (uniqueId == 0) {
             this._currentHover = null;

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -975,7 +975,7 @@ export default class GenomeSpy {
      * @param {number} [logicalHeight] defaults to canvas height
      * @param {number} [devicePixelRatio] defaults to window.devicePixelRatio
      * @param {string} [clearColor] null for transparent
-     * @returns
+     * @returns A PNG data Url
      */
     exportCanvas(
         logicalWidth,

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -368,7 +368,6 @@ export default class GenomeSpy {
                 this.viewRoot
                     ? calculateCanvasSize(this.viewRoot)
                     : { width: undefined, height: undefined },
-            this.spec.background,
             { powerPreference: this.options.powerPreference ?? "default" }
         );
 
@@ -985,17 +984,18 @@ export default class GenomeSpy {
         }
 
         this._renderingContext = new BufferedViewRenderingContext(
+            { picking: false },
             {
-                picking: false,
-            },
-            this._glHelper
+                webGLHelper: this._glHelper,
+                clearColor: this.spec.background,
+            }
         );
         this._pickingContext = new BufferedViewRenderingContext(
+            { picking: true },
             {
-                picking: true,
-            },
-            this._glHelper,
-            this._glHelper._pickingBufferInfo
+                webGLHelper: this._glHelper,
+                framebufferInfo: this._glHelper._pickingBufferInfo,
+            }
         );
 
         root.render(

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -983,17 +983,23 @@ export default class GenomeSpy {
             return;
         }
 
+        const commonOptions = {
+            webGLHelper: this._glHelper,
+            canvasSize,
+            devicePixelRatio: window.devicePixelRatio ?? 1,
+        };
+
         this._renderingContext = new BufferedViewRenderingContext(
             { picking: false },
             {
-                webGLHelper: this._glHelper,
+                ...commonOptions,
                 clearColor: this.spec.background,
             }
         );
         this._pickingContext = new BufferedViewRenderingContext(
             { picking: true },
             {
-                webGLHelper: this._glHelper,
+                ...commonOptions,
                 framebufferInfo: this._glHelper._pickingBufferInfo,
             }
         );

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -149,6 +149,8 @@ export default class GenomeSpy {
 
         /** @type {Point} */
         this._mouseDownCoords = undefined;
+
+        this.dpr = window.devicePixelRatio;
     }
 
     get #canvasWrapper() {
@@ -308,12 +310,13 @@ export default class GenomeSpy {
     #setupDpr() {
         const dprSetter = this.viewRoot.paramMediator.allocateSetter(
             "devicePixelRatio",
-            window.devicePixelRatio
+            this.dpr
         );
 
         const resizeCallback = () => {
             this._glHelper.invalidateSize();
-            dprSetter(window.devicePixelRatio);
+            this.dpr = window.devicePixelRatio;
+            dprSetter(this.dpr);
             this.computeLayout();
             // Render immediately, without RAF
             this.renderAll();
@@ -443,10 +446,6 @@ export default class GenomeSpy {
             animator: this.animator,
             genomeStore: this.genomeStore,
             fontManager: new BmFontManager(this._glHelper),
-
-            get devicePixelRatio() {
-                return self._glHelper.dpr;
-            },
 
             requestLayoutReflow: () => {
                 // placeholder
@@ -877,7 +876,7 @@ export default class GenomeSpy {
      * @param {number} y
      */
     _handlePicking(x, y) {
-        const dpr = this._glHelper.dpr;
+        const dpr = this.dpr;
         const pp = readPickingPixel(
             this._glHelper.gl,
             this._glHelper._pickingBufferInfo,

--- a/packages/core/src/gl/webGLHelper.js
+++ b/packages/core/src/gl/webGLHelper.js
@@ -194,7 +194,8 @@ export default class WebGLHelper {
     }
 
     /**
-     * Returns the canvas size in logical pixels (without devicePixelRatio correction)
+     * Returns the size of the canvas canvas container size in logical pixels,
+     * without devicePixelRatio correction.
      */
     getLogicalCanvasSize() {
         if (this._logicalCanvasSize) {

--- a/packages/core/src/gl/webGLHelper.js
+++ b/packages/core/src/gl/webGLHelper.js
@@ -26,7 +26,6 @@ import {
     isColorChannel,
     isDiscreteChannel,
 } from "../encoder/encoder.js";
-import { color } from "d3-color";
 import { isMultiPointSelection } from "../selection/selection.js";
 
 export default class WebGLHelper {
@@ -97,8 +96,6 @@ export default class WebGLHelper {
 
         addExtensionsToContext(gl);
 
-        // TODO: view background: https://vega.github.io/vega-lite/docs/spec.html#view-background
-
         // Always use pre-multiplied alpha
         gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
 
@@ -124,13 +121,6 @@ export default class WebGLHelper {
         this.adjustGl();
 
         this._updateDpr();
-
-        /** @type {[number, number, number, number]} */
-        this._clearColor = [0, 0, 0, 0];
-        if (clearColor) {
-            const c = color(clearColor).rgb();
-            this._clearColor = [c.r / 255, c.g / 255, c.b / 255, c.opacity];
-        }
     }
 
     invalidateSize() {
@@ -248,10 +238,10 @@ export default class WebGLHelper {
         x *= this.dpr;
         y *= this.dpr;
 
-        const height = this.getPhysicalCanvasSize().height;
+        const { height, framebuffer } = this._pickingBufferInfo;
 
         const pixel = new Uint8Array(4);
-        gl.bindFramebuffer(gl.FRAMEBUFFER, this._pickingBufferInfo.framebuffer);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
         gl.readPixels(
             x,
             height - y - 1,
@@ -264,15 +254,6 @@ export default class WebGLHelper {
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
 
         return pixel;
-    }
-
-    clearAll() {
-        const gl = this.gl;
-        const { width, height } = this.getPhysicalCanvasSize();
-        gl.viewport(0, 0, width, height);
-        gl.disable(gl.SCISSOR_TEST);
-        gl.clearColor(...this._clearColor);
-        gl.clear(gl.COLOR_BUFFER_BIT);
     }
 
     /**

--- a/packages/core/src/gl/webGLHelper.js
+++ b/packages/core/src/gl/webGLHelper.js
@@ -484,3 +484,37 @@ export function readPickingPixel(gl, framebufferInfo, x, y) {
 
     return pixel;
 }
+
+/**
+ *
+ * @param {WebGL2RenderingContext} gl
+ * @param {import("twgl.js").FramebufferInfo} framebufferInfo
+ * @param {string} [type]
+ */
+export function framebufferToDataUrl(gl, framebufferInfo, type = "image/png") {
+    const { width, height } = framebufferInfo;
+    const pixels = new Uint8Array(width * height * 4);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, framebufferInfo.framebuffer);
+    gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+    const exportCanvas = document.createElement("canvas");
+    exportCanvas.width = width;
+    exportCanvas.height = height;
+    const ctx = exportCanvas.getContext("2d");
+    const imageData = ctx.createImageData(width, height);
+
+    // Flip Y axis (WebGL's origin is bottom-left, canvas is top-left)
+    for (let y = 0; y < height; y++) {
+        const srcStart = (height - 1 - y) * width * 4;
+        const destStart = y * width * 4;
+        imageData.data.set(
+            pixels.subarray(srcStart, srcStart + width * 4),
+            destStart
+        );
+    }
+
+    ctx.putImageData(imageData, 0, 0);
+
+    return exportCanvas.toDataURL(type);
+}

--- a/packages/core/src/gl/webGLHelper.js
+++ b/packages/core/src/gl/webGLHelper.js
@@ -228,35 +228,6 @@ export default class WebGLHelper {
     }
 
     /**
-     *
-     * @param {number} x
-     * @param {number} y
-     */
-    readPickingPixel(x, y) {
-        const gl = this.gl;
-
-        x *= this.dpr;
-        y *= this.dpr;
-
-        const { height, framebuffer } = this._pickingBufferInfo;
-
-        const pixel = new Uint8Array(4);
-        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
-        gl.readPixels(
-            x,
-            height - y - 1,
-            1,
-            1,
-            gl.RGBA,
-            gl.UNSIGNED_BYTE,
-            pixel
-        );
-        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-
-        return pixel;
-    }
-
-    /**
      * Creates textures for color schemes and discrete/discretizing ranges.
      * N.B. Discrete range textures need domain. Thus, this cannot be called
      * before the final domains are resolved.
@@ -505,4 +476,22 @@ export function createOrUpdateTexture(gl, options, src, texture) {
         });
     }
     return texture;
+}
+
+/**
+ *
+ * @param {WebGL2RenderingContext} gl
+ * @param {import("twgl.js").FramebufferInfo} framebufferInfo
+ * @param {number} x
+ * @param {number} y
+ */
+export function readPickingPixel(gl, framebufferInfo, x, y) {
+    const { height, framebuffer } = framebufferInfo;
+
+    const pixel = new Uint8Array(4);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+    gl.readPixels(x, height - y - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+    return pixel;
 }

--- a/packages/core/src/gl/webGLHelper.js
+++ b/packages/core/src/gl/webGLHelper.js
@@ -35,15 +35,9 @@ export default class WebGLHelper {
      * @param {() => {width: number, height: number}} [sizeSource]
      *      A function that returns the content size. If a dimension is undefined,
      *      the canvas fills the container, otherwise the canvas is adjusted to the content size.
-     * @param {string} [clearColor]
      * @param {WebGLContextAttributes} [webglContextAttributes]
      */
-    constructor(
-        container,
-        sizeSource,
-        clearColor,
-        webglContextAttributes = {}
-    ) {
+    constructor(container, sizeSource, webglContextAttributes = {}) {
         this._container = container;
         this._sizeSource =
             sizeSource ??

--- a/packages/core/src/gl/webGLHelper.js
+++ b/packages/core/src/gl/webGLHelper.js
@@ -113,18 +113,11 @@ export default class WebGLHelper {
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
 
         this.adjustGl();
-
-        this._updateDpr();
     }
 
     invalidateSize() {
         this._logicalCanvasSize = undefined;
-        this._updateDpr();
         this.adjustGl();
-    }
-
-    _updateDpr() {
-        this.dpr = window.devicePixelRatio;
     }
 
     /**
@@ -186,10 +179,11 @@ export default class WebGLHelper {
      * @param {{ width: number, height: number }} [logicalSize]
      */
     getPhysicalCanvasSize(logicalSize) {
+        const dpr = window.devicePixelRatio ?? 1;
         logicalSize = logicalSize || this.getLogicalCanvasSize();
         return {
-            width: logicalSize.width * this.dpr,
-            height: logicalSize.height * this.dpr,
+            width: logicalSize.width * dpr,
+            height: logicalSize.height * dpr,
         };
     }
 

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -88,6 +88,7 @@ export async function embed(el, spec, options = {}) {
         },
 
         updateNamedData: genomeSpy.updateNamedData.bind(genomeSpy),
+        exportCanvas: genomeSpy.exportCanvas.bind(genomeSpy),
     };
 }
 

--- a/packages/core/src/marks/mark.js
+++ b/packages/core/src/marks/mark.js
@@ -1386,18 +1386,17 @@ export default class Mark {
     /**
      * Sets viewport, clipping, and uniforms related to scaling and translation
      *
+     * @param {{width: number, height: number}} canvasSize Size of the canvas in logical pixels
+     * @param {number} dpr Device pixel ratio
      * @param {import("../view/layout/rectangle.js").default} coords
      * @param {import("../view/layout/rectangle.js").default} [clipRect]
      * @returns {boolean} true if the viewport is renderable (size > 0)
      */
-    setViewport(coords, clipRect) {
+    setViewport(canvasSize, dpr, coords, clipRect) {
         coords = coords.flatten();
 
-        const dpr = this.unitView.context.devicePixelRatio;
         const gl = this.gl;
         const props = this.properties;
-
-        const logicalSize = this.glHelper.getLogicalCanvasSize();
 
         // Translate by half a pixel to place vertical / horizontal
         // rules inside pixels, not between pixels.
@@ -1442,7 +1441,7 @@ export default class Mark {
 
             const physicalGlCoords = [
                 clippedCoords.x,
-                logicalSize.height - clippedCoords.y2,
+                canvasSize.height - clippedCoords.y2,
                 clippedCoords.width,
                 clippedCoords.height,
             ].map((x) => x * dpr);
@@ -1476,24 +1475,19 @@ export default class Mark {
             }
 
             // Viewport comprises the full canvas
-            gl.viewport(
-                0,
-                0,
-                logicalSize.width * dpr,
-                logicalSize.height * dpr
-            );
+            gl.viewport(0, 0, canvasSize.width * dpr, canvasSize.height * dpr);
             gl.disable(gl.SCISSOR_TEST);
 
             // Offset and scale all drawing to the view rectangle
             uniforms = {
                 uViewOffset: [
-                    (coords.x + xOffset) / logicalSize.width,
-                    (logicalSize.height - coords.y - yOffset - coords.height) /
-                        logicalSize.height,
+                    (coords.x + xOffset) / canvasSize.width,
+                    (canvasSize.height - coords.y - yOffset - coords.height) /
+                        canvasSize.height,
                 ],
                 uViewScale: [
-                    coords.width / logicalSize.width,
-                    coords.height / logicalSize.height,
+                    coords.width / canvasSize.width,
+                    coords.height / canvasSize.height,
                 ],
             };
         }

--- a/packages/core/src/marks/text.js
+++ b/packages/core/src/marks/text.js
@@ -171,21 +171,11 @@ export default class TextMark extends Mark {
 
         const props = this.properties;
 
-        this.registerMarkUniformValue(
-            "uSdfNumerator",
-            /** @type {import("../spec/parameter.js").ExprRef | number} */
-            ({ expr: "devicePixelRatio" }),
-            (dpr) => {
-                let q = 0.35; // TODO: Ensure that this makes sense. Now chosen by trial & error
-                if (this.properties.logoLetters) {
-                    // Adjust to make stretched letters a bit less blurry
-                    // A proper solution would probably be to compute gradients in the fragment shader
-                    // to find a suitable divisor.
-                    q /= 2;
-                }
-                return this.font.metrics.common.base / (dpr / q);
-            }
-        );
+        // 0.35 is a magic number found by trial and error
+        const sdfNumerator =
+            this.font.metrics.common.base *
+            0.35 *
+            (this.properties.logoLetters ? 0.5 : 1);
 
         this.registerMarkUniformValue("uPaddingX", props.paddingX);
         this.registerMarkUniformValue("uPaddingY", props.paddingY);
@@ -199,6 +189,8 @@ export default class TextMark extends Mark {
             uD: [props.dx, -props.dy],
 
             uLogoLetter: !!props.logoLetters,
+
+            uSdfNumerator: sdfNumerator,
 
             uViewportEdgeFadeWidth: [
                 props.viewportEdgeFadeWidthTop,

--- a/packages/core/src/marks/text.vertex.glsl
+++ b/packages/core/src/marks/text.vertex.glsl
@@ -202,7 +202,7 @@ void main(void) {
     gl_Position = unitToNdc(unitPos);
 
     // Controls antialiasing of the SDF
-    vSlope = max(1.0, min(size.x, size.y) / uSdfNumerator);
+    vSlope = max(1.0, min(size.x, size.y) / uSdfNumerator * uDevicePixelRatio);
 
     vec3 color = getScaled_color();
 

--- a/packages/core/src/types/embedApi.d.ts
+++ b/packages/core/src/types/embedApi.d.ts
@@ -77,4 +77,20 @@ export interface EmbedResult {
      * @param data new data. If left undefined, the data is retrieved from a provider.
      */
     updateNamedData: (name: string, data?: any[]) => void;
+
+    /**
+     * Returns a PNG data URL of the current canvas.
+     *
+     * @param {number} [logicalWidth] Custom width, defaults to canvas width
+     * @param {number} [logicalHeight] Custom height, defaults to canvas height
+     * @param {number} [devicePixelRatio] Defaults to window.devicePixelRatio
+     * @param {string} [clearColor] Background color. A CSS color, null for transparent
+     * @returns A PNG data URL
+     */
+    exportCanvas: (
+        logicalWidth: number,
+        logicalHeight: number,
+        devicePixelRatio: number,
+        clearColor: string
+    ) => string;
 }

--- a/packages/core/src/types/viewContext.d.ts
+++ b/packages/core/src/types/viewContext.d.ts
@@ -28,8 +28,6 @@ export default interface ViewContext {
     genomeStore?: GenomeStore;
     fontManager: BmFontManager;
 
-    devicePixelRatio: number;
-
     requestLayoutReflow: () => void;
 
     updateTooltip: <T>(

--- a/packages/core/src/view/gridView/gridView.js
+++ b/packages/core/src/view/gridView/gridView.js
@@ -449,7 +449,7 @@ export default class GridView extends ContainerView {
         context.pushView(this, coords);
 
         const flexOpts = {
-            devicePixelRatio: this.context.devicePixelRatio,
+            devicePixelRatio: context.getDevicePixelRatio(),
         };
         const columnFlexCoords = mapToPixelCoords(
             this.#makeFlexItems("column"),

--- a/packages/core/src/view/renderingContext/bufferedViewRenderingContext.js
+++ b/packages/core/src/view/renderingContext/bufferedViewRenderingContext.js
@@ -6,6 +6,8 @@ import { color } from "d3-color";
 /**
  * @typedef {object} BufferedViewRenderingOptions
  * @prop {import("../../gl/webGLHelper.js").default} webGLHelper
+ * @prop {{width: number, height: number}} canvasSize Size of the canvas in logical pixels.
+ * @prop {number} devicePixelRatio
  * @prop {import("twgl.js").FramebufferInfo} [framebufferInfo]
  * @prop {string} [clearColor] Clear color for the  WebGL context,
  *      defaults to transparent black.
@@ -39,6 +41,9 @@ export default class BufferedViewRenderingContext extends ViewRenderingContext {
     /** @type {import("../layout/rectangle.js").default} */
     #coords = undefined;
 
+    #dpr = 1;
+    #canvasSize = { width: 0, height: 0 };
+
     /**
      * @param {import("../../types/rendering.js").GlobalRenderingOptions} globalOptions
      * @param {BufferedViewRenderingOptions} bufferedOptions
@@ -48,6 +53,8 @@ export default class BufferedViewRenderingContext extends ViewRenderingContext {
 
         this.#webGLHelper = bufferedOptions.webGLHelper;
         this.#framebufferInfo = bufferedOptions.framebufferInfo;
+        this.#dpr = bufferedOptions.devicePixelRatio;
+        this.#canvasSize = bufferedOptions.canvasSize;
 
         if (bufferedOptions.clearColor) {
             const c = color(bufferedOptions.clearColor).rgb();
@@ -194,6 +201,8 @@ export default class BufferedViewRenderingContext extends ViewRenderingContext {
                         ifEnabled(() => {
                             // Suppress rendering if viewport is outside the clipRect
                             viewportVisible = mark.setViewport(
+                                this.#canvasSize,
+                                this.#dpr,
                                 coords,
                                 request.clipRect
                             );

--- a/packages/core/src/view/renderingContext/bufferedViewRenderingContext.js
+++ b/packages/core/src/view/renderingContext/bufferedViewRenderingContext.js
@@ -62,6 +62,10 @@ export default class BufferedViewRenderingContext extends ViewRenderingContext {
         }
     }
 
+    getDevicePixelRatio() {
+        return this.#dpr;
+    }
+
     /**
      * Must be called when a view's render() method is entered
      *

--- a/packages/core/src/view/renderingContext/bufferedViewRenderingContext.js
+++ b/packages/core/src/view/renderingContext/bufferedViewRenderingContext.js
@@ -1,7 +1,20 @@
 import { group } from "d3-array";
 
 import ViewRenderingContext from "./viewRenderingContext.js";
+import { color } from "d3-color";
 
+/**
+ * @typedef {object} BufferedViewRenderingOptions
+ * @prop {import("../../gl/webGLHelper.js").default} webGLHelper
+ * @prop {import("twgl.js").FramebufferInfo} [framebufferInfo]
+ * @prop {string} [clearColor] Clear color for the  WebGL context,
+ *      defaults to transparent black.
+ */
+
+/**
+ * View rendering context that buffers the actual WebGL rendering for
+ * efficient animation.
+ */
 export default class BufferedViewRenderingContext extends ViewRenderingContext {
     /** @type {[number, number, number, number]} */
     #clearColor = [0, 0, 0, 0];
@@ -28,21 +41,18 @@ export default class BufferedViewRenderingContext extends ViewRenderingContext {
 
     /**
      * @param {import("../../types/rendering.js").GlobalRenderingOptions} globalOptions
-     * @param {import("../../gl/webGLHelper.js").default} webGLHelper
-     * @param {import("twgl.js").FramebufferInfo} [framebufferInfo]
+     * @param {BufferedViewRenderingOptions} bufferedOptions
      */
-    constructor(globalOptions, webGLHelper, framebufferInfo) {
+    constructor(globalOptions, bufferedOptions) {
         super(globalOptions);
 
-        this.#webGLHelper = webGLHelper;
-        this.#framebufferInfo = framebufferInfo;
+        this.#webGLHelper = bufferedOptions.webGLHelper;
+        this.#framebufferInfo = bufferedOptions.framebufferInfo;
 
-        /*
-        if (clearColor) {
-            const c = color(clearColor).rgb();
+        if (bufferedOptions.clearColor) {
+            const c = color(bufferedOptions.clearColor).rgb();
             this.#clearColor = [c.r / 255, c.g / 255, c.b / 255, c.opacity];
         }
-        */
     }
 
     /**

--- a/packages/core/src/view/renderingContext/simpleViewRenderingContext.js
+++ b/packages/core/src/view/renderingContext/simpleViewRenderingContext.js
@@ -58,7 +58,11 @@ export default class SimpleViewRenderingContext extends ViewRenderingContext {
         for (const op of mark.prepareRender(this.globalOptions)) {
             op();
         }
-        mark.setViewport(this.coords, options.clipRect);
+
+        const canvasSize = { width: 100, height: 100 }; // Placeholder, should be replaced with actual canvas size
+        const dpr = window.devicePixelRatio ?? 1;
+
+        mark.setViewport(canvasSize, dpr, this.coords, options.clipRect);
         mark.render(options)();
     }
 }

--- a/packages/core/src/view/renderingContext/simpleViewRenderingContext.js
+++ b/packages/core/src/view/renderingContext/simpleViewRenderingContext.js
@@ -60,7 +60,7 @@ export default class SimpleViewRenderingContext extends ViewRenderingContext {
         }
 
         const canvasSize = { width: 100, height: 100 }; // Placeholder, should be replaced with actual canvas size
-        const dpr = window.devicePixelRatio ?? 1;
+        const dpr = this.getDevicePixelRatio();
 
         mark.setViewport(canvasSize, dpr, this.coords, options.clipRect);
         mark.render(options)();

--- a/packages/core/src/view/renderingContext/viewRenderingContext.js
+++ b/packages/core/src/view/renderingContext/viewRenderingContext.js
@@ -38,4 +38,8 @@ export default class ViewRenderingContext {
     renderMark(mark, options) {
         //
     }
+
+    getDevicePixelRatio() {
+        return 1;
+    }
 }


### PR DESCRIPTION
This PR introduces `exportCanvas()` method in the embed api and adds a button to App's toolbar for saving the visualization as a PNG file.

Closes #246
Closes #75 
Related to #74 

![image](https://github.com/user-attachments/assets/d8db7214-d521-482e-937b-57fed502e869)
