### PR TITLE
feat: event filters in point selections

### DIFF
--- a/packages/core/examples/selection/bars_shift.json
+++ b/packages/core/examples/selection/bars_shift.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "description": "A bar chart with highlighting on hover and selecting on click. (Inspired by Tableau's interaction style.)",
+
+  "width": 200,
+  "height": 200,
+
+  "data": {
+    "values": [
+      { "a": "A", "b": 28 },
+      { "a": "B", "b": 55 },
+      { "a": "C", "b": 43 },
+      { "a": "D", "b": 91 },
+      { "a": "E", "b": 81 },
+      { "a": "F", "b": 53 },
+      { "a": "G", "b": 19 },
+      { "a": "H", "b": 87 },
+      { "a": "I", "b": 52 }
+    ]
+  },
+  "params": [
+    {
+      "name": "highlight",
+      "select": { "type": "point", "on": "pointerover" }
+    },
+    {
+      "name": "select",
+      "select": { "type": "point", "on": "click[event.shiftKey]" }
+    }
+  ],
+  "mark": {
+    "type": "rect",
+    "fill": "#4C78A8",
+    "stroke": "black"
+  },
+  "encoding": {
+    "x": {
+      "field": "a",
+      "type": "ordinal",
+      "scale": { "type": "band", "padding": 0.2 }
+    },
+    "y": { "field": "b", "type": "quantitative" },
+    "fillOpacity": {
+      "value": 0.3,
+      "condition": { "param": "select", "value": 1 }
+    },
+    "strokeWidth": {
+      "value": 0,
+      "condition": [
+        { "param": "select", "value": 2, "empty": false },
+        { "param": "highlight", "value": 1, "empty": false }
+      ]
+    }
+  }
+}

--- a/packages/core/src/selection/selection.js
+++ b/packages/core/src/selection/selection.js
@@ -185,17 +185,21 @@ export function isProjectedSelection(selection) {
  * @returns {import("../spec/parameter.js").SelectionConfig}
  */
 export function asSelectionConfig(typeOrConfig) {
+    /** @type {import("../spec/parameter.js").SelectionConfig} */
     const config =
         typeof typeOrConfig === "string"
             ? { type: typeOrConfig }
-            : typeOrConfig;
+            : { ...typeOrConfig };
+
+    config.on = config.on
+        ? asEventConfig(config.on)
+        : isPointSelectionConfig(config)
+          ? { type: "click" }
+          : undefined;
 
     // Set some default
-    if (isPointSelectionConfig(config)) {
-        config.on ??= "click";
-        if (config.on === "click") {
-            config.toggle = true;
-        }
+    if (isPointSelectionConfig(config) && config.on.type === "click") {
+        config.toggle = true;
     }
 
     return config;
@@ -241,4 +245,30 @@ export function selectionContainsPoint(selection, point) {
             interval[0] <= point[channel] &&
             interval[1] >= point[channel]
     );
+}
+
+/**
+ * @param {import("../spec/parameter.js").SelectionConfig["on"]} eventType
+ * @returns {import("../spec/parameter.js").EventConfig}
+ */
+export function asEventConfig(eventType) {
+    if (typeof eventType === "string") {
+        const m = eventType.match(/^([a-zA-Z]+)(?:\[(.+)\])?$/);
+        if (!m) {
+            throw new Error(`Invalid event type string: ${eventType}`);
+        }
+        const [, type, filter] = m;
+        /** @type {import("../spec/parameter.js").EventConfig} */
+        const eventSpec = {
+            type: /** @type {import("../spec/parameter.js").DomEventType} */ (
+                type
+            ),
+        };
+        if (filter) {
+            eventSpec.filter = filter;
+        }
+        return eventSpec;
+    } else {
+        return eventType;
+    }
 }

--- a/packages/core/src/selection/selection.js
+++ b/packages/core/src/selection/selection.js
@@ -197,6 +197,13 @@ export function asSelectionConfig(typeOrConfig) {
           ? { type: "click" }
           : undefined;
 
+    config.clear =
+        config.clear === false
+            ? undefined
+            : config.clear === true || config.clear == null
+              ? { type: "dblclick" }
+              : asEventConfig(config.clear);
+
     // Set some default
     if (isPointSelectionConfig(config) && config.on.type === "click") {
         config.toggle = true;

--- a/packages/core/src/selection/selection.test.js
+++ b/packages/core/src/selection/selection.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { asEventConfig } from "./selection.js";
+
+describe("asEventSpec", () => {
+    it("parses a simple string event type", () => {
+        const res = asEventConfig("click");
+        expect(res).toEqual({ type: "click" });
+    });
+
+    it("parses a string event type with bracket filter", () => {
+        const res = asEventConfig("click[event.shiftKey]");
+        expect(res).toEqual({ type: "click", filter: "event.shiftKey" });
+    });
+});

--- a/packages/core/src/spec/parameter.d.ts
+++ b/packages/core/src/spec/parameter.d.ts
@@ -167,7 +167,7 @@ export type SelectionInitInterval =
 export type InteractionEventType = "click" | "dblclick" | "mouseover";
 
 // TODO: merge with InteractionEventType
-export type DomEventType = "click" | "mouseover" | "pointerover";
+export type DomEventType = "click" | "dblclick" | "mouseover" | "pointerover";
 
 export interface EventConfig {
     /**
@@ -186,7 +186,7 @@ export interface EventConfig {
 
 export interface BaseSelectionConfig<T extends SelectionType = SelectionType> {
     /**
-     * Determines the default event processing and data query for the selection. Vega-Lite currently supports two selection types:
+     * The selection type.
      *
      * - `"point"` -- to select multiple discrete data values; the first value is selected on `click` and additional values toggled on shift-click.
      * - `"interval"` -- to select a continuous range of data values on `drag`.
@@ -194,8 +194,16 @@ export interface BaseSelectionConfig<T extends SelectionType = SelectionType> {
     type: T;
 
     /**
+     * A string or object that defines the events to which the selection should listen.
      */
     on?: DomEventType | EventConfig | string;
+
+    /**
+     * A string or object that defines the events that should clear the selection.
+     *
+     * __Default value:__ `"dblclick"`
+     */
+    clear?: DomEventType | EventConfig | string | boolean;
 }
 
 export interface PointSelectionConfig extends BaseSelectionConfig<"point"> {

--- a/packages/core/src/spec/parameter.d.ts
+++ b/packages/core/src/spec/parameter.d.ts
@@ -166,6 +166,24 @@ export type SelectionInitInterval =
 
 export type InteractionEventType = "click" | "dblclick" | "mouseover";
 
+// TODO: merge with InteractionEventType
+export type DomEventType = "click" | "mouseover" | "pointerover";
+
+export interface EventConfig {
+    /**
+     * The type of event to listen to. For example, `"click"` or `"mouseover"`.
+     */
+    type: DomEventType;
+
+    /**
+     * An optional filter expression to further filter events of the specified type.
+     * The expression can only refer to the event object as `event`, and should
+     * evaluate to a boolean value indicating whether to include the event.
+     * No other data or parameters are in scope.
+     */
+    filter?: string;
+}
+
 export interface BaseSelectionConfig<T extends SelectionType = SelectionType> {
     /**
      * Determines the default event processing and data query for the selection. Vega-Lite currently supports two selection types:
@@ -177,7 +195,7 @@ export interface BaseSelectionConfig<T extends SelectionType = SelectionType> {
 
     /**
      */
-    on?: "click" | "mouseover" | "pointerover";
+    on?: DomEventType | EventConfig | string;
 }
 
 export interface PointSelectionConfig extends BaseSelectionConfig<"point"> {

--- a/packages/core/src/utils/interactionEvent.js
+++ b/packages/core/src/utils/interactionEvent.js
@@ -77,7 +77,11 @@ export function createPrimitiveEventProxy(target) {
 
     /** @type {ProxyHandler<any>} */
     const handler = {
-        /** @param {any} target @param {PropertyKey} prop @param {any} receiver */
+        /**
+         * @param {any} target
+         * @param {PropertyKey} prop
+         * @param {any} receiver
+         */
         get(target, prop, receiver) {
             const value = Reflect.get(target, prop, target);
             if (!isPrimitiveOrNull(value)) {
@@ -87,18 +91,27 @@ export function createPrimitiveEventProxy(target) {
             }
             return value;
         },
-        /** @returns {null} */
+
         getPrototypeOf() {
             return null;
         },
-        /** @param {any} target @returns {ArrayLike<string|symbol>} */
+
+        /**
+         * @param {any} target
+         * @returns {ArrayLike<string|symbol>}
+         */
         ownKeys(target) {
             const keys = Reflect.ownKeys(target).filter((k) =>
                 isPrimitiveOrNull(target[k])
             );
             return keys.map((k) => (typeof k === "symbol" ? k : String(k)));
         },
-        /** @param {any} target @param {PropertyKey} prop @returns {PropertyDescriptor|undefined} */
+
+        /**
+         * @param {any} target
+         * @param {PropertyKey} prop
+         * @returns {PropertyDescriptor|undefined}
+         */
         getOwnPropertyDescriptor(target, prop) {
             const desc = Reflect.getOwnPropertyDescriptor(target, prop);
             if (!desc) return undefined;
@@ -113,7 +126,11 @@ export function createPrimitiveEventProxy(target) {
                 configurable: !!desc.configurable,
             };
         },
-        /** @param {any} target @param {PropertyKey} prop @returns {boolean} */
+
+        /**
+         * @param {any} target
+         * @param {PropertyKey} prop
+         * @returns {boolean} */
         has(target, prop) {
             if (!(prop in target)) return false;
             return isPrimitiveOrNull(target[prop]);

--- a/packages/core/src/utils/interactionEvent.js
+++ b/packages/core/src/utils/interactionEvent.js
@@ -4,8 +4,10 @@
  * as in the DOM.
  */
 export default class InteractionEvent {
+    /** @type {MouseEvent} */
+    #primitiveMouseEventProxy;
+
     /**
-     *
      * @param {import("../view/layout/point.js").default} point Event coordinates
      *      inside the visualization canvas.
      * @param {UIEvent} uiEvent The event to be wrapped
@@ -27,8 +29,25 @@ export default class InteractionEvent {
         this.stopped = true;
     }
 
+    /**
+     * The event type string of the underlying UI event (e.g. "click", "keydown").
+     *
+     * This getter proxies and returns the `type` property from the internal `UIEvent` instance (`this.uiEvent`).
+     *
+     * @returns {string} The UI event type.
+     */
     get type() {
         return this.uiEvent.type;
+    }
+
+    get proxiedMouseEvent() {
+        if (!this.#primitiveMouseEventProxy) {
+            this.#primitiveMouseEventProxy = createPrimitiveEventProxy(
+                this.mouseEvent
+            );
+        }
+
+        return this.#primitiveMouseEventProxy;
     }
 
     get mouseEvent() {
@@ -38,4 +57,68 @@ export default class InteractionEvent {
             throw new Error("Not a MouseEvent!");
         }
     }
+}
+
+/**
+ * Create a safe proxy for an event-like object that exposes only primitive
+ * (string, number, boolean, bigint, symbol, undefined) properties and null.
+ *
+ * @param {T} target The event-like object to wrap.
+ * @returns {T} A proxy exposing only primitive properties.
+ * @template T
+ */
+export function createPrimitiveEventProxy(target) {
+    /**
+     * @param {any} v
+     * @returns {boolean}
+     */
+    const isPrimitiveOrNull = (v) =>
+        v === null || (typeof v !== "object" && typeof v !== "function");
+
+    /** @type {ProxyHandler<any>} */
+    const handler = {
+        /** @param {any} target @param {PropertyKey} prop @param {any} receiver */
+        get(target, prop, receiver) {
+            const value = Reflect.get(target, prop, target);
+            if (!isPrimitiveOrNull(value)) {
+                throw new Error(
+                    `Access to non-primitive property "${String(prop)}" is not allowed.`
+                );
+            }
+            return value;
+        },
+        /** @returns {null} */
+        getPrototypeOf() {
+            return null;
+        },
+        /** @param {any} target @returns {ArrayLike<string|symbol>} */
+        ownKeys(target) {
+            const keys = Reflect.ownKeys(target).filter((k) =>
+                isPrimitiveOrNull(target[k])
+            );
+            return keys.map((k) => (typeof k === "symbol" ? k : String(k)));
+        },
+        /** @param {any} target @param {PropertyKey} prop @returns {PropertyDescriptor|undefined} */
+        getOwnPropertyDescriptor(target, prop) {
+            const desc = Reflect.getOwnPropertyDescriptor(target, prop);
+            if (!desc) return undefined;
+            // hide accessor properties (getters/setters)
+            if ("get" in desc || "set" in desc) return undefined;
+            if (!isPrimitiveOrNull(desc.value)) return undefined;
+            // Preserve configurability/enumerability/writability to satisfy proxy invariants
+            return {
+                value: desc.value,
+                writable: !!desc.writable,
+                enumerable: !!desc.enumerable,
+                configurable: !!desc.configurable,
+            };
+        },
+        /** @param {any} target @param {PropertyKey} prop @returns {boolean} */
+        has(target, prop) {
+            if (!(prop in target)) return false;
+            return isPrimitiveOrNull(target[prop]);
+        },
+    };
+
+    return new Proxy(target, handler);
 }

--- a/packages/core/src/utils/interactionEvent.test.js
+++ b/packages/core/src/utils/interactionEvent.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { createPrimitiveEventProxy } from "./interactionEvent.js";
+
+describe("createPrimitiveEventProxy", () => {
+    it("exposes primitive properties and hides non-primitives", () => {
+        const mock = {
+            type: "click",
+            clientX: 42,
+            meta: { foo: "bar" },
+            nested: { a: 1 },
+        };
+
+        /** @type {any} */
+        const proxy = createPrimitiveEventProxy(mock);
+
+        // allowed primitives
+        expect(proxy.type).toBe("click");
+        expect(proxy.clientX).toBe(42);
+
+        // non-primitive access throws
+        expect(() => proxy.meta).toThrow(/non-primitive/);
+
+        // keys enumeration hides non-primitives
+        const keys = Object.keys(proxy);
+        expect(keys).toContain("type");
+        expect(keys).not.toContain("meta");
+
+        // `in` operator respects the policy
+        expect("type" in proxy).toBe(true);
+        expect("meta" in proxy).toBe(false);
+
+        // prototype is hidden
+        expect(Object.getPrototypeOf(proxy)).toBeNull();
+    });
+});

--- a/packages/core/src/view/unitView.js
+++ b/packages/core/src/view/unitView.js
@@ -115,6 +115,11 @@ export default class UnitView extends View {
                     select.on
                 );
 
+            const clearEventConfig =
+                /** @type {import("../spec/parameter.js").EventConfig} */ (
+                    select.clear
+                );
+
             if (isPointSelectionConfig(select)) {
                 // Handle projection-free point selections
 
@@ -179,9 +184,34 @@ export default class UnitView extends View {
                 this.addInteractionEventListener(
                     ["mouseover", "pointerover"].includes(eventConfig.type)
                         ? "mousemove"
-                        : "click",
+                        : eventConfig.type,
                     listener
                 );
+
+                if (clearEventConfig) {
+                    const clearPredicate = clearEventConfig.filter
+                        ? createEventFilterFunction(clearEventConfig.filter)
+                        : () => true;
+
+                    const clearListener = (
+                        /** @type {any} */ _,
+                        /** @type {import("../utils/interactionEvent.js").default} */ event
+                    ) => {
+                        if (!clearPredicate(event.mouseEvent)) {
+                            return;
+                        }
+                        lastId = none;
+                        const selection = select.toggle
+                            ? createMultiPointSelection()
+                            : createSinglePointSelection(null);
+                        setter(selection);
+                    };
+
+                    this.addInteractionEventListener(
+                        clearEventConfig.type,
+                        clearListener
+                    );
+                }
             }
         }
     }

--- a/packages/core/src/view/unitView.js
+++ b/packages/core/src/view/unitView.js
@@ -141,7 +141,7 @@ export default class UnitView extends View {
                     /** @type {any} */ _,
                     /** @type {import("../utils/interactionEvent.js").default} */ event
                 ) => {
-                    if (!eventPredicate(event.mouseEvent)) {
+                    if (!eventPredicate(event.proxiedMouseEvent)) {
                         return;
                     }
                     const datum = getHoveredDatum();
@@ -197,7 +197,7 @@ export default class UnitView extends View {
                         /** @type {any} */ _,
                         /** @type {import("../utils/interactionEvent.js").default} */ event
                     ) => {
-                        if (!clearPredicate(event.mouseEvent)) {
+                        if (!clearPredicate(event.proxiedMouseEvent)) {
                             return;
                         }
                         lastId = none;


### PR DESCRIPTION
Allows additional constraints for point selections. For instance, only select points when the shift key is pressed:

```json
      "params": [
        {
          "name": "cnvSelect",
          "select": {
            "on": "click[event.shiftKey]",
            "type": "point"
          }
        }
      ],
```

For now, this is a quick hack for point selections only and documentation is lacking. However, works similarly to Vega.