### PR TITLE
refactor: view lifecycle for dynamic subtree init/cleanup

### DIFF
--- a/VIEW_REFACTOR_PLAN.md
+++ b/VIEW_REFACTOR_PLAN.md
@@ -51,6 +51,10 @@ without requiring a full rebuild or relying on a global registry.
   track their collector observer and remove it during `dispose`.
 - Added `Collector.observe()` + `View.registerDisposer()` so observer cleanup
   does not require per-class listener fields.
+- Added subtree data-ready helpers (`collectNearestViewSubtreeDataSources`,
+  `loadViewSubtreeData`) and tests for nested source boundaries.
+- Metadata rebuild uses subtree source collection to ensure decorations such as
+  titles/axes are loaded along with primary data sources.
 - Metadata rebuild now uses subtree init and removes old dataflow hosts before
   rebuilding; title-view data source hacks removed.
 - Metadata view now unsubscribes from Redux, unregisters its attribute info

--- a/VIEW_REFACTOR_PLAN.md
+++ b/VIEW_REFACTOR_PLAN.md
@@ -54,7 +54,8 @@ without requiring a full rebuild or relying on a global registry.
 - Added subtree data-ready helpers (`collectNearestViewSubtreeDataSources`,
   `loadViewSubtreeData`) and tests for nested source boundaries.
 - `loadViewSubtreeData` now emits a subtree-scoped "subtreeDataReady" broadcast;
-  sample view listens to it for sample extraction.
+  `dataLoaded` global broadcast removed and sample view listens to subtree
+  readiness for sample extraction.
 - Metadata rebuild uses subtree source collection to ensure decorations such as
   titles/axes are loaded along with primary data sources.
 - Metadata rebuild now uses subtree init and removes old dataflow hosts before

--- a/VIEW_REFACTOR_PLAN.md
+++ b/VIEW_REFACTOR_PLAN.md
@@ -43,7 +43,7 @@ without requiring a full rebuild or relying on a global registry.
 - Added removal for scale/axis resolution members and invalidation of cached
   scale resolutions.
 - Added observer cleanup for collectors and flow-handle-based teardown.
-- Added subtree initialization helpers (`initializeSubtree`,
+- Added subtree initialization helpers (`initializeViewSubtree`,
   `finalizeSubtreeGraphics`) to build flow and initialize marks per subtree.
 - Dropped host-based `DataFlow` lookup and replaced it with per-view flow
   handles; `DataFlow` now tracks only data sources and collectors.
@@ -66,7 +66,7 @@ without requiring a full rebuild or relying on a global registry.
 ## Proposed fixes (incremental direction)
 
 - Introduce explicit lifecycle hooks for views:
-  - `initializeSubtree()` for post-order setup (axes, scale resolution, mark
+  - `initializeViewSubtree()` for post-order setup (axes, scale resolution, mark
     encoders, flow build/init, and initial data propagation).
   - `disposeSubtree()` for pre-order teardown (unsubscribe, remove listeners,
     release mark resources, detach flow nodes).
@@ -157,7 +157,7 @@ graph/optimizer, while views access flow via handles.
   by letting local subtrees initialize their own sources on completion.
 - Lifecycle ordering for dynamic insertion:
   - build the subtree completely (pre/post-order creation, no side effects)
-  - run subtree init (`initializeSubtree`) in post-order
+  - run subtree init (`initializeViewSubtree`) in post-order
   - attach/replace into the live hierarchy
   - dispose old subtree via `disposeSubtree` when replacing
 
@@ -240,4 +240,4 @@ lives next to the owner view (not in `DataFlow`).
   listeners at construction; lacks a remove/unresolve path.
 - `packages/app`: several views are still instantiated via `new` instead of
   `createOrImportView`; these should follow the same subtree lifecycle
-  (build fully, initializeSubtree, then attach) and dispose old subtrees.
+  (build fully, initializeViewSubtree, then attach) and dispose old subtrees.

--- a/VIEW_REFACTOR_PLAN.md
+++ b/VIEW_REFACTOR_PLAN.md
@@ -1,4 +1,4 @@
-# View Refactor Plan (Draft)
+# View Refactor Plan
 
 ## Problem statement
 
@@ -10,241 +10,57 @@ steps are skipped for newly created subtrees. The goal is to incrementally
 refactor the architecture so that view subtrees can be added and removed safely
 without requiring a full rebuild or relying on a global registry.
 
-## Key findings (current state)
+## Current state (implemented)
 
-- Layout children are replaced without any view teardown. Old views keep
-  interaction listeners, mark instances, and closures alive, which leads to
-  leaks and stale rendering state when dynamic views are replaced.
-- Dataflow construction is additive. `buildDataFlow(root, existingFlow)`
-  mutates a shared `DataFlow` and never removes the old nodes or observers for
-  replaced views; old collectors and data sources remain reachable.
-- Observer wiring is ad hoc. Mark observers are added in multiple places and
-  cleanup relies on per-view teardown; this needs to stay consistent as global
-  init is replaced by subtree init.
-- Scale and axis resolution are not reversible. `ScaleResolution.addMember`
-  only grows the membership; there is no removal or invalidation on view
-  deletion, so domains and event listeners can include stale views.
-- Store subscriptions are not disposed. `subscribeTo` returns an unsubscribe
-  function but most views do not hold or call it, keeping views alive via
-  Redux closures even after removal.
-- Action augmenters are not disposed. `SampleView` registers an augmenter that
-  is never removed, causing similar lifetime leaks for the view.
-- Global initialization is static. `GenomeSpy` runs one-time setup such as
-  `configureViewOpacity`, `createAxes`, `optimizeDataFlow`, and mark init.
-  Dynamically inserted views bypass these steps or run incomplete subsets.
-- Dataflow and view hierarchies are only "decoupled" in theory: flow graphs are
-  derived from `dataParent` trees built from the view hierarchy, so replacements
-  must be coordinated; without teardown, both hierarchies drift out of sync.
+- Subtree lifecycle helpers exist (`initializeViewSubtree`,
+  `finalizeSubtreeGraphics`, `disposeSubtree`) and are used in metadata rebuild.
+- Flow handles are view-owned; `DataFlow` host maps are removed and observers
+  are managed via `Collector.observe()` + `View.registerDisposer()`.
+- Subtree data-ready signaling exists: `loadViewSubtreeData` emits
+  `subtreeDataReady`, and sample extraction listens to it. Global `dataLoaded`
+  broadcast is removed.
+- Metadata rebuild now uses subtree init + subtree data loading and cleans up
+  subscriptions/listeners on dispose.
+- Scale/axis resolution membership can be removed during disposal, and unit
+  views dispose marks and listener wiring.
 
-## Recent updates (implemented)
+## Remaining work (resume checklist)
 
-- Added view disposal hooks and teardown paths (`dispose`, `disposeSubtree`) and
-  wired `UnitView.dispose` to remove scale listeners and dispose marks.
-- Added removal for scale/axis resolution members and invalidation of cached
-  scale resolutions.
-- Added observer cleanup for collectors and flow-handle-based teardown.
-- Added subtree initialization helpers (`initializeViewSubtree`,
-  `finalizeSubtreeGraphics`) to build flow and initialize marks per subtree.
-- Dropped host-based `DataFlow` lookup and replaced it with per-view flow
-  handles; `DataFlow` now tracks only data sources and collectors.
-- Removed `DataFlow.addObserver` and flow-handle-stored callbacks; views now
-  track their collector observer and remove it during `dispose`.
-- Added `Collector.observe()` + `View.registerDisposer()` so observer cleanup
-  does not require per-class listener fields.
-- Added subtree data-ready helpers (`collectNearestViewSubtreeDataSources`,
-  `loadViewSubtreeData`) and tests for nested source boundaries.
-- `loadViewSubtreeData` now emits a subtree-scoped "subtreeDataReady" broadcast;
-  `dataLoaded` global broadcast removed and sample view listens to subtree
-  readiness for sample extraction.
-- Metadata rebuild uses subtree source collection to ensure decorations such as
-  titles/axes are loaded along with primary data sources.
-- Metadata rebuild now uses subtree init and removes old dataflow hosts before
-  rebuilding; title-view data source hacks removed.
-- Metadata view now unsubscribes from Redux, unregisters its attribute info
-  source, and removes its ancestor mousemove listener on dispose.
-- Sample label view now unsubscribes and unregisters its attribute info source
-  on dispose; sample view now removes its action augmenter and store
-  subscription on dispose.
-- Grid and facet view replacement now dispose old children (including grid
-  decorations), preventing view/mark/resource leaks.
-- Tests added/extended: `viewDispose`, `viewUtils`, `paramMediator`,
-  `dataFlow`, and `metadataView` dynamic rebuild coverage.
+1) Replace global init path in `genomeSpy.js`
+- Move flow initialization/loading and `reconfigureScales` into subtree-aware
+  helpers, driven by view creation or subtree insertion.
+- Ensure flow optimization + handle sync still run when subtrees are added.
+- Add per-data-source load-state (cached load promise) to avoid duplicate loads
+  when sources are shared across subtrees.
 
-## Proposed fixes (incremental direction)
+2) Dataflow lifecycle for subtree replacement
+- Define how subtree flow branches are attached to the global graph and how
+  replaced branches are pruned or detached (flowBuilder or flowInit cleanup).
+- Ensure collectors and observers are removed when a subtree is disposed.
 
-- Introduce explicit lifecycle hooks for views:
-  - `initializeViewSubtree()` for post-order setup (axes, scale resolution, mark
-    encoders, flow build/init, and initial data propagation).
-  - `disposeSubtree()` for pre-order teardown (unsubscribe, remove listeners,
-    release mark resources, detach flow nodes).
-- Build dataflow per subtree rather than globally. When a container completes
-  child creation, build and initialize a flow branch for that subtree and
-  attach it to the nearest ancestor flow node if needed.
-- Replace `DataFlow` host mapping with view-local handles. Each view can
-  optionally expose `flowNode` / `collector` / `dataSource` via a small
-  interface so marks and scales can bind to the local branch without a global
-  registry.
-- Add removal paths for scale/axis resolution:
-  - track membership per view and allow removal;
-  - ensure resolution listeners are detached when views are disposed.
-- Ensure mark lifecycle parity:
-  - mark init (`initializeEncoders`, `initializeGraphics`, `initializeData`)
-    should be triggered when a subtree is ready;
-  - mark teardown should release GPU buffers/textures to avoid leaks.
-- Introduce explicit teardown for Redux-based subscriptions and action
-  augmenters so removed views do not hold references to the store.
+3) View creation consistency (app-side)
+- Replace direct `new` usage with `createOrImportView` where practical.
+- Follow the same lifecycle: build subtree -> initializeViewSubtree -> attach ->
+  dispose old subtree.
+- Keep metadata/sidebar out of sample-extraction readiness checks.
 
-## Proposed refactor phases (suggested)
+4) Scale reconfiguration wiring
+- Decide where scale reconfiguration belongs for subtree data loads.
+- Wire `reconfigureScales` to subtree init or subtree data-ready as appropriate.
 
-### Phase 0: Instrumentation and tests
+5) Tests to make resumption safe
+- SubtreeDataReady boundaries (metadata vs. sample data) and ancestry checks.
+- Shared data source caching (one load, many subtrees).
+- Flow branch cleanup on metadata rebuild (no orphaned nodes/collectors).
 
-- Add tests around dynamic add/remove for metadata views to surface leaks:
-  - replacing metadata should not multiply observers or listeners
-  - replacing metadata should not leave old flow nodes reachable
-  - scale membership should reflect only current views
-- Add minimal lifecycle hooks in tests to verify teardown is invoked.
+## Notes for later
 
-Status: started. Metadata rebuild test covers observer/collector sizes and
-unsubscribe behavior. Core tests cover disposal and flow-handle wiring.
+- Nearest data source boundary: when collecting sources for a subtree, stop
+  descending once a view owns a data source. Readiness should not bubble past
+  a nearer source owner.
+- WebGL ordering: build subtree first, initialize flow + observers post-order,
+  compile/init graphics in parallel, then initialize data and render.
 
-### Immediate next steps (metadata-first)
+## Progress estimate
 
-- Focus on `MetadataView` subtree lifecycle first; postpone Redux teardown
-  unless it becomes a blocker.
-- Introduce a local subtree init path for metadata that replaces:
-  - global `buildDataFlow` usage in `#setMetadata`
-  - the title-view data source load hack
-- Add a minimal flow handle on the metadata subtree so unit views can access
-  their collector/source without global `DataFlow` lookup.
-- Add teardown for metadata subtree only (observer removal, flow detachment,
-  mark disposal) to prevent leaks during add/remove.
-
-Status: partial. Subtree init helpers exist and metadata rebuild uses them;
-flow handles are in place.
-
-### Phase 1: Safe teardown without changing architecture
-
-- Add `disposeSubtree()` on `View` and implement in `UnitView` to dispose marks.
-- Track and unsubscribe store listeners in views (`SampleLabelView`,
-  `MetadataView`, `SampleView` action augmenters). This can be deferred unless
-  it becomes a blocker for metadata removal.
-- Add a way to unregister flow observers and scale listeners associated with
-  a view (even if flow stays global for now).
-
-Status: mostly done. Disposal hooks, mark cleanup, scale/axis membership
-removal, observer cleanup, and app-level unsubscribe paths are implemented.
-DataFlow host registry is removed; handles are the primary access path.
-
-### Phase 2: Subtree dataflow init
-
-- Create a helper to build flow for a subtree and initialize its data sources,
-  collectors, and marks without requiring a global root pass.
-- Update metadata view rebuild to:
-  - dispose old subtree
-  - rebuild views
-  - build/init flow for the new subtree
-  - reconfigure scales locally
-
-Status: helper exists and metadata rebuild uses it; `DataFlow` remains a global
-graph/optimizer, while views access flow via handles.
-
-## Notes on initialization order (WebGL constraints)
-
-- Avoid touching GPU resources until the view subtree is structurally ready.
-  Shader compilation should run in parallel but marks must not be used until
-  initialization completes.
-- Proposed split for each subtree:
-  - Phase A (sync, post-order): build views, build flow branch, wire observers,
-    register scale/axis resolutions, schedule data source loads.
-  - Phase B (async, parallel): kick `mark.initializeGraphics()` across unit
-    views and await readiness.
-  - Phase C (sync): run `initializeData()` and `updateGraphicsData()` once
-    graphics are ready; request render.
-- This should replace ad hoc "find title views and load data sources" hacks
-  by letting local subtrees initialize their own sources on completion.
-- Lifecycle ordering for dynamic insertion:
-  - build the subtree completely (pre/post-order creation, no side effects)
-  - run subtree init (`initializeViewSubtree`) in post-order
-  - attach/replace into the live hierarchy
-  - dispose old subtree via `disposeSubtree` when replacing
-
-## Notes on early data loading
-
-- Goal: trigger data loads as soon as a subtree is ready while still benefiting
-  from global optimization (shared sources).
-- Proposed sequence for subtree init:
-  - build subtree flow
-  - run `optimizeDataFlow` globally
-  - sync flow handles to canonical data sources
-  - load only canonical data sources for the subtree (guarded by load state)
-- Requires a load-state or cached load promise on each data source to avoid
-  duplicate fetches when sources are shared across subtrees.
- - Data-ready boundaries: when collecting sources for a subtree, stop
-   descending once a view owns a data source (nearest-source wins). Likewise,
-   readiness propagation should not bubble past the nearest ancestor that also
-   owns a data source.
-
-### Phase 3: Remove `DataFlow` registry
-
-- Migrate from global host-based lookup to view-local flow handles.
-- Replace `flow.findCollectorByKey`/`findDataSourceByKey` with direct access
-  from the owning view or flow branch.
-- Simplify dataflow ownership: each view or subtree can own its flow node and
-  be responsible for disposal.
-
-Phase 3 checklist (concrete tasks):
-
-- Define a minimal flow-handle interface, e.g., `{ dataSource, collector }`,
-  stored on views that participate in dataflow.
-- Attach handles during `buildDataFlow` and re-sync after optimization.
-- Use local handles in view code paths (no global lookup fallback).
-- Ensure subtree init syncs flow handles and uses canonical data sources.
-- Remove host-map lookups; keep `DataFlow` as a graph/optimizer container only.
-- Add tests that assert flow-handle availability in subtree init and selection
-  rect updates.
-
-Status: in progress. Host maps removed; flow handles are required for view-owned
-sources/collectors and selection rect has handle coverage. Observer wiring now
-lives next to the owner view (not in `DataFlow`).
-
-### Progress estimate
-
-[███████████████░░░░░░░░░░░] 58%
-
-### Phase 4: Resolution and layout cleanup
-
-- Make scale/axis resolution membership fully dynamic with add/remove.
-- Ensure layout cache invalidation and opacity config are triggered when views
-  are added or removed.
-
-## Open questions / design constraints
-
-- How should shared named sources behave across subtrees when reusing datasets?
-- Should resolution membership be stored on `ScaleResolution` or on the view?
-- What is the minimal interface for view <-> flow coupling that keeps tests
-  stable but avoids concrete type dependencies?
-
-## Current pain points by file
-
-- `packages/app/src/sampleView/metadata/metadataView.js`: now uses subtree init
-  and cleans up subscriptions/listeners on dispose, but relies on manual
-  `reconfigureScales`.
-- `packages/app/src/sampleView/sampleLabelView.js`: now unsubscribes and removes
-  its attribute info source on dispose.
-- `packages/app/src/sampleView/sampleView.js`: now removes its action augmenter
-  and store subscription on dispose; dynamic sidebar lifecycle still relies on
-  global init.
-- `packages/core/src/genomeSpy.js`: global one-shot init still owns data
-  loading, scale reconfiguration, and `dataLoaded` broadcast; these should move
-  to subtree-aware initialization.
-- `packages/core/src/view/flowBuilder.js`: builds flow from current view tree
-  but has no corresponding teardown/prune for replaced branches.
-- `packages/core/src/data/dataFlow.js`: now a graph/optimizer container; still
-  needs load-state tracking for early-loading without duplicate fetches.
-- `packages/core/src/view/scaleResolution.js`: membership grows without removal,
-  so domains/listeners can outlive the owning view.
-- `packages/core/src/view/unitView.js`: resolves scale/axis and registers scale
-  listeners at construction; lacks a remove/unresolve path.
-- `packages/app`: several views are still instantiated via `new` instead of
-  `createOrImportView`; these should follow the same subtree lifecycle
-  (build fully, initializeViewSubtree, then attach) and dispose old subtrees.
+[█████████████████░░░░░░░░░] 63%

--- a/VIEW_REFACTOR_PLAN.md
+++ b/VIEW_REFACTOR_PLAN.md
@@ -1,0 +1,159 @@
+# View Refactor Plan (Draft)
+
+## Problem statement
+
+Dynamic mutation of the view hierarchy (add/remove views) is fragile because
+initialization is global and one-way: views, dataflow, and scale/axis resolution
+are built once from the root and never cleanly torn down. As a result, dynamic
+changes leak listeners, dataflow nodes, and GPU resources, and some view setup
+steps are skipped for newly created subtrees. The goal is to incrementally
+refactor the architecture so that view subtrees can be added and removed safely
+without requiring a full rebuild or relying on a global registry.
+
+## Key findings (current state)
+
+- Layout children are replaced without any view teardown. Old views keep
+  interaction listeners, mark instances, and closures alive, which leads to
+  leaks and stale rendering state when dynamic views are replaced.
+- Dataflow construction is additive. `buildDataFlow(root, existingFlow)`
+  mutates a shared `DataFlow` and never removes the old nodes or observers for
+  replaced views; old collectors and data sources remain reachable.
+- Observers are one-way. `flow.addObserver` is used for marks and never
+  unregistered, so any re-build of metadata views stacks new observers on top
+  of old ones.
+- Scale and axis resolution are not reversible. `ScaleResolution.addMember`
+  only grows the membership; there is no removal or invalidation on view
+  deletion, so domains and event listeners can include stale views.
+- Store subscriptions are not disposed. `subscribeTo` returns an unsubscribe
+  function but most views do not hold or call it, keeping views alive via
+  Redux closures even after removal.
+- Action augmenters are not disposed. `SampleView` registers an augmenter that
+  is never removed, causing similar lifetime leaks for the view.
+- Global initialization is static. `GenomeSpy` runs one-time setup such as
+  `configureViewOpacity`, `createAxes`, `optimizeDataFlow`, and mark init.
+  Dynamically inserted views bypass these steps or run incomplete subsets.
+- Dataflow and view hierarchies are only "decoupled" in theory: flow graphs are
+  derived from `dataParent` trees built from the view hierarchy, so replacements
+  must be coordinated; without teardown, both hierarchies drift out of sync.
+
+## Proposed fixes (incremental direction)
+
+- Introduce explicit lifecycle hooks for views:
+  - `initializeSubtree()` for post-order setup (axes, scale resolution, mark
+    encoders, flow build/init, and initial data propagation).
+  - `disposeSubtree()` for pre-order teardown (unsubscribe, remove listeners,
+    release mark resources, detach flow nodes).
+- Build dataflow per subtree rather than globally. When a container completes
+  child creation, build and initialize a flow branch for that subtree and
+  attach it to the nearest ancestor flow node if needed.
+- Replace `DataFlow` host mapping with view-local handles. Each view can
+  optionally expose `flowNode` / `collector` / `dataSource` via a small
+  interface so marks and scales can bind to the local branch without a global
+  registry.
+- Add removal paths for scale/axis resolution:
+  - track membership per view and allow removal;
+  - ensure resolution listeners are detached when views are disposed.
+- Ensure mark lifecycle parity:
+  - mark init (`initializeEncoders`, `initializeGraphics`, `initializeData`)
+    should be triggered when a subtree is ready;
+  - mark teardown should release GPU buffers/textures to avoid leaks.
+- Introduce explicit teardown for Redux-based subscriptions and action
+  augmenters so removed views do not hold references to the store.
+
+## Proposed refactor phases (suggested)
+
+### Phase 0: Instrumentation and tests
+
+- Add tests around dynamic add/remove for metadata views to surface leaks:
+  - replacing metadata should not multiply observers or listeners
+  - replacing metadata should not leave old flow nodes reachable
+  - scale membership should reflect only current views
+- Add minimal lifecycle hooks in tests to verify teardown is invoked.
+
+### Immediate next steps (metadata-first)
+
+- Focus on `MetadataView` subtree lifecycle first; postpone Redux teardown
+  unless it becomes a blocker.
+- Introduce a local subtree init path for metadata that replaces:
+  - global `buildDataFlow` usage in `#setMetadata`
+  - the title-view data source load hack
+- Add a minimal flow handle on the metadata subtree so unit views can access
+  their collector/source without global `DataFlow` lookup.
+- Add teardown for metadata subtree only (observer removal, flow detachment,
+  mark disposal) to prevent leaks during add/remove.
+
+### Phase 1: Safe teardown without changing architecture
+
+- Add `disposeSubtree()` on `View` and implement in `UnitView` to dispose marks.
+- Track and unsubscribe store listeners in views (`SampleLabelView`,
+  `MetadataView`, `SampleView` action augmenters). This can be deferred unless
+  it becomes a blocker for metadata removal.
+- Add a way to unregister flow observers and scale listeners associated with
+  a view (even if flow stays global for now).
+
+### Phase 2: Subtree dataflow init
+
+- Create a helper to build flow for a subtree and initialize its data sources,
+  collectors, and marks without requiring a global root pass.
+- Update metadata view rebuild to:
+  - dispose old subtree
+  - rebuild views
+  - build/init flow for the new subtree
+  - reconfigure scales locally
+
+## Notes on initialization order (WebGL constraints)
+
+- Avoid touching GPU resources until the view subtree is structurally ready.
+  Shader compilation should run in parallel but marks must not be used until
+  initialization completes.
+- Proposed split for each subtree:
+  - Phase A (sync, post-order): build views, build flow branch, wire observers,
+    register scale/axis resolutions, schedule data source loads.
+  - Phase B (async, parallel): kick `mark.initializeGraphics()` across unit
+    views and await readiness.
+  - Phase C (sync): run `initializeData()` and `updateGraphicsData()` once
+    graphics are ready; request render.
+- This should replace ad hoc "find title views and load data sources" hacks
+  by letting local subtrees initialize their own sources on completion.
+
+### Phase 3: Remove `DataFlow` registry
+
+- Migrate from global host-based lookup to view-local flow handles.
+- Replace `flow.findCollectorByKey`/`findDataSourceByKey` with direct access
+  from the owning view or flow branch.
+- Simplify dataflow ownership: each view or subtree can own its flow node and
+  be responsible for disposal.
+
+### Phase 4: Resolution and layout cleanup
+
+- Make scale/axis resolution membership fully dynamic with add/remove.
+- Ensure layout cache invalidation and opacity config are triggered when views
+  are added or removed.
+
+## Open questions / design constraints
+
+- How should shared named sources behave across subtrees when reusing datasets?
+- Should resolution membership be stored on `ScaleResolution` or on the view?
+- What is the minimal interface for view <-> flow coupling that keeps tests
+  stable but avoids concrete type dependencies?
+
+## Current pain points by file
+
+- `packages/app/src/sampleView/metadata/metadataView.js`: rebuilds child views
+  on metadata changes without teardown; manually rebuilds flow and observers;
+  lacks explicit unsubscribe or mark disposal.
+- `packages/app/src/sampleView/sampleLabelView.js`: subscribes to store without
+  retaining unsubscribe; uses dynamic data updates without view disposal path.
+- `packages/app/src/sampleView/sampleView.js`: registers action augmenters and
+  global listeners without unregister; constructs sidebar subtree without
+  dynamic lifecycle hooks.
+- `packages/core/src/genomeSpy.js`: global one-shot init assumes static tree and
+  does not support incremental subtree init/teardown.
+- `packages/core/src/view/flowBuilder.js`: builds flow from current view tree
+  but has no corresponding teardown/prune for replaced branches.
+- `packages/core/src/data/dataFlow.js`: global registry with host-based lookup
+  complicates dynamic removal; observers are only added, never removed.
+- `packages/core/src/view/scaleResolution.js`: membership grows without removal,
+  so domains/listeners can outlive the owning view.
+- `packages/core/src/view/unitView.js`: resolves scale/axis and registers scale
+  listeners at construction; lacks a remove/unresolve path.

--- a/VIEW_REFACTOR_PLAN.md
+++ b/VIEW_REFACTOR_PLAN.md
@@ -53,6 +53,8 @@ without requiring a full rebuild or relying on a global registry.
   does not require per-class listener fields.
 - Added subtree data-ready helpers (`collectNearestViewSubtreeDataSources`,
   `loadViewSubtreeData`) and tests for nested source boundaries.
+- `loadViewSubtreeData` now emits a subtree-scoped "subtreeDataReady" broadcast;
+  sample view listens to it for sample extraction.
 - Metadata rebuild uses subtree source collection to ensure decorations such as
   titles/axes are loaded along with primary data sources.
 - Metadata rebuild now uses subtree init and removes old dataflow hosts before

--- a/packages/app/src/components/dialogs/dataflowInspectorDialog.js
+++ b/packages/app/src/components/dialogs/dataflowInspectorDialog.js
@@ -238,7 +238,7 @@ customElements.define("gs-dataflow-inspector", DataFlowInspectorDialog);
 /**
  * Show the dataflow inspector dialog
  *
- * @param {import("@genome-spy/core/data/dataFlow.js").default<any>} dataFlow
+ * @param {import("@genome-spy/core/data/dataFlow.js").default} dataFlow
  * @param {DataFlowInspectorOptions} [options]
  * @returns {Promise<import("../generic/baseDialog.js").DialogFinishDetail>}
  */

--- a/packages/app/src/sampleView/compositeAttributeInfoSource.js
+++ b/packages/app/src/sampleView/compositeAttributeInfoSource.js
@@ -24,6 +24,21 @@ export default class CompositeAttributeInfoSource {
     }
 
     /**
+     * @param {string} type
+     * @param {AttributeInfoSource} [attributeInfoSource]
+     */
+    removeAttributeInfoSource(type, attributeInfoSource) {
+        if (
+            attributeInfoSource &&
+            this.attributeInfoSourcesByType[type] !== attributeInfoSource
+        ) {
+            return;
+        }
+
+        delete this.attributeInfoSourcesByType[type];
+    }
+
+    /**
      *
      * @param {AttributeIdentifier} attribute
      */

--- a/packages/app/src/sampleView/metadata/metadataView.js
+++ b/packages/app/src/sampleView/metadata/metadataView.js
@@ -125,7 +125,8 @@ export class MetadataView extends ConcatView {
             this.handleContextMenu.bind(this)
         );
 
-        this.addInteractionEventListener("mousemove", (coords, event) => {
+        /** @type {import("@genome-spy/core/view/view.js").InteractionEventListener} */
+        const mouseMoveListener = (coords, event) => {
             const view = event.target;
             const sample = this.#sampleView.findSampleForMouseEvent(
                 coords,
@@ -146,12 +147,15 @@ export class MetadataView extends ConcatView {
             }
 
             this.#handleAttributeHighlight(attributeName);
-        });
+        };
+
+        this.addInteractionEventListener("mousemove", mouseMoveListener);
 
         // TODO: Implement "mouseleave" event. Let's hack for now...
         this.#highlightTarget = peek([
             ...this.#sampleView.getLayoutAncestors(),
         ]);
+        /** @type {import("@genome-spy/core/view/view.js").InteractionEventListener} */
         const highlightTargetListener = (coords, event) => {
             if (!this._attributeHighlighState.currentAttribute) {
                 return;

--- a/packages/app/src/sampleView/metadata/metadataView.js
+++ b/packages/app/src/sampleView/metadata/metadataView.js
@@ -17,8 +17,8 @@ import { contextMenu, DIVIDER } from "../../utils/ui/contextMenu.js";
 import {
     checkForDuplicateScaleNames,
     finalizeSubtreeGraphics,
-    initializeSubtree,
 } from "@genome-spy/core/view/viewUtils.js";
+import { initializeSubtree } from "@genome-spy/core/data/flowInit.js";
 import { subscribeTo } from "../../state/subscribeTo.js";
 import { buildPathTree, METADATA_PATH_SEPARATOR } from "./metadataUtils.js";
 import { splitPath } from "../../utils/escapeSeparator.js";

--- a/packages/app/src/sampleView/metadata/metadataView.js
+++ b/packages/app/src/sampleView/metadata/metadataView.js
@@ -59,6 +59,11 @@ export class MetadataView extends ConcatView {
     #viewToAttribute = new WeakMap();
 
     /**
+     * @type {(identifier: import("../types.js").AttributeIdentifier) => import("../types.js").AttributeInfo}
+     */
+    #attributeInfoSource;
+
+    /**
      * @type {import("@genome-spy/core/view/view.js").default}
      */
     #highlightTarget;
@@ -101,12 +106,12 @@ export class MetadataView extends ConcatView {
             abortController: new AbortController(),
         };
 
+        this.#attributeInfoSource = (attribute) =>
+            this.getAttributeInfo(/** @type {string} */ (attribute.specifier));
+
         this.#sampleView.compositeAttributeInfoSource.addAttributeInfoSource(
             SAMPLE_ATTRIBUTE,
-            (attribute) =>
-                this.getAttributeInfo(
-                    /** @type {string} */ (attribute.specifier)
-                )
+            this.#attributeInfoSource
         );
 
         this.#unsubscribe = subscribeTo(
@@ -623,6 +628,10 @@ export class MetadataView extends ConcatView {
     dispose() {
         super.dispose();
         this.#unsubscribe();
+        this.#sampleView.compositeAttributeInfoSource.removeAttributeInfoSource(
+            SAMPLE_ATTRIBUTE,
+            this.#attributeInfoSource
+        );
         this.#highlightTarget.removeInteractionEventListener(
             "mousemove",
             this.#highlightTargetListener

--- a/packages/app/src/sampleView/metadata/metadataView.js
+++ b/packages/app/src/sampleView/metadata/metadataView.js
@@ -294,7 +294,6 @@ export class MetadataView extends ConcatView {
         this.#metadata = sampleMetadata.entities;
 
         const flow = this.context.dataFlow;
-        flow.removeHost(this);
 
         const metadataGeneration = ++this.#metadataGeneration;
 

--- a/packages/app/src/sampleView/metadata/metadataView.js
+++ b/packages/app/src/sampleView/metadata/metadataView.js
@@ -302,9 +302,12 @@ export class MetadataView extends ConcatView {
 
         const { dataSources, graphicsPromises } = initializeSubtree(this, flow);
 
+        const flowHandle = this.flowHandle;
         const dynamicSource =
             /** @type {import("@genome-spy/core/data/sources/namedSource.js").default} */ (
-                flow.findDataSourceByKey(this)
+                flowHandle && flowHandle.dataSource
+                    ? flowHandle.dataSource
+                    : flow.findDataSourceByKey(this)
             );
 
         if (!dynamicSource) {

--- a/packages/app/src/sampleView/metadata/metadataView.js
+++ b/packages/app/src/sampleView/metadata/metadataView.js
@@ -268,8 +268,7 @@ export class MetadataView extends ConcatView {
         this.#metadata = sampleMetadata.entities;
 
         const flow = this.context.dataFlow;
-        const previousViews = this.getDescendants();
-        flow.removeHosts(previousViews);
+        flow.removeHost(this);
 
         const metadataGeneration = ++this.#metadataGeneration;
 

--- a/packages/app/src/sampleView/metadata/metadataView.js
+++ b/packages/app/src/sampleView/metadata/metadataView.js
@@ -302,16 +302,13 @@ export class MetadataView extends ConcatView {
 
         const { dataSources, graphicsPromises } = initializeSubtree(this, flow);
 
-        const flowHandle = this.flowHandle;
         const dynamicSource =
             /** @type {import("@genome-spy/core/data/sources/namedSource.js").default} */ (
-                flowHandle && flowHandle.dataSource
-                    ? flowHandle.dataSource
-                    : flow.findDataSourceByKey(this)
+                this.flowHandle?.dataSource
             );
 
         if (!dynamicSource) {
-            throw new Error("Cannot find metadata data source!");
+            throw new Error("Cannot find metadata data source handle!");
         }
 
         finalizeSubtreeGraphics(

--- a/packages/app/src/sampleView/metadata/metadataView.js
+++ b/packages/app/src/sampleView/metadata/metadataView.js
@@ -47,6 +47,8 @@ export class MetadataView extends ConcatView {
      */
     #attributeViews = new Map();
 
+    #metadataGeneration = 0;
+
     /** @type {WeakMap<View, string>} */
     #viewToAttribute = new WeakMap();
 
@@ -270,6 +272,8 @@ export class MetadataView extends ConcatView {
         this.disposeSubtree();
         flow.removeHosts(previousViews);
 
+        const metadataGeneration = ++this.#metadataGeneration;
+
         this.#createViews();
 
         buildDataFlow(this, flow);
@@ -308,6 +312,9 @@ export class MetadataView extends ConcatView {
         });
 
         Promise.allSettled(promises).then((results) => {
+            if (metadataGeneration !== this.#metadataGeneration) {
+                return;
+            }
             for (const result of results) {
                 if ("value" in result) {
                     result.value.finalizeGraphicsInitialization();

--- a/packages/app/src/sampleView/metadata/metadataView.js
+++ b/packages/app/src/sampleView/metadata/metadataView.js
@@ -18,7 +18,7 @@ import {
     checkForDuplicateScaleNames,
     finalizeSubtreeGraphics,
 } from "@genome-spy/core/view/viewUtils.js";
-import { initializeSubtree } from "@genome-spy/core/data/flowInit.js";
+import { initializeViewSubtree } from "@genome-spy/core/data/flowInit.js";
 import { subscribeTo } from "../../state/subscribeTo.js";
 import { buildPathTree, METADATA_PATH_SEPARATOR } from "./metadataUtils.js";
 import { splitPath } from "../../utils/escapeSeparator.js";
@@ -299,7 +299,10 @@ export class MetadataView extends ConcatView {
 
         this.#createViews();
 
-        const { dataSources, graphicsPromises } = initializeSubtree(this, flow);
+        const { dataSources, graphicsPromises } = initializeViewSubtree(
+            this,
+            flow
+        );
 
         const dynamicSource =
             /** @type {import("@genome-spy/core/data/sources/namedSource.js").default} */ (

--- a/packages/app/src/sampleView/metadata/metadataView.js
+++ b/packages/app/src/sampleView/metadata/metadataView.js
@@ -16,6 +16,7 @@ import { ActionCreators } from "redux-undo";
 import { contextMenu, DIVIDER } from "../../utils/ui/contextMenu.js";
 import {
     checkForDuplicateScaleNames,
+    finalizeSubtreeGraphics,
     initializeSubtree,
 } from "@genome-spy/core/view/viewUtils.js";
 import { subscribeTo } from "../../state/subscribeTo.js";
@@ -287,21 +288,10 @@ export class MetadataView extends ConcatView {
             throw new Error("Cannot find metadata data source!");
         }
 
-        Promise.allSettled(graphicsPromises).then((results) => {
-            if (metadataGeneration !== this.#metadataGeneration) {
-                return;
-            }
-            for (const result of results) {
-                if ("value" in result) {
-                    result.value.finalizeGraphicsInitialization();
-                } else if ("reason" in result) {
-                    console.error(result.reason);
-                }
-            }
-            // TODO: Ensure that the views are rendered after finalization:
-            // this.context.animator.requestRender();
-            // But also ensure that the cached batch is invalidated
-        });
+        finalizeSubtreeGraphics(
+            graphicsPromises,
+            () => metadataGeneration === this.#metadataGeneration
+        );
 
         const sampleEntities =
             this.#sampleView.sampleHierarchy.sampleData.entities;

--- a/packages/app/src/sampleView/metadata/metadataView.js
+++ b/packages/app/src/sampleView/metadata/metadataView.js
@@ -269,7 +269,6 @@ export class MetadataView extends ConcatView {
 
         const flow = this.context.dataFlow;
         const previousViews = this.getDescendants();
-        this.disposeSubtree();
         flow.removeHosts(previousViews);
 
         const metadataGeneration = ++this.#metadataGeneration;

--- a/packages/app/src/sampleView/metadata/metadataView.test.js
+++ b/packages/app/src/sampleView/metadata/metadataView.test.js
@@ -161,14 +161,30 @@ describe("MetadataView", () => {
                 .SAMPLE_ATTRIBUTE
         ).toBeDefined();
 
-        const getFlowSnapshot = () => ({
-            dataSources: dataFlow._dataSourcesByHost.size,
-            collectors: dataFlow._collectorsByHost.size,
-            observers: dataFlow._observers.size,
-            unitViews: metadataView
+        const getFlowSnapshot = () => {
+            const unitViews = metadataView
                 .getDescendants()
-                .filter((view) => view instanceof UnitView).length,
-        });
+                .filter((view) => view instanceof UnitView);
+            const firstUnitView = unitViews[0];
+
+            const hasCollector =
+                !!firstUnitView &&
+                !!firstUnitView.flowHandle &&
+                !!firstUnitView.flowHandle.collector;
+
+            const hasDataSource =
+                !!metadataView.flowHandle &&
+                !!metadataView.flowHandle.dataSource;
+
+            return {
+                dataSources: dataFlow._dataSourcesByHost.size,
+                collectors: dataFlow._collectorsByHost.size,
+                observers: dataFlow._observers.size,
+                unitViews: unitViews.length,
+                hasCollector,
+                hasDataSource,
+            };
+        };
 
         /**
          * @param {string[]} attributeNames
@@ -204,6 +220,8 @@ describe("MetadataView", () => {
         const initialSnapshot = getFlowSnapshot();
         assertFlowMatchesSubtree(metadataView, context.dataFlow);
         expect(dataFlow.findDataSourceByKey(metadataView)).toBeDefined();
+        expect(initialSnapshot.hasCollector).toBe(true);
+        expect(initialSnapshot.hasDataSource).toBe(true);
 
         updateMetadata(["a"], {
             s1: { a: "x" },
@@ -216,6 +234,8 @@ describe("MetadataView", () => {
         expect(reducedSnapshot.unitViews).toBeLessThan(
             initialSnapshot.unitViews
         );
+        expect(reducedSnapshot.hasCollector).toBe(true);
+        expect(reducedSnapshot.hasDataSource).toBe(true);
 
         updateMetadata(["a"], {
             s1: { a: "z" },

--- a/packages/app/src/sampleView/metadata/metadataView.test.js
+++ b/packages/app/src/sampleView/metadata/metadataView.test.js
@@ -96,8 +96,8 @@ function assertFlowMatchesSubtree(metadataView, dataFlow) {
     const unitViews = descendants.filter((view) => view instanceof UnitView);
     const dataSources = dataFlow.getDataSourcesForHosts(descendants);
 
-    expect(dataFlow._dataSourcesByHost.size).toBe(dataSources.length);
-    expect(dataFlow._collectorsByHost.size).toBe(unitViews.length);
+    expect(dataFlow.getDataSourceHostCount()).toBe(dataSources.length);
+    expect(dataFlow.getCollectorHostCount()).toBe(unitViews.length);
     expect(dataFlow._observers.size).toBe(unitViews.length);
 }
 
@@ -177,8 +177,8 @@ describe("MetadataView", () => {
                 !!metadataView.flowHandle.dataSource;
 
             return {
-                dataSources: dataFlow._dataSourcesByHost.size,
-                collectors: dataFlow._collectorsByHost.size,
+                dataSources: dataFlow.getDataSourceHostCount(),
+                collectors: dataFlow.getCollectorHostCount(),
                 observers: dataFlow._observers.size,
                 unitViews: unitViews.length,
                 hasCollector,

--- a/packages/app/src/sampleView/metadata/metadataView.test.js
+++ b/packages/app/src/sampleView/metadata/metadataView.test.js
@@ -10,6 +10,7 @@ vi.mock("../attributeContextMenu.js", () => ({ default: () => [] }));
  * @typedef {object} StoreStub
  * @prop {() => any} getState
  * @prop {(listener: () => void) => () => void} subscribe
+ * @prop {() => number} getListenerCount
  * @prop {(nextState: any) => void} setState
  */
 
@@ -48,6 +49,7 @@ function createStore(initialState) {
             listeners.add(listener);
             return () => listeners.delete(listener);
         },
+        getListenerCount: () => listeners.size,
         setState: (nextState) => {
             state = nextState;
             for (const listener of Array.from(listeners)) {
@@ -154,6 +156,7 @@ describe("MetadataView", () => {
 
         const sampleView = createSampleView(context, store, sampleHierarchy);
         const metadataView = new MetadataView(sampleView, sampleView);
+        expect(store.getListenerCount()).toBe(1);
 
         const getFlowSnapshot = () => ({
             dataSources: dataFlow._dataSourcesByHost.size,
@@ -230,5 +233,8 @@ describe("MetadataView", () => {
         assertFlowMatchesSubtree(metadataView, context.dataFlow);
         expect(dataFlow.findDataSourceByKey(metadataView)).toBeDefined();
         expect(restoredSnapshot).toEqual(initialSnapshot);
+
+        metadataView.dispose();
+        expect(store.getListenerCount()).toBe(0);
     });
 });

--- a/packages/app/src/sampleView/metadata/metadataView.test.js
+++ b/packages/app/src/sampleView/metadata/metadataView.test.js
@@ -105,7 +105,7 @@ function assertFlowMatchesSubtree(metadataView, dataFlow) {
             .filter((collector) => collector)
     );
     const observerCount = [...collectors].reduce(
-        (sum, collector) => sum + collector.observers.length,
+        (sum, collector) => sum + collector.observers.size,
         0
     );
 
@@ -190,8 +190,7 @@ describe("MetadataView", () => {
                 collectors: dataFlow.collectors.length,
                 observers: unitViews.reduce(
                     (sum, view) =>
-                        sum +
-                        (view.flowHandle?.collector?.observers.length ?? 0),
+                        sum + (view.flowHandle?.collector?.observers.size ?? 0),
                     0
                 ),
                 unitViews: unitViews.length,

--- a/packages/app/src/sampleView/metadata/metadataView.test.js
+++ b/packages/app/src/sampleView/metadata/metadataView.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import ConcatView from "@genome-spy/core/view/concatView.js";
 import UnitView from "@genome-spy/core/view/unitView.js";
 import { createTestViewContext } from "@genome-spy/core/view/testUtils.js";
+import CompositeAttributeInfoSource from "../compositeAttributeInfoSource.js";
 
 vi.mock("../attributeContextMenu.js", () => ({ default: () => [] }));
 
@@ -24,7 +25,7 @@ vi.mock("../attributeContextMenu.js", () => ({ default: () => [] }));
  * @typedef {import("@genome-spy/core/view/concatView.js").default & {
  *   spec: { samples: import("@genome-spy/core/spec/sampleView.js").SampleDef },
  *   sampleHierarchy: SampleHierarchyStub,
- *   compositeAttributeInfoSource: { addAttributeInfoSource: (name: string, resolver: (attribute: any) => any) => void },
+ *   compositeAttributeInfoSource: { addAttributeInfoSource: (name: string, resolver: (attribute: any) => any) => void, removeAttributeInfoSource: (name: string, resolver?: (attribute: any) => any) => void, attributeInfoSourcesByType: Record<string, any> },
  *   provenance: { store: StoreStub, getPresentState: () => any },
  *   locationManager: { clipBySummary: (coords: import("@genome-spy/core/view/layout/rectangle.js").default) => import("@genome-spy/core/view/layout/rectangle.js").default },
  *   findSampleForMouseEvent: (coords: import("@genome-spy/core/view/layout/rectangle.js").default, event: any) => any,
@@ -70,9 +71,7 @@ function createSampleView(context, store, sampleHierarchy) {
 
     view.spec = { samples: {} };
     view.sampleHierarchy = sampleHierarchy;
-    view.compositeAttributeInfoSource = {
-        addAttributeInfoSource: () => undefined,
-    };
+    view.compositeAttributeInfoSource = new CompositeAttributeInfoSource();
     view.provenance = {
         store,
         getPresentState: () => ({}),
@@ -157,6 +156,10 @@ describe("MetadataView", () => {
         const sampleView = createSampleView(context, store, sampleHierarchy);
         const metadataView = new MetadataView(sampleView, sampleView);
         expect(store.getListenerCount()).toBe(1);
+        expect(
+            sampleView.compositeAttributeInfoSource.attributeInfoSourcesByType
+                .SAMPLE_ATTRIBUTE
+        ).toBeDefined();
 
         const getFlowSnapshot = () => ({
             dataSources: dataFlow._dataSourcesByHost.size,
@@ -236,5 +239,9 @@ describe("MetadataView", () => {
 
         metadataView.dispose();
         expect(store.getListenerCount()).toBe(0);
+        expect(
+            sampleView.compositeAttributeInfoSource.attributeInfoSourcesByType
+                .SAMPLE_ATTRIBUTE
+        ).toBeUndefined();
     });
 });

--- a/packages/app/src/sampleView/metadata/metadataView.test.js
+++ b/packages/app/src/sampleView/metadata/metadataView.test.js
@@ -219,7 +219,6 @@ describe("MetadataView", () => {
 
         const initialSnapshot = getFlowSnapshot();
         assertFlowMatchesSubtree(metadataView, context.dataFlow);
-        expect(dataFlow.findDataSourceByKey(metadataView)).toBeDefined();
         expect(initialSnapshot.hasCollector).toBe(true);
         expect(initialSnapshot.hasDataSource).toBe(true);
 
@@ -230,7 +229,6 @@ describe("MetadataView", () => {
 
         const reducedSnapshot = getFlowSnapshot();
         assertFlowMatchesSubtree(metadataView, context.dataFlow);
-        expect(dataFlow.findDataSourceByKey(metadataView)).toBeDefined();
         expect(reducedSnapshot.unitViews).toBeLessThan(
             initialSnapshot.unitViews
         );
@@ -244,7 +242,6 @@ describe("MetadataView", () => {
 
         const stableSnapshot = getFlowSnapshot();
         assertFlowMatchesSubtree(metadataView, context.dataFlow);
-        expect(dataFlow.findDataSourceByKey(metadataView)).toBeDefined();
         expect(stableSnapshot).toEqual(reducedSnapshot);
 
         updateMetadata(["a", "b"], {
@@ -254,7 +251,6 @@ describe("MetadataView", () => {
 
         const restoredSnapshot = getFlowSnapshot();
         assertFlowMatchesSubtree(metadataView, context.dataFlow);
-        expect(dataFlow.findDataSourceByKey(metadataView)).toBeDefined();
         expect(restoredSnapshot).toEqual(initialSnapshot);
 
         metadataView.dispose();

--- a/packages/app/src/sampleView/metadata/metadataView.test.js
+++ b/packages/app/src/sampleView/metadata/metadataView.test.js
@@ -132,10 +132,6 @@ describe("MetadataView", () => {
         context.getNamedDataFromProvider = () => [];
 
         const dataFlow = context.dataFlow;
-        const addObserver = dataFlow.addObserver.bind(dataFlow);
-        dataFlow.addObserver = (collector, callback, handle) => {
-            addObserver(collector, () => undefined, handle);
-        };
 
         const store = createStore({
             provenance: {

--- a/packages/app/src/sampleView/metadata/metadataView.test.js
+++ b/packages/app/src/sampleView/metadata/metadataView.test.js
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from "vitest";
+
+import ConcatView from "@genome-spy/core/view/concatView.js";
+import UnitView from "@genome-spy/core/view/unitView.js";
+import { createTestViewContext } from "@genome-spy/core/view/testUtils.js";
+
+vi.mock("../attributeContextMenu.js", () => ({ default: () => [] }));
+
+/**
+ * @typedef {object} StoreStub
+ * @prop {() => any} getState
+ * @prop {(listener: () => void) => () => void} subscribe
+ * @prop {(nextState: any) => void} setState
+ */
+
+/**
+ * @typedef {object} SampleHierarchyStub
+ * @prop {{ attributeNames: string[], attributeDefs: Record<string, any>, entities: Record<string, any> }} sampleMetadata
+ * @prop {{ entities: Record<string, { indexNumber: number }> }} sampleData
+ */
+
+/**
+ * @typedef {import("@genome-spy/core/view/concatView.js").default & {
+ *   spec: { samples: import("@genome-spy/core/spec/sampleView.js").SampleDef },
+ *   sampleHierarchy: SampleHierarchyStub,
+ *   compositeAttributeInfoSource: { addAttributeInfoSource: (name: string, resolver: (attribute: any) => any) => void },
+ *   provenance: { store: StoreStub, getPresentState: () => any },
+ *   locationManager: { clipBySummary: (coords: import("@genome-spy/core/view/layout/rectangle.js").default) => import("@genome-spy/core/view/layout/rectangle.js").default },
+ *   findSampleForMouseEvent: (coords: import("@genome-spy/core/view/layout/rectangle.js").default, event: any) => any,
+ *   makePeekMenuItem: () => any,
+ *   actions: { filterByNominal: any },
+ *   dispatchAttributeAction: (action: any) => void,
+ * }} SampleViewStub
+ */
+
+/**
+ * @param {any} initialState
+ * @returns {StoreStub}
+ */
+function createStore(initialState) {
+    let state = initialState;
+    /** @type {Set<() => void>} */
+    const listeners = new Set();
+
+    return {
+        getState: () => state,
+        subscribe: (listener) => {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+        },
+        setState: (nextState) => {
+            state = nextState;
+            for (const listener of Array.from(listeners)) {
+                listener();
+            }
+        },
+    };
+}
+
+/**
+ * @param {import("@genome-spy/core/types/viewContext.js").default} context
+ * @param {StoreStub} store
+ * @param {SampleHierarchyStub} sampleHierarchy
+ * @returns {SampleViewStub}
+ */
+function createSampleView(context, store, sampleHierarchy) {
+    const view = new ConcatView({ hconcat: [] }, context, null, null, "sample");
+
+    view.spec = { samples: {} };
+    view.sampleHierarchy = sampleHierarchy;
+    view.compositeAttributeInfoSource = {
+        addAttributeInfoSource: () => undefined,
+    };
+    view.provenance = {
+        store,
+        getPresentState: () => ({}),
+    };
+    view.locationManager = {
+        clipBySummary: (coords) => coords,
+    };
+    view.findSampleForMouseEvent = () => undefined;
+    view.makePeekMenuItem = () => ({});
+    view.actions = { filterByNominal: () => ({}) };
+    view.dispatchAttributeAction = () => undefined;
+
+    return /** @type {SampleViewStub} */ (view);
+}
+
+/**
+ * @param {import("./metadataView.js").MetadataView} metadataView
+ * @param {import("@genome-spy/core/data/dataFlow.js").default} dataFlow
+ */
+function assertFlowMatchesSubtree(metadataView, dataFlow) {
+    const descendants = metadataView.getDescendants();
+    const unitViews = descendants.filter((view) => view instanceof UnitView);
+    const dataSources = dataFlow.getDataSourcesForHosts(descendants);
+
+    expect(dataFlow._dataSourcesByHost.size).toBe(dataSources.length);
+    expect(dataFlow._collectorsByHost.size).toBe(unitViews.length);
+    expect(dataFlow._observers.size).toBe(unitViews.length);
+}
+
+describe("MetadataView", () => {
+    it("removes dataflow hosts when metadata is rebuilt", async () => {
+        const { MetadataView } = await import("./metadataView.js");
+        const context = createTestViewContext();
+        context.animator = {
+            transition: () => Promise.resolve(),
+            requestRender: () => undefined,
+        };
+        context.requestLayoutReflow = () => undefined;
+        context.updateTooltip = () => undefined;
+        context.getCurrentHover = () => undefined;
+        context.addKeyboardListener = () => undefined;
+        context.addBroadcastListener = () => undefined;
+        context.removeBroadcastListener = () => undefined;
+        context.setDataLoadingStatus = () => undefined;
+        context.getNamedDataFromProvider = () => [];
+
+        const dataFlow = context.dataFlow;
+        const addObserver = dataFlow.addObserver.bind(dataFlow);
+        dataFlow.addObserver = (callback, key) => {
+            addObserver(() => undefined, key);
+        };
+
+        const store = createStore({
+            provenance: {
+                present: {
+                    sampleView: {
+                        sampleMetadata: {
+                            attributeNames: [],
+                            attributeDefs: {},
+                            entities: {},
+                        },
+                    },
+                },
+            },
+        });
+
+        /** @type {SampleHierarchyStub} */
+        const sampleHierarchy = {
+            sampleMetadata: {
+                attributeNames: [],
+                attributeDefs: {},
+                entities: {},
+            },
+            sampleData: {
+                entities: {
+                    s1: { indexNumber: 0 },
+                    s2: { indexNumber: 1 },
+                },
+            },
+        };
+
+        const sampleView = createSampleView(context, store, sampleHierarchy);
+        const metadataView = new MetadataView(sampleView, sampleView);
+
+        const getFlowSnapshot = () => ({
+            dataSources: dataFlow._dataSourcesByHost.size,
+            collectors: dataFlow._collectorsByHost.size,
+            observers: dataFlow._observers.size,
+            unitViews: metadataView
+                .getDescendants()
+                .filter((view) => view instanceof UnitView).length,
+        });
+
+        /**
+         * @param {string[]} attributeNames
+         * @param {Record<string, any>} entities
+         */
+        const updateMetadata = (attributeNames, entities) => {
+            const attributeDefs = Object.fromEntries(
+                attributeNames.map((name) => [name, { type: "nominal" }])
+            );
+            const sampleMetadata = {
+                attributeNames,
+                attributeDefs,
+                entities,
+            };
+
+            sampleView.sampleHierarchy.sampleMetadata = sampleMetadata;
+            store.setState({
+                provenance: {
+                    present: {
+                        sampleView: {
+                            sampleMetadata,
+                        },
+                    },
+                },
+            });
+        };
+
+        updateMetadata(["a", "b"], {
+            s1: { a: "x", b: 1 },
+            s2: { a: "y", b: 2 },
+        });
+
+        const initialSnapshot = getFlowSnapshot();
+        assertFlowMatchesSubtree(metadataView, context.dataFlow);
+        expect(dataFlow.findDataSourceByKey(metadataView)).toBeDefined();
+
+        updateMetadata(["a"], {
+            s1: { a: "x" },
+            s2: { a: "y" },
+        });
+
+        const reducedSnapshot = getFlowSnapshot();
+        assertFlowMatchesSubtree(metadataView, context.dataFlow);
+        expect(dataFlow.findDataSourceByKey(metadataView)).toBeDefined();
+        expect(reducedSnapshot.unitViews).toBeLessThan(
+            initialSnapshot.unitViews
+        );
+
+        updateMetadata(["a"], {
+            s1: { a: "z" },
+            s2: { a: "w" },
+        });
+
+        const stableSnapshot = getFlowSnapshot();
+        assertFlowMatchesSubtree(metadataView, context.dataFlow);
+        expect(dataFlow.findDataSourceByKey(metadataView)).toBeDefined();
+        expect(stableSnapshot).toEqual(reducedSnapshot);
+
+        updateMetadata(["a", "b"], {
+            s1: { a: "x", b: 3 },
+            s2: { a: "y", b: 4 },
+        });
+
+        const restoredSnapshot = getFlowSnapshot();
+        assertFlowMatchesSubtree(metadataView, context.dataFlow);
+        expect(dataFlow.findDataSourceByKey(metadataView)).toBeDefined();
+        expect(restoredSnapshot).toEqual(initialSnapshot);
+    });
+});

--- a/packages/app/src/sampleView/metadata/metadataView.test.js
+++ b/packages/app/src/sampleView/metadata/metadataView.test.js
@@ -1,91 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 
-import ConcatView from "@genome-spy/core/view/concatView.js";
 import UnitView from "@genome-spy/core/view/unitView.js";
 import { createTestViewContext } from "@genome-spy/core/view/testUtils.js";
-import CompositeAttributeInfoSource from "../compositeAttributeInfoSource.js";
+import {
+    createSampleViewStub,
+    createStoreStub,
+} from "../../testUtils/appTestUtils.js";
 
 vi.mock("../attributeContextMenu.js", () => ({ default: () => [] }));
-
-/**
- * @typedef {object} StoreStub
- * @prop {() => any} getState
- * @prop {(listener: () => void) => () => void} subscribe
- * @prop {() => number} getListenerCount
- * @prop {(nextState: any) => void} setState
- */
 
 /**
  * @typedef {object} SampleHierarchyStub
  * @prop {{ attributeNames: string[], attributeDefs: Record<string, any>, entities: Record<string, any> }} sampleMetadata
  * @prop {{ entities: Record<string, { indexNumber: number }> }} sampleData
  */
-
-/**
- * @typedef {import("@genome-spy/core/view/concatView.js").default & {
- *   spec: { samples: import("@genome-spy/core/spec/sampleView.js").SampleDef },
- *   sampleHierarchy: SampleHierarchyStub,
- *   compositeAttributeInfoSource: { addAttributeInfoSource: (name: string, resolver: (attribute: any) => any) => void, removeAttributeInfoSource: (name: string, resolver?: (attribute: any) => any) => void, attributeInfoSourcesByType: Record<string, any> },
- *   provenance: { store: StoreStub, getPresentState: () => any },
- *   locationManager: { clipBySummary: (coords: import("@genome-spy/core/view/layout/rectangle.js").default) => import("@genome-spy/core/view/layout/rectangle.js").default },
- *   findSampleForMouseEvent: (coords: import("@genome-spy/core/view/layout/rectangle.js").default, event: any) => any,
- *   makePeekMenuItem: () => any,
- *   actions: { filterByNominal: any },
- *   dispatchAttributeAction: (action: any) => void,
- * }} SampleViewStub
- */
-
-/**
- * @param {any} initialState
- * @returns {StoreStub}
- */
-function createStore(initialState) {
-    let state = initialState;
-    /** @type {Set<() => void>} */
-    const listeners = new Set();
-
-    return {
-        getState: () => state,
-        subscribe: (listener) => {
-            listeners.add(listener);
-            return () => listeners.delete(listener);
-        },
-        getListenerCount: () => listeners.size,
-        setState: (nextState) => {
-            state = nextState;
-            for (const listener of Array.from(listeners)) {
-                listener();
-            }
-        },
-    };
-}
-
-/**
- * @param {import("@genome-spy/core/types/viewContext.js").default} context
- * @param {StoreStub} store
- * @param {SampleHierarchyStub} sampleHierarchy
- * @returns {SampleViewStub}
- */
-function createSampleView(context, store, sampleHierarchy) {
-    const view = new ConcatView({ hconcat: [] }, context, null, null, "sample");
-
-    view.spec = { samples: {} };
-    view.sampleHierarchy = sampleHierarchy;
-    view.compositeAttributeInfoSource = new CompositeAttributeInfoSource();
-    view.provenance = {
-        store,
-        getPresentState: () => ({}),
-    };
-    view.locationManager = {
-        clipBySummary: (coords) => coords,
-    };
-    view.findSampleForMouseEvent = () => undefined;
-    view.makePeekMenuItem = () => ({});
-    view.actions = { filterByNominal: () => ({}) };
-    view.dispatchAttributeAction = () => undefined;
-
-    return /** @type {SampleViewStub} */ (view);
-}
 
 /**
  * @param {import("./metadataView.js").MetadataView} metadataView
@@ -133,7 +61,7 @@ describe("MetadataView", () => {
 
         const dataFlow = context.dataFlow;
 
-        const store = createStore({
+        const store = createStoreStub({
             provenance: {
                 present: {
                     sampleView: {
@@ -162,7 +90,11 @@ describe("MetadataView", () => {
             },
         };
 
-        const sampleView = createSampleView(context, store, sampleHierarchy);
+        const sampleView = createSampleViewStub({
+            context,
+            store,
+            sampleHierarchy,
+        });
         const metadataView = new MetadataView(sampleView, sampleView);
         expect(store.getListenerCount()).toBe(1);
         expect(

--- a/packages/app/src/sampleView/sampleGroupView.js
+++ b/packages/app/src/sampleView/sampleGroupView.js
@@ -203,7 +203,9 @@ export default class SampleGroupView extends LayerView {
 
         const dynamicSource =
             /** @type {import("@genome-spy/core/data/sources/namedSource.js").default} */ (
-                this.context.dataFlow.findDataSourceByKey(this)
+                this.flowHandle && this.flowHandle.dataSource
+                    ? this.flowHandle.dataSource
+                    : this.context.dataFlow.findDataSourceByKey(this)
             );
 
         if (!dynamicSource) {

--- a/packages/app/src/sampleView/sampleGroupView.js
+++ b/packages/app/src/sampleView/sampleGroupView.js
@@ -203,14 +203,11 @@ export default class SampleGroupView extends LayerView {
 
         const dynamicSource =
             /** @type {import("@genome-spy/core/data/sources/namedSource.js").default} */ (
-                this.flowHandle && this.flowHandle.dataSource
-                    ? this.flowHandle.dataSource
-                    : this.context.dataFlow.findDataSourceByKey(this)
+                this.flowHandle?.dataSource
             );
 
         if (!dynamicSource) {
-            // Why this happens? TODO: Investigate
-            return;
+            throw new Error("Cannot find sample group data source handle!");
         }
 
         const attributeTitles = this.#getAttributeTitles();

--- a/packages/app/src/sampleView/sampleLabelView.js
+++ b/packages/app/src/sampleView/sampleLabelView.js
@@ -70,10 +70,12 @@ export class SampleLabelView extends UnitView {
     #setSamples(samples) {
         const dynamicSource =
             /** @type {import("@genome-spy/core/data/sources/namedSource.js").default} */ (
-                this.flowHandle && this.flowHandle.dataSource
-                    ? this.flowHandle.dataSource
-                    : this.context.dataFlow.findDataSourceByKey(this)
+                this.flowHandle?.dataSource
             );
+
+        if (!dynamicSource) {
+            throw new Error("Cannot find sample label data source handle!");
+        }
 
         dynamicSource.updateDynamicData(
             // Make a copy because the state-derived data is immutable

--- a/packages/app/src/sampleView/sampleLabelView.js
+++ b/packages/app/src/sampleView/sampleLabelView.js
@@ -19,6 +19,14 @@ export class SampleLabelView extends UnitView {
     /** @type {import("./sampleView.js").default} */
     #sampleView;
 
+    /** @type {() => void} */
+    #unsubscribe = () => undefined;
+
+    /**
+     * @type {(identifier: import("./types.js").AttributeIdentifier) => import("./types.js").AttributeInfo}
+     */
+    #attributeInfoSource;
+
     /**
      * @param {import("./sampleView.js").default} sampleView
      * @param {import("@genome-spy/core/view/containerView.js").default} dataParent
@@ -34,9 +42,10 @@ export class SampleLabelView extends UnitView {
 
         this.#sampleView = sampleView;
 
+        this.#attributeInfoSource = () => SAMPLE_NAME_ATTRIBUTE_INFO;
         sampleView.compositeAttributeInfoSource.addAttributeInfoSource(
             SAMPLE_NAME,
-            (attribute) => SAMPLE_NAME_ATTRIBUTE_INFO
+            this.#attributeInfoSource
         );
 
         this.addInteractionEventListener(
@@ -45,7 +54,7 @@ export class SampleLabelView extends UnitView {
         );
 
         // TODO: Data could be inherited from the parent view
-        subscribeTo(
+        this.#unsubscribe = subscribeTo(
             sampleView.provenance.store,
             (state) => state.provenance.present.sampleView.sampleData,
             (sampleData) => {
@@ -99,6 +108,18 @@ export class SampleLabelView extends UnitView {
         );
 
         contextMenu({ items }, event.mouseEvent);
+    }
+
+    /**
+     * @override
+     */
+    dispose() {
+        super.dispose();
+        this.#unsubscribe();
+        this.#sampleView.compositeAttributeInfoSource.removeAttributeInfoSource(
+            SAMPLE_NAME,
+            this.#attributeInfoSource
+        );
     }
 }
 

--- a/packages/app/src/sampleView/sampleLabelView.js
+++ b/packages/app/src/sampleView/sampleLabelView.js
@@ -19,9 +19,6 @@ export class SampleLabelView extends UnitView {
     /** @type {import("./sampleView.js").default} */
     #sampleView;
 
-    /** @type {() => void} */
-    #unsubscribe = () => undefined;
-
     /**
      * @type {(identifier: import("./types.js").AttributeIdentifier) => import("./types.js").AttributeInfo}
      */
@@ -54,12 +51,14 @@ export class SampleLabelView extends UnitView {
         );
 
         // TODO: Data could be inherited from the parent view
-        this.#unsubscribe = subscribeTo(
-            sampleView.provenance.store,
-            (state) => state.provenance.present.sampleView.sampleData,
-            (sampleData) => {
-                this.#setSamples(Object.values(sampleData.entities));
-            }
+        this.registerDisposer(
+            subscribeTo(
+                sampleView.provenance.store,
+                (state) => state.provenance.present.sampleView.sampleData,
+                (sampleData) => {
+                    this.#setSamples(Object.values(sampleData.entities));
+                }
+            )
         );
     }
 
@@ -119,7 +118,6 @@ export class SampleLabelView extends UnitView {
      */
     dispose() {
         super.dispose();
-        this.#unsubscribe();
         this.#sampleView.compositeAttributeInfoSource.removeAttributeInfoSource(
             SAMPLE_NAME,
             this.#attributeInfoSource

--- a/packages/app/src/sampleView/sampleLabelView.js
+++ b/packages/app/src/sampleView/sampleLabelView.js
@@ -70,7 +70,9 @@ export class SampleLabelView extends UnitView {
     #setSamples(samples) {
         const dynamicSource =
             /** @type {import("@genome-spy/core/data/sources/namedSource.js").default} */ (
-                this.context.dataFlow.findDataSourceByKey(this)
+                this.flowHandle && this.flowHandle.dataSource
+                    ? this.flowHandle.dataSource
+                    : this.context.dataFlow.findDataSourceByKey(this)
             );
 
         dynamicSource.updateDynamicData(

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -466,9 +466,7 @@ export default class SampleView extends ContainerView {
         });
 
         // Synchronize loading with other data
-        const key = "samples " + this.getPathString();
-        // @ts-expect-error TODO: Using a string as key is ugly. Try something else.
-        this.context.dataFlow.addDataSource(dataSource, key);
+        this.context.dataFlow.addDataSource(dataSource);
     }
 
     #extractSamplesFromData() {

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -162,10 +162,18 @@ export default class SampleView extends ContainerView {
                 return;
             }
             const subtreeRoot = message.payload.subtreeRoot;
+            if (!this.#gridChild?.view) {
+                return;
+            }
             if (
-                subtreeRoot === this ||
-                subtreeRoot.getDataAncestors().includes(this)
+                subtreeRoot === this.#gridChild.view ||
+                this.#gridChild.view.getDataAncestors().includes(subtreeRoot)
             ) {
+                // Extract samples only from the main data subtree, not metadata/sidebar.
+                // TODO: Add a test that asserts subtreeDataReady from metadata does not
+                // trigger sample extraction.
+                // TODO: This assumes the main data subtree is fully loaded for all
+                // child views; if visibility gating changes, revisit this logic.
                 this.#extractSamplesFromData();
             }
         });

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -418,7 +418,7 @@ export default class SampleView extends ContainerView {
         // Here's quite a bit of wrangling but the number of samples is so low that
         // performance doesn't really matter.
 
-        collector.observers.push(() => {
+        const stop = collector.observe(() => {
             const result =
                 /** @type {{sample: Sample, attributes: import("./state/sampleState.js").Metadatum}[]} */ (
                     collector.getData()
@@ -464,6 +464,7 @@ export default class SampleView extends ContainerView {
                 );
             }
         });
+        this.registerDisposer(stop);
 
         // Synchronize loading with other data
         this.context.dataFlow.addDataSource(dataSource);

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -157,9 +157,6 @@ export default class SampleView extends ContainerView {
      * Setup broadcast handlers for lifecycle events
      */
     #setupBroadcastHandlers() {
-        this._addBroadcastHandler("dataLoaded", () =>
-            this.#extractSamplesFromData()
-        );
         this._addBroadcastHandler("subtreeDataReady", (message) => {
             if (!message.payload || !("subtreeRoot" in message.payload)) {
                 return;

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -160,6 +160,18 @@ export default class SampleView extends ContainerView {
         this._addBroadcastHandler("dataLoaded", () =>
             this.#extractSamplesFromData()
         );
+        this._addBroadcastHandler("subtreeDataReady", (message) => {
+            if (!message.payload || !("subtreeRoot" in message.payload)) {
+                return;
+            }
+            const subtreeRoot = message.payload.subtreeRoot;
+            if (
+                subtreeRoot === this ||
+                subtreeRoot.getDataAncestors().includes(this)
+            ) {
+                this.#extractSamplesFromData();
+            }
+        });
         this._addBroadcastHandler("layout", () => {
             this.locationManager.resetLocations();
         });

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -64,7 +64,7 @@ export default class SampleView extends ContainerView {
      * @typedef {import("@genome-spy/core/view/layout/flexLayout.js").LocSize} LocSize
      * @typedef {import("@genome-spy/core/view/view.js").default} View
      * @typedef {import("@genome-spy/core/view/layerView.js").default} LayerView
-     * @typedef {import("@genome-spy/core/data/dataFlow.js").default<View>} DataFlow
+     * @typedef {import("@genome-spy/core/data/dataFlow.js").default} DataFlow
      * @typedef {import("@genome-spy/core/genome/genome.js").ChromosomalLocus} ChromosomalLocus
      */
 

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -85,9 +85,6 @@ export default class SampleView extends ContainerView {
     /** @type {(action: import("@reduxjs/toolkit").PayloadAction<any>) => any} */
     #actionAugmenter;
 
-    /** @type {() => void} */
-    #unsubscribe = () => undefined;
-
     /**
      *
      * @param {import("@genome-spy/core/spec/sampleView.js").SampleSpec} spec
@@ -267,15 +264,17 @@ export default class SampleView extends ContainerView {
      * Setup subscriptions for provenance-driven updates.
      */
     #setupStoreSubscriptions() {
-        this.#unsubscribe = subscribeTo(
-            this.provenance.store,
-            () => this.sampleHierarchy.rootGroup,
-            withMicrotask(() => {
-                this.locationManager.reset();
-                this.sampleGroupView?.updateGroups();
-                this.context.requestLayoutReflow();
-                this.context.animator.requestRender();
-            })
+        this.registerDisposer(
+            subscribeTo(
+                this.provenance.store,
+                () => this.sampleHierarchy.rootGroup,
+                withMicrotask(() => {
+                    this.locationManager.reset();
+                    this.sampleGroupView?.updateGroups();
+                    this.context.requestLayoutReflow();
+                    this.context.animator.requestRender();
+                })
+            )
         );
     }
 
@@ -981,7 +980,6 @@ export default class SampleView extends ContainerView {
      */
     dispose() {
         super.dispose();
-        this.#unsubscribe();
         this.intentExecutor.removeActionAugmenter(this.#actionAugmenter);
     }
 }

--- a/packages/app/src/sampleView/sampleView.test.js
+++ b/packages/app/src/sampleView/sampleView.test.js
@@ -9,34 +9,11 @@ vi.mock("@fortawesome/free-solid-svg-icons", async (importOriginal) => ({
     __esModule: true,
     ...(await importOriginal()),
 }));
-import { createTestViewContext } from "@genome-spy/core/view/testUtils.js";
-import { initializeViewSubtree } from "@genome-spy/core/data/flowInit.js";
-import SampleView from "./sampleView.js";
-import setupStore from "../state/setupStore.js";
-import IntentExecutor from "../state/intentExecutor.js";
-import Provenance from "../state/provenance.js";
+import { createSampleViewForTest } from "../testUtils/appTestUtils.js";
 import { SAMPLE_SLICE_NAME } from "./state/sampleSlice.js";
 
 describe("SampleView", () => {
     test("extracts samples from main data subtree on subtreeDataReady", async () => {
-        const context = createTestViewContext();
-        context.animator = {
-            transition: () => Promise.resolve(),
-            requestRender: () => undefined,
-        };
-        context.requestLayoutReflow = () => undefined;
-        context.updateTooltip = () => undefined;
-        context.getCurrentHover = () => undefined;
-        context.addKeyboardListener = () => undefined;
-        context.addBroadcastListener = () => undefined;
-        context.removeBroadcastListener = () => undefined;
-        context.setDataLoadingStatus = () => undefined;
-        context.glHelper = undefined;
-
-        const store = setupStore();
-        const intentExecutor = new IntentExecutor(store);
-        const provenance = new Provenance(store, intentExecutor);
-
         /** @type {import("@genome-spy/core/spec/sampleView.js").SampleSpec} */
         const spec = {
             data: {
@@ -55,19 +32,10 @@ describe("SampleView", () => {
             },
         };
 
-        const view = new SampleView(
+        const { view, store } = await createSampleViewForTest({
             spec,
-            context,
-            null,
-            null,
-            "samples",
-            provenance,
-            intentExecutor
-        );
-
-        await view.initializeChildren();
-        initializeViewSubtree(view, context.dataFlow);
-        view.sampleGroupView.updateGroups = () => undefined;
+            disableGroupUpdates: true,
+        });
 
         // Ensure sample extraction relies on a predictable domain for the test.
         view.getScaleResolution = () =>

--- a/packages/app/src/sampleView/sampleView.test.js
+++ b/packages/app/src/sampleView/sampleView.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@fortawesome/fontawesome-svg-core", () => ({
+    icon: () => ({ node: [""] }),
+    dom: { css: () => "" },
+}));
+
+vi.mock("@fortawesome/free-solid-svg-icons", async (importOriginal) => ({
+    __esModule: true,
+    ...(await importOriginal()),
+}));
+import { createTestViewContext } from "@genome-spy/core/view/testUtils.js";
+import { initializeViewSubtree } from "@genome-spy/core/data/flowInit.js";
+import SampleView from "./sampleView.js";
+import setupStore from "../state/setupStore.js";
+import IntentExecutor from "../state/intentExecutor.js";
+import Provenance from "../state/provenance.js";
+import { SAMPLE_SLICE_NAME } from "./state/sampleSlice.js";
+
+describe("SampleView", () => {
+    test("extracts samples from main data subtree on subtreeDataReady", async () => {
+        const context = createTestViewContext();
+        context.animator = {
+            transition: () => Promise.resolve(),
+            requestRender: () => undefined,
+        };
+        context.requestLayoutReflow = () => undefined;
+        context.updateTooltip = () => undefined;
+        context.getCurrentHover = () => undefined;
+        context.addKeyboardListener = () => undefined;
+        context.addBroadcastListener = () => undefined;
+        context.removeBroadcastListener = () => undefined;
+        context.setDataLoadingStatus = () => undefined;
+        context.glHelper = undefined;
+
+        const store = setupStore();
+        const intentExecutor = new IntentExecutor(store);
+        const provenance = new Provenance(store, intentExecutor);
+
+        /** @type {import("@genome-spy/core/spec/sampleView.js").SampleSpec} */
+        const spec = {
+            data: {
+                values: [
+                    { sample: "A", x: 1 },
+                    { sample: "B", x: 2 },
+                ],
+            },
+            samples: {},
+            spec: {
+                mark: "point",
+                encoding: {
+                    sample: { field: "sample" },
+                    x: { field: "x", type: "quantitative" },
+                },
+            },
+        };
+
+        const view = new SampleView(
+            spec,
+            context,
+            null,
+            null,
+            "samples",
+            provenance,
+            intentExecutor
+        );
+
+        await view.initializeChildren();
+        initializeViewSubtree(view, context.dataFlow);
+        view.sampleGroupView.updateGroups = () => undefined;
+
+        // Ensure sample extraction relies on a predictable domain for the test.
+        view.getScaleResolution = () =>
+            /** @type {import("@genome-spy/core/view/scaleResolution.js").default} */ (
+                /** @type {unknown} */ ({
+                    getDataDomain: () => ["A", "B"],
+                })
+            );
+
+        // Guard that subtree readiness triggers sample extraction when no metadata ids exist.
+        view.handleBroadcast({
+            type: "subtreeDataReady",
+            payload: { subtreeRoot: view },
+        });
+
+        const state = store.getState().provenance.present?.[SAMPLE_SLICE_NAME];
+        expect(state?.sampleData?.ids).toEqual(["A", "B"]);
+    });
+});

--- a/packages/app/src/testUtils/appTestUtils.js
+++ b/packages/app/src/testUtils/appTestUtils.js
@@ -42,10 +42,15 @@ export function createAppTestContext(options = {}) {
     const intentExecutor = new IntentExecutor(store);
     const provenance = new Provenance(store, intentExecutor);
 
-    context.animator = {
-        transition: () => Promise.resolve(),
-        requestRender: () => undefined,
-    };
+    context.animator =
+        /** @type {import("@genome-spy/core/utils/animator.js").default} */ (
+            /** @type {any} */ ({
+                transition: /** @type {() => Promise<void>} */ (
+                    () => Promise.resolve()
+                ),
+                requestRender: /** @type {() => void} */ (() => undefined),
+            })
+        );
     context.requestLayoutReflow = () => undefined;
     context.updateTooltip = () => undefined;
     context.getCurrentHover = () => undefined;
@@ -105,22 +110,30 @@ export function createSampleViewStub(options) {
         "sample"
     );
 
-    view.spec = { samples: {} };
-    view.sampleHierarchy = options.sampleHierarchy;
-    view.compositeAttributeInfoSource = new CompositeAttributeInfoSource();
-    view.provenance = {
+    const sampleView = /** @type {SampleViewStub} */ (view);
+
+    sampleView.spec = {
+        ...view.spec,
+        samples:
+            /** @type {import("@genome-spy/core/spec/sampleView.js").SampleDef} */ ({}),
+    };
+    sampleView.sampleHierarchy = options.sampleHierarchy;
+    sampleView.compositeAttributeInfoSource =
+        new CompositeAttributeInfoSource();
+    sampleView.provenance = {
         store: options.store,
         getPresentState: () => ({}),
     };
-    view.locationManager = {
+    sampleView.locationManager = {
+        /** @type {(coords: import("@genome-spy/core/view/layout/rectangle.js").default) => import("@genome-spy/core/view/layout/rectangle.js").default} */
         clipBySummary: (coords) => coords,
     };
-    view.findSampleForMouseEvent = () => undefined;
-    view.makePeekMenuItem = () => ({});
-    view.actions = { filterByNominal: () => ({}) };
-    view.dispatchAttributeAction = () => undefined;
+    sampleView.findSampleForMouseEvent = () => undefined;
+    sampleView.makePeekMenuItem = () => ({});
+    sampleView.actions = { filterByNominal: () => ({}) };
+    sampleView.dispatchAttributeAction = () => undefined;
 
-    return /** @type {SampleViewStub} */ (view);
+    return sampleView;
 }
 
 /**

--- a/packages/app/src/testUtils/appTestUtils.js
+++ b/packages/app/src/testUtils/appTestUtils.js
@@ -1,0 +1,82 @@
+import { createTestViewContext } from "@genome-spy/core/view/testUtils.js";
+import { initializeViewSubtree } from "@genome-spy/core/data/flowInit.js";
+
+import setupStore from "../state/setupStore.js";
+import IntentExecutor from "../state/intentExecutor.js";
+import Provenance from "../state/provenance.js";
+import SampleView from "../sampleView/sampleView.js";
+
+/**
+ * @typedef {import("@genome-spy/core/types/viewContext.js").default} ViewContext
+ * @typedef {import("@genome-spy/core/spec/sampleView.js").SampleSpec} SampleSpec
+ * @typedef {ReturnType<setupStore>} AppStore
+ */
+
+/**
+ * @param {{ context?: ViewContext }} [options]
+ */
+export function createAppTestContext(options = {}) {
+    const context = options.context ?? createTestViewContext();
+    const store = setupStore();
+    const intentExecutor = new IntentExecutor(store);
+    const provenance = new Provenance(store, intentExecutor);
+
+    context.animator = {
+        transition: () => Promise.resolve(),
+        requestRender: () => undefined,
+    };
+    context.requestLayoutReflow = () => undefined;
+    context.updateTooltip = () => undefined;
+    context.getCurrentHover = () => undefined;
+    context.addKeyboardListener = () => undefined;
+    context.addBroadcastListener = () => undefined;
+    context.removeBroadcastListener = () => undefined;
+    context.setDataLoadingStatus = () => undefined;
+    context.glHelper = undefined;
+
+    return {
+        context,
+        store,
+        provenance,
+        intentExecutor,
+    };
+}
+
+/**
+ * @param {{
+ *   spec: SampleSpec,
+ *   context?: ViewContext,
+ *   initializeFlow?: boolean,
+ *   disableGroupUpdates?: boolean,
+ * }} options
+ * @returns {Promise<{ view: SampleView, context: ViewContext, store: AppStore }>}
+ */
+export async function createSampleViewForTest(options) {
+    const { context, store, provenance, intentExecutor } = createAppTestContext(
+        {
+            context: options.context,
+        }
+    );
+
+    const view = new SampleView(
+        options.spec,
+        context,
+        null,
+        null,
+        "samples",
+        provenance,
+        intentExecutor
+    );
+
+    await view.initializeChildren();
+
+    if (options.initializeFlow ?? true) {
+        initializeViewSubtree(view, context.dataFlow);
+    }
+
+    if (options.disableGroupUpdates) {
+        view.sampleGroupView.updateGroups = () => undefined;
+    }
+
+    return { view, context, store };
+}

--- a/packages/core/src/data/collector.js
+++ b/packages/core/src/data/collector.js
@@ -61,8 +61,8 @@ export default class Collector extends FlowNode {
 
         this.params = params ?? { type: "collect" };
 
-        /** @type {(function(Collector):void)[]} */
-        this.observers = [];
+        /** @type {Set<function(Collector):void>} */
+        this.observers = new Set();
 
         // TODO: Consider nested maps instead of InternMap
         /** @type {Map<import("../spec/channel.js").Scalar[], Data>} TODO: proper type for key */
@@ -147,6 +147,17 @@ export default class Collector extends FlowNode {
         for (const observer of this.observers) {
             observer(this);
         }
+    }
+
+    /**
+     * @param {function(Collector):void} listener
+     * @returns {() => void}
+     */
+    observe(listener) {
+        this.observers.add(listener);
+        return () => {
+            this.observers.delete(listener);
+        };
     }
 
     #propagateToChildren() {

--- a/packages/core/src/data/dataFlow.js
+++ b/packages/core/src/data/dataFlow.js
@@ -58,7 +58,7 @@ export default class DataFlow {
      * @param {import("./collector.js").default} collector
      */
     removeCollector(collector) {
-        collector.observers.length = 0;
+        collector.observers.clear();
         this.#collectors.delete(collector);
     }
 

--- a/packages/core/src/data/dataFlow.js
+++ b/packages/core/src/data/dataFlow.js
@@ -130,6 +130,42 @@ export default class DataFlow {
     }
 
     /**
+     * @param {H} key
+     */
+    removeHost(key) {
+        this._dataSourcesByHost.delete(key);
+        this._collectorsByHost.delete(key);
+        this._observers.delete(key);
+    }
+
+    /**
+     * @param {Iterable<H>} keys
+     */
+    removeHosts(keys) {
+        for (const key of keys) {
+            this.removeHost(key);
+        }
+    }
+
+    /**
+     * @param {Iterable<H>} keys
+     * @returns {import("./sources/dataSource.js").default[]}
+     */
+    getDataSourcesForHosts(keys) {
+        /** @type {import("./sources/dataSource.js").default[]} */
+        const dataSources = [];
+
+        for (const key of keys) {
+            const dataSource = this._dataSourcesByHost.get(key);
+            if (dataSource) {
+                dataSources.push(dataSource);
+            }
+        }
+
+        return dataSources;
+    }
+
+    /**
      * Allows the flow nodes to perform final initialization after the flow
      * structure has been built and optimized.
      * Must be called before any data are to be propagated.

--- a/packages/core/src/data/dataFlow.js
+++ b/packages/core/src/data/dataFlow.js
@@ -93,20 +93,6 @@ export default class DataFlow {
     }
 
     /**
-     * Adds a callback function that will be called when a collector has completed.
-     *
-     * @param {import("./collector.js").default} collector
-     * @param {function(import("./collector.js").default):void} callback
-     * @param {import("./flowHandle.js").FlowHandle} [handle]
-     */
-    addObserver(collector, callback, handle) {
-        collector.observers.push(callback);
-        if (handle) {
-            handle.collectorObserver = callback;
-        }
-    }
-
-    /**
      * Allows the flow nodes to perform final initialization after the flow
      * structure has been built and optimized.
      * Must be called before any data are to be propagated.

--- a/packages/core/src/data/dataFlow.js
+++ b/packages/core/src/data/dataFlow.js
@@ -69,14 +69,6 @@ export default class DataFlow {
 
     /**
      *
-     * @param {H} key
-     */
-    findDataSourceByKey(key) {
-        return this._dataSourcesByHost.get(key);
-    }
-
-    /**
-     *
      * @param {string} name
      */
     findNamedDataSource(name) {
@@ -123,14 +115,6 @@ export default class DataFlow {
             this._relayObserverCallback(c, key);
         this._collectorObserverByHost.set(key, observer);
         collector.observers.push(observer);
-    }
-
-    /**
-     *
-     * @param {H} key
-     */
-    findCollectorByKey(key) {
-        return this._collectorsByHost.get(key);
     }
 
     /**

--- a/packages/core/src/data/dataFlow.test.js
+++ b/packages/core/src/data/dataFlow.test.js
@@ -4,49 +4,35 @@ import DataSource from "./sources/dataSource.js";
 import Collector from "./collector.js";
 
 describe("DataFlow", () => {
-    test("removes hosts and ignores observer callbacks", () => {
+    test("removes sources and collectors and clears observers", () => {
         const flow = new DataFlow();
 
         const sourceA = new DataSource(/** @type {any} */ ({}));
         const sourceB = new DataSource(/** @type {any} */ ({}));
 
-        flow.addDataSource(sourceA, "a");
-        flow.addDataSource(sourceB, "b");
+        flow.addDataSource(sourceA);
+        flow.addDataSource(sourceB);
 
         const collector = new Collector();
-        flow.addCollector(collector, "c");
+        flow.addCollector(collector);
 
         let called = false;
-        flow.addObserver(() => {
+        flow.addObserver(collector, () => {
             called = true;
-        }, "c");
+        });
 
-        const dataSourceEntry = flow
-            .getDataSourceEntries()
-            .find(([key]) => key === "a");
-        expect(dataSourceEntry).toBeDefined();
-        expect(dataSourceEntry?.[1]).toBe(sourceA);
-
-        const collectorEntry = flow
-            .getCollectorEntries()
-            .find(([key]) => key === "c");
-        expect(collectorEntry).toBeDefined();
-        expect(collectorEntry?.[1]).toBe(collector);
+        expect(flow.dataSources).toContain(sourceA);
+        expect(flow.collectors).toContain(collector);
         expect(collector.observers.length).toBe(1);
 
-        flow.removeHosts(["a", "c"]);
+        flow.removeDataSource(sourceA);
+        flow.removeCollector(collector);
 
-        expect(
-            flow.getDataSourceEntries().find(([key]) => key === "a")
-        ).toBeUndefined();
-        expect(
-            flow.getCollectorEntries().find(([key]) => key === "c")
-        ).toBeUndefined();
+        expect(flow.dataSources).not.toContain(sourceA);
+        expect(flow.collectors).not.toContain(collector);
 
         expect(collector.observers.length).toBe(0);
         expect(called).toBe(false);
-        expect(flow.getDataSourcesForHosts(["b", "missing"])).toEqual([
-            sourceB,
-        ]);
+        expect(flow.dataSources).toContain(sourceB);
     });
 });

--- a/packages/core/src/data/dataFlow.test.js
+++ b/packages/core/src/data/dataFlow.test.js
@@ -21,14 +21,27 @@ describe("DataFlow", () => {
             called = true;
         }, "c");
 
-        expect(flow._dataSourcesByHost.get("a")).toBe(sourceA);
-        expect(flow._collectorsByHost.get("c")).toBe(collector);
+        const dataSourceEntry = flow
+            .getDataSourceEntries()
+            .find(([key]) => key === "a");
+        expect(dataSourceEntry).toBeDefined();
+        expect(dataSourceEntry?.[1]).toBe(sourceA);
+
+        const collectorEntry = flow
+            .getCollectorEntries()
+            .find(([key]) => key === "c");
+        expect(collectorEntry).toBeDefined();
+        expect(collectorEntry?.[1]).toBe(collector);
         expect(collector.observers.length).toBe(1);
 
         flow.removeHosts(["a", "c"]);
 
-        expect(flow._dataSourcesByHost.get("a")).toBeUndefined();
-        expect(flow._collectorsByHost.get("c")).toBeUndefined();
+        expect(
+            flow.getDataSourceEntries().find(([key]) => key === "a")
+        ).toBeUndefined();
+        expect(
+            flow.getCollectorEntries().find(([key]) => key === "c")
+        ).toBeUndefined();
 
         expect(collector.observers.length).toBe(0);
         expect(called).toBe(false);

--- a/packages/core/src/data/dataFlow.test.js
+++ b/packages/core/src/data/dataFlow.test.js
@@ -23,14 +23,14 @@ describe("DataFlow", () => {
 
         expect(flow.findDataSourceByKey("a")).toBe(sourceA);
         expect(flow.findCollectorByKey("c")).toBe(collector);
+        expect(collector.observers.length).toBe(1);
 
         flow.removeHosts(["a", "c"]);
 
         expect(flow.findDataSourceByKey("a")).toBeUndefined();
         expect(flow.findCollectorByKey("c")).toBeUndefined();
 
-        collector.observers[0](collector);
-
+        expect(collector.observers.length).toBe(0);
         expect(called).toBe(false);
         expect(flow.getDataSourcesForHosts(["b", "missing"])).toEqual([
             sourceB,

--- a/packages/core/src/data/dataFlow.test.js
+++ b/packages/core/src/data/dataFlow.test.js
@@ -1,5 +1,39 @@
-import { describe, test } from "vitest";
+import { describe, expect, test } from "vitest";
+import DataFlow from "./dataFlow.js";
+import DataSource from "./sources/dataSource.js";
+import Collector from "./collector.js";
 
 describe("DataFlow", () => {
-    test.todo("TODO");
+    test("removes hosts and ignores observer callbacks", () => {
+        const flow = new DataFlow();
+
+        const sourceA = new DataSource(/** @type {any} */ ({}));
+        const sourceB = new DataSource(/** @type {any} */ ({}));
+
+        flow.addDataSource(sourceA, "a");
+        flow.addDataSource(sourceB, "b");
+
+        const collector = new Collector();
+        flow.addCollector(collector, "c");
+
+        let called = false;
+        flow.addObserver(() => {
+            called = true;
+        }, "c");
+
+        expect(flow.findDataSourceByKey("a")).toBe(sourceA);
+        expect(flow.findCollectorByKey("c")).toBe(collector);
+
+        flow.removeHosts(["a", "c"]);
+
+        expect(flow.findDataSourceByKey("a")).toBeUndefined();
+        expect(flow.findCollectorByKey("c")).toBeUndefined();
+
+        collector.observers[0](collector);
+
+        expect(called).toBe(false);
+        expect(flow.getDataSourcesForHosts(["b", "missing"])).toEqual([
+            sourceB,
+        ]);
+    });
 });

--- a/packages/core/src/data/dataFlow.test.js
+++ b/packages/core/src/data/dataFlow.test.js
@@ -21,14 +21,14 @@ describe("DataFlow", () => {
             called = true;
         }, "c");
 
-        expect(flow.findDataSourceByKey("a")).toBe(sourceA);
-        expect(flow.findCollectorByKey("c")).toBe(collector);
+        expect(flow._dataSourcesByHost.get("a")).toBe(sourceA);
+        expect(flow._collectorsByHost.get("c")).toBe(collector);
         expect(collector.observers.length).toBe(1);
 
         flow.removeHosts(["a", "c"]);
 
-        expect(flow.findDataSourceByKey("a")).toBeUndefined();
-        expect(flow.findCollectorByKey("c")).toBeUndefined();
+        expect(flow._dataSourcesByHost.get("a")).toBeUndefined();
+        expect(flow._collectorsByHost.get("c")).toBeUndefined();
 
         expect(collector.observers.length).toBe(0);
         expect(called).toBe(false);

--- a/packages/core/src/data/dataFlow.test.js
+++ b/packages/core/src/data/dataFlow.test.js
@@ -17,13 +17,13 @@ describe("DataFlow", () => {
         flow.addCollector(collector);
 
         let called = false;
-        collector.observers.push(() => {
+        collector.observe(() => {
             called = true;
         });
 
         expect(flow.dataSources).toContain(sourceA);
         expect(flow.collectors).toContain(collector);
-        expect(collector.observers.length).toBe(1);
+        expect(collector.observers.size).toBe(1);
 
         flow.removeDataSource(sourceA);
         flow.removeCollector(collector);
@@ -31,7 +31,7 @@ describe("DataFlow", () => {
         expect(flow.dataSources).not.toContain(sourceA);
         expect(flow.collectors).not.toContain(collector);
 
-        expect(collector.observers.length).toBe(0);
+        expect(collector.observers.size).toBe(0);
         expect(called).toBe(false);
         expect(flow.dataSources).toContain(sourceB);
     });

--- a/packages/core/src/data/dataFlow.test.js
+++ b/packages/core/src/data/dataFlow.test.js
@@ -17,7 +17,7 @@ describe("DataFlow", () => {
         flow.addCollector(collector);
 
         let called = false;
-        flow.addObserver(collector, () => {
+        collector.observers.push(() => {
             called = true;
         });
 

--- a/packages/core/src/data/flowHandle.js
+++ b/packages/core/src/data/flowHandle.js
@@ -2,7 +2,6 @@
  * @typedef {object} FlowHandle
  * @prop {import("./sources/dataSource.js").default} [dataSource]
  * @prop {import("./collector.js").default} [collector]
- * @prop {function(import("./collector.js").default):void} [collectorObserver]
  */
 
 /**

--- a/packages/core/src/data/flowHandle.js
+++ b/packages/core/src/data/flowHandle.js
@@ -1,0 +1,13 @@
+/**
+ * @typedef {object} FlowHandle
+ * @prop {import("./sources/dataSource.js").default} [dataSource]
+ * @prop {import("./collector.js").default} [collector]
+ */
+
+/**
+ * @param {FlowHandle} [handle]
+ * @returns {FlowHandle}
+ */
+export function createFlowHandle(handle = {}) {
+    return handle;
+}

--- a/packages/core/src/data/flowHandle.js
+++ b/packages/core/src/data/flowHandle.js
@@ -2,6 +2,7 @@
  * @typedef {object} FlowHandle
  * @prop {import("./sources/dataSource.js").default} [dataSource]
  * @prop {import("./collector.js").default} [collector]
+ * @prop {function(import("./collector.js").default):void} [collectorObserver]
  */
 
 /**

--- a/packages/core/src/data/flowInit.js
+++ b/packages/core/src/data/flowInit.js
@@ -99,8 +99,7 @@ export function initializeSubtree(root, flow) {
                 mark.updateGraphicsData();
             }
         };
-        view.flowHandle.collector.observers.push(observer);
-        view.collectorObserver = observer;
+        view.registerDisposer(view.flowHandle.collector.observe(observer));
     }
 
     return {

--- a/packages/core/src/data/flowInit.js
+++ b/packages/core/src/data/flowInit.js
@@ -91,14 +91,16 @@ export function initializeSubtree(root, flow) {
             graphicsPromises.push(mark.initializeGraphics().then(() => mark));
         }
 
-        flow.addObserver(
-            view.flowHandle.collector,
-            (/** @type {import("./collector.js").default} */ _collector) => {
-                mark.initializeData(); // does faceting
+        const observer = (
+            /** @type {import("./collector.js").default} */ _collector
+        ) => {
+            mark.initializeData(); // does faceting
+            if (canInitializeGraphics) {
                 mark.updateGraphicsData();
-            },
-            view.flowHandle
-        );
+            }
+        };
+        view.flowHandle.collector.observers.push(observer);
+        view.collectorObserver = observer;
     }
 
     return {

--- a/packages/core/src/data/flowInit.js
+++ b/packages/core/src/data/flowInit.js
@@ -1,0 +1,107 @@
+import UnitView from "../view/unitView.js";
+import { buildDataFlow } from "../view/flowBuilder.js";
+import { optimizeDataFlow } from "./flowOptimizer.js";
+
+/**
+ * @param {import("../view/view.js").default} root
+ * @param {import("./dataFlow.js").default<import("../view/view.js").default>} [existingFlow]
+ */
+export async function initializeData(root, existingFlow) {
+    const flow = buildDataFlow(root, existingFlow);
+    const canonicalBySource = optimizeDataFlow(flow);
+    syncFlowHandles(root, canonicalBySource);
+    flow.initialize();
+
+    /** @type {Promise<void>[]} */
+    const promises = flow.dataSources.map((dataSource) => dataSource.load());
+
+    await Promise.all(promises);
+
+    return flow;
+}
+
+/**
+ * Synchronize flow handles after data flow optimization.
+ *
+ * @param {import("../view/view.js").default} root
+ * @param {Map<import("./sources/dataSource.js").default, import("./sources/dataSource.js").default>} canonicalBySource
+ */
+export function syncFlowHandles(root, canonicalBySource) {
+    for (const view of root.getDescendants()) {
+        const handle = view.flowHandle;
+        if (!handle) {
+            continue;
+        }
+
+        const dataSource = handle.dataSource;
+        if (dataSource) {
+            handle.dataSource = canonicalBySource.get(dataSource) ?? dataSource;
+        }
+    }
+}
+
+/**
+ * Initializes data flow and marks for a subtree without reinitializing the whole view tree.
+ *
+ * @param {import("../view/view.js").default} root
+ * @param {import("./dataFlow.js").default<import("../view/view.js").default>} flow
+ * @returns {{
+ *     dataFlow: import("./dataFlow.js").default<import("../view/view.js").default>,
+ *     unitViews: UnitView[],
+ *     dataSources: Set<import("./sources/dataSource.js").default>,
+ *     graphicsPromises: Promise<import("../marks/mark.js").default>[]
+ * }}
+ */
+export function initializeSubtree(root, flow) {
+    const dataFlow = buildDataFlow(root, flow);
+    const canonicalBySource = optimizeDataFlow(dataFlow);
+    syncFlowHandles(root, canonicalBySource);
+    const subtreeViews = root.getDescendants();
+    /** @type {Set<import("./sources/dataSource.js").default>} */
+    const dataSources = new Set();
+    for (const view of subtreeViews) {
+        let current = view;
+        while (current && !current.flowHandle?.dataSource) {
+            current = current.dataParent;
+        }
+        if (current?.flowHandle?.dataSource) {
+            dataSources.add(current.flowHandle.dataSource);
+        }
+    }
+
+    for (const dataSource of dataSources) {
+        dataSource.visit((node) => node.initialize());
+    }
+
+    /** @type {UnitView[]} */
+    const unitViews = subtreeViews.filter((view) => view instanceof UnitView);
+
+    /** @type {Promise<import("../marks/mark.js").default>[]} */
+    const graphicsPromises = [];
+
+    const canInitializeGraphics = !!root.context.glHelper;
+
+    for (const view of unitViews) {
+        const mark = view.mark;
+        mark.initializeEncoders();
+        if (canInitializeGraphics) {
+            graphicsPromises.push(mark.initializeGraphics().then(() => mark));
+        }
+
+        flow.addObserver(
+            view.flowHandle.collector,
+            (collector) => {
+                mark.initializeData(); // does faceting
+                mark.updateGraphicsData();
+            },
+            view.flowHandle
+        );
+    }
+
+    return {
+        dataFlow,
+        unitViews,
+        dataSources,
+        graphicsPromises,
+    };
+}

--- a/packages/core/src/data/flowInit.js
+++ b/packages/core/src/data/flowInit.js
@@ -44,9 +44,43 @@ export function syncFlowHandles(root, canonicalBySource) {
 }
 
 /**
- * Initializes data flow and marks for a subtree without reinitializing the whole view tree.
+ * Initializes data flow and mark wiring for a subtree without rebuilding the
+ * entire view hierarchy. This is the primary entry point for dynamic view
+ * insertion: build the subtree fully, call this, then attach the subtree to
+ * the live hierarchy.
  *
- * @param {import("../view/view.js").default} root
+ * What it does:
+ * - builds/extends the dataflow graph for the subtree
+ * - runs flow optimization and syncs flow handles to canonical data sources
+ * - discovers the nearest data sources for views in the subtree
+ * - initializes dataflow nodes (initialize) for those sources
+ * - initializes mark encoders for unit views
+ * - queues graphics initialization (if a GL context exists)
+ * - wires collector observers so marks update on data arrival
+ *
+ * How to use it:
+ * - call after the subtree is fully constructed (post-order build)
+ * - do not attach the subtree to the live hierarchy until after this call
+ * - dispose the old subtree before replacing it to prevent observer leaks
+ * - follow up with finalizeSubtreeGraphics(...) once graphics promises resolve
+ * - reconfigure scales for the subtree when data loads complete
+ *
+ * Considerations:
+ * - this does not trigger data loading; callers decide when to load
+ * - data sources are derived by walking to the nearest ancestor source; nested
+ *   sources should be treated as boundaries (do not walk past them)
+ * - only call updateGraphicsData when graphics are initialized or a GL context
+ *   is available; headless/test contexts must avoid WebGL usage
+ *
+ * TODO:
+ * - add a load-state/cache so shared canonical sources load once
+ * - emit subtree-level "data ready" events that respect nearest-source
+ *   boundaries, rather than relying on global dataLoaded broadcasts
+ * - reconfigure scales automatically after subtree data load
+ * - integrate with async font readiness for text marks
+ * - unify observer wiring via a disposable registry across view types
+ *
+ * @param {import("../view/view.js").default} subtreeRoot
  * @param {import("./dataFlow.js").default} flow
  * @returns {{
  *     dataFlow: import("./dataFlow.js").default,
@@ -55,14 +89,15 @@ export function syncFlowHandles(root, canonicalBySource) {
  *     graphicsPromises: Promise<import("../marks/mark.js").default>[]
  * }}
  */
-export function initializeSubtree(root, flow) {
-    const dataFlow = buildDataFlow(root, flow);
+export function initializeViewSubtree(subtreeRoot, flow) {
+    const dataFlow = buildDataFlow(subtreeRoot, flow);
     const canonicalBySource = optimizeDataFlow(dataFlow);
-    syncFlowHandles(root, canonicalBySource);
-    const subtreeViews = root.getDescendants();
+    syncFlowHandles(subtreeRoot, canonicalBySource);
+    const subtreeViews = subtreeRoot.getDescendants();
     /** @type {Set<import("./sources/dataSource.js").default>} */
     const dataSources = new Set();
     for (const view of subtreeViews) {
+        // Walk up to the nearest view that owns a data source.
         let current = view;
         while (current && !current.flowHandle?.dataSource) {
             current = current.dataParent;
@@ -72,6 +107,7 @@ export function initializeSubtree(root, flow) {
         }
     }
 
+    // Initialize flow nodes for the sources that belong to this subtree.
     for (const dataSource of dataSources) {
         dataSource.visit((node) => node.initialize());
     }
@@ -82,15 +118,17 @@ export function initializeSubtree(root, flow) {
     /** @type {Promise<import("../marks/mark.js").default>[]} */
     const graphicsPromises = [];
 
-    const canInitializeGraphics = !!root.context.glHelper;
+    const canInitializeGraphics = !!subtreeRoot.context.glHelper;
 
     for (const view of unitViews) {
         const mark = view.mark;
+        // Encoders can be initialized immediately; graphics need a GL context.
         mark.initializeEncoders();
         if (canInitializeGraphics) {
             graphicsPromises.push(mark.initializeGraphics().then(() => mark));
         }
 
+        // Wire collector completion to mark data/graphics updates.
         const observer = (
             /** @type {import("./collector.js").default} */ _collector
         ) => {

--- a/packages/core/src/data/flowInit.js
+++ b/packages/core/src/data/flowInit.js
@@ -4,7 +4,7 @@ import { optimizeDataFlow } from "./flowOptimizer.js";
 
 /**
  * @param {import("../view/view.js").default} root
- * @param {import("./dataFlow.js").default<import("../view/view.js").default>} [existingFlow]
+ * @param {import("./dataFlow.js").default} [existingFlow]
  */
 export async function initializeData(root, existingFlow) {
     const flow = buildDataFlow(root, existingFlow);
@@ -13,7 +13,10 @@ export async function initializeData(root, existingFlow) {
     flow.initialize();
 
     /** @type {Promise<void>[]} */
-    const promises = flow.dataSources.map((dataSource) => dataSource.load());
+    const promises = flow.dataSources.map(
+        (/** @type {import("./sources/dataSource.js").default} */ dataSource) =>
+            dataSource.load()
+    );
 
     await Promise.all(promises);
 
@@ -44,9 +47,9 @@ export function syncFlowHandles(root, canonicalBySource) {
  * Initializes data flow and marks for a subtree without reinitializing the whole view tree.
  *
  * @param {import("../view/view.js").default} root
- * @param {import("./dataFlow.js").default<import("../view/view.js").default>} flow
+ * @param {import("./dataFlow.js").default} flow
  * @returns {{
- *     dataFlow: import("./dataFlow.js").default<import("../view/view.js").default>,
+ *     dataFlow: import("./dataFlow.js").default,
  *     unitViews: UnitView[],
  *     dataSources: Set<import("./sources/dataSource.js").default>,
  *     graphicsPromises: Promise<import("../marks/mark.js").default>[]
@@ -90,7 +93,7 @@ export function initializeSubtree(root, flow) {
 
         flow.addObserver(
             view.flowHandle.collector,
-            (collector) => {
+            (/** @type {import("./collector.js").default} */ _collector) => {
                 mark.initializeData(); // does faceting
                 mark.updateGraphicsData();
             },

--- a/packages/core/src/data/flowInit.js
+++ b/packages/core/src/data/flowInit.js
@@ -209,8 +209,11 @@ export function loadViewSubtreeData(
  * @param {import("../view/view.js").default} subtreeRoot
  */
 function broadcastSubtreeDataReady(subtreeRoot) {
+    /** @type {import("../view/view.js").BroadcastMessage} */
     const message = {
-        type: "subtreeDataReady",
+        type: /** @type {import("../genomeSpy.js").BroadcastEventType} */ (
+            "subtreeDataReady"
+        ),
         payload: { subtreeRoot },
     };
     subtreeRoot.visit((view) => view.handleBroadcast(message));

--- a/packages/core/src/data/flowInit.test.js
+++ b/packages/core/src/data/flowInit.test.js
@@ -129,7 +129,7 @@ describe("flowInit", () => {
         firstRoot.disposeSubtree();
 
         // This prevents stale observers from firing after a subtree is rebuilt.
-        expect(firstCollector.observers.length).toBe(0);
+        expect(firstCollector.observers.size).toBe(0);
 
         const secondRoot = await context.createOrImportView(
             spec,

--- a/packages/core/src/data/flowInit.test.js
+++ b/packages/core/src/data/flowInit.test.js
@@ -3,7 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 import { createTestViewContext } from "../view/testUtils.js";
 import { buildDataFlow } from "../view/flowBuilder.js";
 import { optimizeDataFlow } from "./flowOptimizer.js";
-import { initializeSubtree, syncFlowHandles } from "./flowInit.js";
+import { initializeViewSubtree, syncFlowHandles } from "./flowInit.js";
 
 describe("flowInit", () => {
     test("syncs handles to canonical data sources after merge", async () => {
@@ -54,7 +54,7 @@ describe("flowInit", () => {
         expect(sharedSources).toEqual([left.flowHandle.dataSource]);
     });
 
-    test("initializeSubtree wires collector updates for subtree loads", async () => {
+    test("initializeViewSubtree wires collector updates for subtree loads", async () => {
         const context = createTestViewContext();
         context.getNamedDataFromProvider = () => [];
         context.addBroadcastListener = () => undefined;
@@ -70,7 +70,7 @@ describe("flowInit", () => {
         };
 
         const root = await context.createOrImportView(spec, null, null, "root");
-        const { dataSources } = initializeSubtree(root, context.dataFlow);
+        const { dataSources } = initializeViewSubtree(root, context.dataFlow);
 
         // This guards subtree-only initialization: dynamic view rebuilds should still
         // trigger mark updates when their local collectors complete.
@@ -108,7 +108,7 @@ describe("flowInit", () => {
             null,
             "first"
         );
-        const { dataSources: firstSources } = initializeSubtree(
+        const { dataSources: firstSources } = initializeViewSubtree(
             firstRoot,
             context.dataFlow
         );
@@ -137,7 +137,7 @@ describe("flowInit", () => {
             null,
             "second"
         );
-        const { dataSources: secondSources } = initializeSubtree(
+        const { dataSources: secondSources } = initializeViewSubtree(
             secondRoot,
             context.dataFlow
         );

--- a/packages/core/src/data/flowInit.test.js
+++ b/packages/core/src/data/flowInit.test.js
@@ -296,17 +296,16 @@ describe("flowInit", () => {
         const root = await context.createOrImportView(spec, null, null, "root");
         initializeViewSubtree(root, context.dataFlow);
 
-        // Without a root source, the nearest sources are the child sources.
+        // Without a root source, the nearest sources include the child sources.
+        // Layout decorations may add additional sources.
         const sources = collectNearestViewSubtreeDataSources(root);
-        expect(sources.size).toBe(2);
-
         const concatRoot =
             /** @type {import("../view/concatView.js").default} */ (root);
-        expect(sources).toEqual(
-            new Set([
-                concatRoot.children[0].flowHandle.dataSource,
-                concatRoot.children[1].flowHandle.dataSource,
-            ])
+        expect(sources.has(concatRoot.children[0].flowHandle.dataSource)).toBe(
+            true
+        );
+        expect(sources.has(concatRoot.children[1].flowHandle.dataSource)).toBe(
+            true
         );
     });
 });

--- a/packages/core/src/data/flowInit.test.js
+++ b/packages/core/src/data/flowInit.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+
+import { createTestViewContext } from "../view/testUtils.js";
+import { buildDataFlow } from "../view/flowBuilder.js";
+import { optimizeDataFlow } from "./flowOptimizer.js";
+import { syncFlowHandles } from "./flowInit.js";
+
+describe("flowInit", () => {
+    test("syncs handles to canonical data sources after merge", async () => {
+        const context = createTestViewContext();
+        context.getNamedDataFromProvider = () => [];
+        context.addBroadcastListener = () => undefined;
+        context.removeBroadcastListener = () => undefined;
+
+        /** @type {import("../spec/view.js").ConcatSpec} */
+        const spec = {
+            hconcat: [
+                {
+                    data: { name: "shared" },
+                    mark: "point",
+                    encoding: {
+                        x: { field: "x", type: "quantitative" },
+                    },
+                },
+                {
+                    data: { name: "shared" },
+                    mark: "point",
+                    encoding: {
+                        x: { field: "x", type: "quantitative" },
+                    },
+                },
+            ],
+        };
+
+        const root = await context.createOrImportView(spec, null, null, "root");
+
+        const flow = buildDataFlow(root, context.dataFlow);
+        const canonicalBySource = optimizeDataFlow(flow);
+        syncFlowHandles(root, canonicalBySource);
+
+        const left = root.children[0];
+        const right = root.children[1];
+
+        expect(left.flowHandle.dataSource).toBeDefined();
+        expect(right.flowHandle.dataSource).toBeDefined();
+        expect(left.flowHandle.dataSource).toBe(right.flowHandle.dataSource);
+
+        const sharedSources = flow.dataSources.filter(
+            (source) => source.identifier === "shared"
+        );
+        expect(sharedSources).toEqual([left.flowHandle.dataSource]);
+    });
+});

--- a/packages/core/src/data/flowInit.test.js
+++ b/packages/core/src/data/flowInit.test.js
@@ -77,16 +77,14 @@ describe("flowInit", () => {
         const unitView = /** @type {import("../view/unitView.js").default} */ (
             root
         );
-        const updateSpy = vi
-            .spyOn(unitView.mark, "updateGraphicsData")
-            .mockImplementation(() => undefined);
+        const initializeSpy = vi.spyOn(unitView.mark, "initializeData");
 
         await Promise.all(
             Array.from(dataSources).map((dataSource) => dataSource.load())
         );
 
-        expect(updateSpy).toHaveBeenCalledTimes(1);
-        updateSpy.mockRestore();
+        expect(initializeSpy).toHaveBeenCalledTimes(1);
+        initializeSpy.mockRestore();
     });
 
     test("disposeSubtree removes observers before rebuilding subtree", async () => {
@@ -119,16 +117,14 @@ describe("flowInit", () => {
             firstRoot
         );
         const firstCollector = firstUnit.flowHandle.collector;
-        const firstUpdateSpy = vi
-            .spyOn(firstUnit.mark, "updateGraphicsData")
-            .mockImplementation(() => undefined);
+        const firstInitializeSpy = vi.spyOn(firstUnit.mark, "initializeData");
 
         await Promise.all(
             Array.from(firstSources).map((dataSource) => dataSource.load())
         );
 
-        expect(firstUpdateSpy).toHaveBeenCalledTimes(1);
-        firstUpdateSpy.mockRestore();
+        expect(firstInitializeSpy).toHaveBeenCalledTimes(1);
+        firstInitializeSpy.mockRestore();
 
         firstRoot.disposeSubtree();
 
@@ -148,15 +144,13 @@ describe("flowInit", () => {
 
         const secondUnit =
             /** @type {import("../view/unitView.js").default} */ (secondRoot);
-        const secondUpdateSpy = vi
-            .spyOn(secondUnit.mark, "updateGraphicsData")
-            .mockImplementation(() => undefined);
+        const secondInitializeSpy = vi.spyOn(secondUnit.mark, "initializeData");
 
         await Promise.all(
             Array.from(secondSources).map((dataSource) => dataSource.load())
         );
 
-        expect(secondUpdateSpy).toHaveBeenCalledTimes(1);
-        secondUpdateSpy.mockRestore();
+        expect(secondInitializeSpy).toHaveBeenCalledTimes(1);
+        secondInitializeSpy.mockRestore();
     });
 });

--- a/packages/core/src/data/flowInit.test.js
+++ b/packages/core/src/data/flowInit.test.js
@@ -12,7 +12,7 @@ describe("flowInit", () => {
         context.addBroadcastListener = () => undefined;
         context.removeBroadcastListener = () => undefined;
 
-        /** @type {import("../spec/view.js").ConcatSpec} */
+        /** @type {import("../spec/view.js").HConcatSpec} */
         const spec = {
             hconcat: [
                 {
@@ -38,15 +38,18 @@ describe("flowInit", () => {
         const canonicalBySource = optimizeDataFlow(flow);
         syncFlowHandles(root, canonicalBySource);
 
-        const left = root.children[0];
-        const right = root.children[1];
+        const concatRoot =
+            /** @type {import("../view/concatView.js").default} */ (root);
+        const left = concatRoot.children[0];
+        const right = concatRoot.children[1];
 
         expect(left.flowHandle.dataSource).toBeDefined();
         expect(right.flowHandle.dataSource).toBeDefined();
         expect(left.flowHandle.dataSource).toBe(right.flowHandle.dataSource);
 
         const sharedSources = flow.dataSources.filter(
-            (source) => source.identifier === "shared"
+            (/** @type {import("./sources/dataSource.js").default} */ source) =>
+                source.identifier === "shared"
         );
         expect(sharedSources).toEqual([left.flowHandle.dataSource]);
     });

--- a/packages/core/src/data/flowInit.test.js
+++ b/packages/core/src/data/flowInit.test.js
@@ -308,4 +308,32 @@ describe("flowInit", () => {
             true
         );
     });
+
+    test("loadViewSubtreeData emits subtree data ready broadcast", async () => {
+        const context = createTestViewContext();
+        context.addBroadcastListener = () => undefined;
+        context.removeBroadcastListener = () => undefined;
+
+        /** @type {import("../spec/view.js").UnitSpec} */
+        const spec = {
+            data: { values: [{ x: 1 }] },
+            mark: "point",
+            encoding: {
+                x: { field: "x", type: "quantitative" },
+            },
+        };
+
+        const root = await context.createOrImportView(spec, null, null, "root");
+        initializeViewSubtree(root, context.dataFlow);
+
+        let calls = 0;
+        root._addBroadcastHandler("subtreeDataReady", (message) => {
+            calls += 1;
+            expect(message.payload.subtreeRoot).toBe(root);
+        });
+
+        await loadViewSubtreeData(root);
+
+        expect(calls).toBe(1);
+    });
 });

--- a/packages/core/src/data/flowOptimizer.js
+++ b/packages/core/src/data/flowOptimizer.js
@@ -82,7 +82,7 @@ export function combineAndPullCollectorsUp() {
 //      --F--G
 
 /**
- * @param {import("./dataFlow.js").default<any>} dataFlow
+ * @param {import("./dataFlow.js").default} dataFlow
  * @returns {Map<import("./sources/dataSource.js").default, import("./sources/dataSource.js").default>}
  */
 export function combineIdenticalDataSources(dataFlow) {
@@ -135,7 +135,7 @@ export function optimizeFlowGraph(root) {
 }
 
 /**
- * @param {import("./dataFlow.js").default<any>} dataFlow
+ * @param {import("./dataFlow.js").default} dataFlow
  * @returns {Map<import("./sources/dataSource.js").default, import("./sources/dataSource.js").default>}
  */
 export function optimizeDataFlow(dataFlow) {

--- a/packages/core/src/data/flowOptimizer.js
+++ b/packages/core/src/data/flowOptimizer.js
@@ -85,7 +85,7 @@ export function combineAndPullCollectorsUp() {
  * @param {import("./dataFlow.js").default<any>} dataFlow
  */
 export function combineIdenticalDataSources(dataFlow) {
-    const dataSourceEntries = [...dataFlow._dataSourcesByHost.entries()];
+    const dataSourceEntries = dataFlow.getDataSourceEntries();
 
     /** @type {Map<string, import("./sources/dataSource.js").default>} */
     const sourcesByIdentifiers = new Map();
@@ -96,7 +96,7 @@ export function combineIdenticalDataSources(dataFlow) {
         }
     }
 
-    dataFlow._dataSourcesByHost.clear();
+    dataFlow.replaceDataSourceEntries([]);
 
     for (let [key, dataSource] of dataSourceEntries) {
         const target = sourcesByIdentifiers.get(dataSource.identifier);

--- a/packages/core/src/data/flowOptimizer.test.js
+++ b/packages/core/src/data/flowOptimizer.test.js
@@ -169,9 +169,10 @@ describe("Merge indentical data sources", () => {
 
         expect(dataFlow.dataSources.length).toEqual(2);
 
-        expect(dataFlow._dataSourcesByHost.get("a")).toBe(a);
-        expect(dataFlow._dataSourcesByHost.get("b")).toBe(a); // Merged!
-        expect(dataFlow._dataSourcesByHost.get("c")).toBe(c);
+        const entries = dataFlow.getDataSourceEntries();
+        expect(entries.find(([key]) => key === "a")?.[1]).toBe(a);
+        expect(entries.find(([key]) => key === "b")?.[1]).toBe(a); // Merged!
+        expect(entries.find(([key]) => key === "c")?.[1]).toBe(c);
 
         expect(new Set(a.children)).toEqual(new Set([ac, bc]));
         expect(c.children[0]).toBe(cc);
@@ -198,7 +199,8 @@ describe("Merge indentical data sources", () => {
 
         combineIdenticalDataSources(dataFlow);
 
-        expect(dataFlow._dataSourcesByHost.get("a")).toBe(a);
-        expect(dataFlow._dataSourcesByHost.get("b")).toBe(b);
+        const entries = dataFlow.getDataSourceEntries();
+        expect(entries.find(([key]) => key === "a")?.[1]).toBe(a);
+        expect(entries.find(([key]) => key === "b")?.[1]).toBe(b);
     });
 });

--- a/packages/core/src/data/flowOptimizer.test.js
+++ b/packages/core/src/data/flowOptimizer.test.js
@@ -169,9 +169,9 @@ describe("Merge indentical data sources", () => {
 
         expect(dataFlow.dataSources.length).toEqual(2);
 
-        expect(dataFlow.findDataSourceByKey("a")).toBe(a);
-        expect(dataFlow.findDataSourceByKey("b")).toBe(a); // Merged!
-        expect(dataFlow.findDataSourceByKey("c")).toBe(c);
+        expect(dataFlow._dataSourcesByHost.get("a")).toBe(a);
+        expect(dataFlow._dataSourcesByHost.get("b")).toBe(a); // Merged!
+        expect(dataFlow._dataSourcesByHost.get("c")).toBe(c);
 
         expect(new Set(a.children)).toEqual(new Set([ac, bc]));
         expect(c.children[0]).toBe(cc);
@@ -198,7 +198,7 @@ describe("Merge indentical data sources", () => {
 
         combineIdenticalDataSources(dataFlow);
 
-        expect(dataFlow.findDataSourceByKey("a")).toBe(a);
-        expect(dataFlow.findDataSourceByKey("b")).toBe(b);
+        expect(dataFlow._dataSourcesByHost.get("a")).toBe(a);
+        expect(dataFlow._dataSourcesByHost.get("b")).toBe(b);
     });
 });

--- a/packages/core/src/data/flowOptimizer.test.js
+++ b/packages/core/src/data/flowOptimizer.test.js
@@ -142,7 +142,7 @@ const viewStub = /** @type {any} */ (
 
 describe("Merge indentical data sources", () => {
     test("Merges correctly", () => {
-        /** @type {DataFlow<string>} */
+        /** @type {DataFlow} */
         const dataFlow = new DataFlow();
 
         const a = new UrlSource({ url: "http://genomespy.app/" }, viewStub);
@@ -157,22 +157,25 @@ describe("Merge indentical data sources", () => {
         const cc = new Collector();
         c.addChild(cc);
 
-        dataFlow.addDataSource(a, "a");
-        dataFlow.addDataSource(b, "b");
-        dataFlow.addDataSource(c, "c");
+        dataFlow.addDataSource(a);
+        dataFlow.addDataSource(b);
+        dataFlow.addDataSource(c);
 
-        dataFlow.addCollector(ac, "a");
-        dataFlow.addCollector(bc, "b");
-        dataFlow.addCollector(cc, "c");
+        dataFlow.addCollector(ac);
+        dataFlow.addCollector(bc);
+        dataFlow.addCollector(cc);
 
         combineIdenticalDataSources(dataFlow);
 
         expect(dataFlow.dataSources.length).toEqual(2);
 
-        const entries = dataFlow.getDataSourceEntries();
-        expect(entries.find(([key]) => key === "a")?.[1]).toBe(a);
-        expect(entries.find(([key]) => key === "b")?.[1]).toBe(a); // Merged!
-        expect(entries.find(([key]) => key === "c")?.[1]).toBe(c);
+        const entries = dataFlow.dataSources;
+        const sharedIdentifier = a.identifier;
+        expect(entries).toContain(a);
+        expect(entries).toContain(c);
+        expect(
+            entries.filter((source) => source.identifier == sharedIdentifier)
+        ).toEqual([a]);
 
         expect(new Set(a.children)).toEqual(new Set([ac, bc]));
         expect(c.children[0]).toBe(cc);
@@ -188,19 +191,19 @@ describe("Merge indentical data sources", () => {
     });
 
     test("Does not merge those with undefined identifier", () => {
-        /** @type {DataFlow<string>} */
+        /** @type {DataFlow} */
         const dataFlow = new DataFlow();
 
         const a = new InlineSource({ values: [1, 2, 3] }, viewStub);
         const b = new InlineSource({ values: [1, 2, 3] }, viewStub);
 
-        dataFlow.addDataSource(a, "a");
-        dataFlow.addDataSource(b, "b");
+        dataFlow.addDataSource(a);
+        dataFlow.addDataSource(b);
 
         combineIdenticalDataSources(dataFlow);
 
-        const entries = dataFlow.getDataSourceEntries();
-        expect(entries.find(([key]) => key === "a")?.[1]).toBe(a);
-        expect(entries.find(([key]) => key === "b")?.[1]).toBe(b);
+        const entries = dataFlow.dataSources;
+        expect(entries).toContain(a);
+        expect(entries).toContain(b);
     });
 });

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -593,23 +593,21 @@ export default class GenomeSpy {
         );
 
         for (const view of unitViews) {
-            flow.addObserver(
-                view.flowHandle.collector,
-                (
-                    /** @type {import("./data/collector.js").default} */ _collector
-                ) => {
-                    view.mark.initializeData();
-                    try {
-                        // Update WebGL buffers
-                        view.mark.updateGraphicsData();
-                    } catch (e) {
-                        e.view = view;
-                        throw e;
-                    }
-                    context.animator.requestRender();
-                },
-                view.flowHandle
-            );
+            const observer = (
+                /** @type {import("./data/collector.js").default} */ _collector
+            ) => {
+                view.mark.initializeData();
+                try {
+                    // Update WebGL buffers
+                    view.mark.updateGraphicsData();
+                } catch (e) {
+                    e.view = view;
+                    throw e;
+                }
+                context.animator.requestRender();
+            };
+            view.flowHandle.collector.observers.push(observer);
+            view.collectorObserver = observer;
         }
 
         // Have to wait until asynchronous font loading is complete.

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -11,7 +11,7 @@ import {
     setImplicitScaleNames,
     calculateCanvasSize,
 } from "./view/viewUtils.js";
-import { syncFlowHandles } from "./data/flowInit.js";
+import { loadViewSubtreeData, syncFlowHandles } from "./data/flowInit.js";
 import UnitView from "./view/unitView.js";
 
 import WebGLHelper, {
@@ -615,15 +615,9 @@ export default class GenomeSpy {
         // TODO: Make updateGraphicsData async and await font loading there.
         await context.fontManager.waitUntilReady();
 
-        // Find all data sources and initiate loading
+        // Find all data sources and initiate loading.
         flow.initialize();
-        await Promise.all(
-            flow.dataSources.map(
-                (
-                    /** @type {import("./data/sources/dataSource.js").default} */ dataSource
-                ) => dataSource.load()
-            )
-        );
+        await loadViewSubtreeData(this.viewRoot, new Set(flow.dataSources));
 
         // Now that all data have been loaded, the domains may need adjusting
         // IMPORTANT TODO: Check that discrete domains and indexers match!!!!!!!!!

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -580,8 +580,8 @@ export default class GenomeSpy {
 
         // Build the data flow based on the view hierarchy
         const flow = buildDataFlow(this.viewRoot, context.dataFlow);
-        optimizeDataFlow(flow);
-        syncFlowHandles(this.viewRoot, flow);
+        const canonicalBySource = optimizeDataFlow(flow);
+        syncFlowHandles(this.viewRoot, canonicalBySource);
         this.broadcast("dataFlowBuilt", flow);
 
         // Create encoders (accessors, scales and related metadata)

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -43,7 +43,7 @@ import { createFramebufferInfo } from "twgl.js";
 
 /**
  * Events that are broadcasted to all views.
- * @typedef {"dataFlowBuilt" | "dataLoaded" | "layout" | "layoutComputed" | "subtreeDataReady"} BroadcastEventType
+ * @typedef {"dataFlowBuilt" | "layout" | "layoutComputed" | "subtreeDataReady"} BroadcastEventType
  */
 
 vegaFormats("fasta", fasta);
@@ -628,13 +628,6 @@ export default class GenomeSpy {
         // Now that all data have been loaded, the domains may need adjusting
         // IMPORTANT TODO: Check that discrete domains and indexers match!!!!!!!!!
         reconfigureScales(this.viewRoot);
-
-        // This event is needed by SampleView so that it can extract the sample ids
-        // from the data once they are loaded.
-        // TODO: It would be great if this could be attached to the data flow,
-        // because now this is somewhat a hack and is incompatible with dynamic data
-        // loading in the future.
-        this.broadcast("dataLoaded");
 
         await graphicsInitialized;
 

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -10,6 +10,7 @@ import {
     checkForDuplicateScaleNames,
     setImplicitScaleNames,
     calculateCanvasSize,
+    syncFlowHandles,
 } from "./view/viewUtils.js";
 import UnitView from "./view/unitView.js";
 
@@ -580,6 +581,7 @@ export default class GenomeSpy {
         // Build the data flow based on the view hierarchy
         const flow = buildDataFlow(this.viewRoot, context.dataFlow);
         optimizeDataFlow(flow);
+        syncFlowHandles(flow);
         this.broadcast("dataFlowBuilt", flow);
 
         // Create encoders (accessors, scales and related metadata)

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -606,8 +606,7 @@ export default class GenomeSpy {
                 }
                 context.animator.requestRender();
             };
-            view.flowHandle.collector.observers.push(observer);
-            view.collectorObserver = observer;
+            view.registerDisposer(view.flowHandle.collector.observe(observer));
         }
 
         // Have to wait until asynchronous font loading is complete.

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -43,7 +43,7 @@ import { createFramebufferInfo } from "twgl.js";
 
 /**
  * Events that are broadcasted to all views.
- * @typedef {"dataFlowBuilt" | "dataLoaded" | "layout" | "layoutComputed"} BroadcastEventType
+ * @typedef {"dataFlowBuilt" | "dataLoaded" | "layout" | "layoutComputed" | "subtreeDataReady"} BroadcastEventType
  */
 
 vegaFormats("fasta", fasta);

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -595,7 +595,9 @@ export default class GenomeSpy {
         for (const view of unitViews) {
             flow.addObserver(
                 view.flowHandle.collector,
-                (collector) => {
+                (
+                    /** @type {import("./data/collector.js").default} */ _collector
+                ) => {
                     view.mark.initializeData();
                     try {
                         // Update WebGL buffers
@@ -619,7 +621,11 @@ export default class GenomeSpy {
         // Find all data sources and initiate loading
         flow.initialize();
         await Promise.all(
-            flow.dataSources.map((dataSource) => dataSource.load())
+            flow.dataSources.map(
+                (
+                    /** @type {import("./data/sources/dataSource.js").default} */ dataSource
+                ) => dataSource.load()
+            )
         );
 
         // Now that all data have been loaded, the domains may need adjusting

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -10,8 +10,8 @@ import {
     checkForDuplicateScaleNames,
     setImplicitScaleNames,
     calculateCanvasSize,
-    syncFlowHandles,
 } from "./view/viewUtils.js";
+import { syncFlowHandles } from "./data/flowInit.js";
 import UnitView from "./view/unitView.js";
 
 import WebGLHelper, {

--- a/packages/core/src/marks/mark.js
+++ b/packages/core/src/marks/mark.js
@@ -96,6 +96,11 @@ export default class Mark {
     #callAfterShaderCompilation = [];
 
     /**
+     * @type {{expr: import("../view/paramMediator.js").ExprRefFunction, listener: () => void}[]}
+     */
+    #exprListeners = [];
+
+    /**
      * @param {import("../view/unitView.js").default} unitView
      */
     constructor(unitView) {
@@ -1034,6 +1039,7 @@ export default class Mark {
 
             // Register a listener ...
             fn.addListener(set);
+            this.#exprListeners.push({ expr: fn, listener: set });
             // ... and set the initial value
             set();
         } else {
@@ -1075,6 +1081,14 @@ export default class Mark {
             }
             this.bufferInfo = undefined;
         }
+    }
+
+    dispose() {
+        for (const { expr, listener } of this.#exprListeners) {
+            expr.removeListener(listener);
+        }
+        this.#exprListeners.length = 0;
+        this.deleteGraphicsData();
     }
 
     /**

--- a/packages/core/src/marks/mark.js
+++ b/packages/core/src/marks/mark.js
@@ -1045,7 +1045,14 @@ export default class Mark {
      * Delete WebGL buffers etc.
      */
     deleteGraphicsData() {
-        const gl = this.gl;
+        const glHelper = this.glHelper;
+        if (!glHelper) {
+            this.vertexArrayInfo = undefined;
+            this.bufferInfo = undefined;
+            return;
+        }
+
+        const gl = glHelper.gl;
 
         if (this.vertexArrayInfo) {
             this.gl.bindVertexArray(null);

--- a/packages/core/src/types/viewContext.d.ts
+++ b/packages/core/src/types/viewContext.d.ts
@@ -22,7 +22,7 @@ export type DataLoadingStatus = "loading" | "complete" | "error";
  * ViewContext provides essential data and interfaces to View classes.
  */
 export default interface ViewContext {
-    dataFlow: DataFlow<View>;
+    dataFlow: DataFlow;
     glHelper: WebGLHelper;
     animator: Animator;
     genomeStore?: GenomeStore;

--- a/packages/core/src/view/axisResolution.js
+++ b/packages/core/src/view/axisResolution.js
@@ -11,7 +11,7 @@ import { peek } from "../utils/arrayUtils.js";
 import coalesce from "../utils/coalesce.js";
 
 import mergeObjects from "../utils/mergeObjects.js";
-import { getCachedOrCall } from "../utils/propertyCacher.js";
+import { getCachedOrCall, invalidate } from "../utils/propertyCacher.js";
 
 /**
  * @template {import("../spec/channel.js").PositionalChannel}[T=PositionalChannel]
@@ -68,6 +68,21 @@ export default class AxisResolution {
         }
 
         this.members.push(newMember);
+        invalidate(this, "axisProps");
+    }
+
+    /**
+     * @param {UnitView} view
+     * @returns {boolean}
+     */
+    removeMembersByView(view) {
+        const before = this.members.length;
+        this.members = this.members.filter((member) => member.view !== view);
+        if (this.members.length !== before) {
+            invalidate(this, "axisProps");
+            return true;
+        }
+        return false;
     }
 
     getAxisProps() {

--- a/packages/core/src/view/facetView.js
+++ b/packages/core/src/view/facetView.js
@@ -129,6 +129,7 @@ export default class FacetView extends ContainerView {
             throw new Error("Not my child!");
         }
 
+        child.disposeSubtree();
         this.child = /** @type {UnitView | LayerView | DecoratorView} */ (
             replacement
         );

--- a/packages/core/src/view/flowBuilder.js
+++ b/packages/core/src/view/flowBuilder.js
@@ -122,6 +122,15 @@ export function buildDataFlow(root, existingFlow) {
     /** @param {View} view */
     const processView = (view) => {
         if (view.spec.data) {
+            const previousDataSource = view.flowHandle?.dataSource;
+            if (
+                previousDataSource &&
+                previousDataSource.view === view &&
+                !previousDataSource.identifier
+            ) {
+                dataFlow.removeDataSource(previousDataSource);
+            }
+
             const dataSource = isNamedData(view.spec.data)
                 ? new NamedSource(
                       view.spec.data,
@@ -132,7 +141,7 @@ export function buildDataFlow(root, existingFlow) {
 
             currentNode = dataSource;
             nodeStack.push(dataSource);
-            dataFlow.addDataSource(dataSource, view);
+            dataFlow.addDataSource(dataSource);
             view.flowHandle ??= {};
             view.flowHandle.dataSource = dataSource;
         }
@@ -188,7 +197,11 @@ export function buildDataFlow(root, existingFlow) {
             });
 
             appendNode(collector);
-            dataFlow.addCollector(collector, view);
+            const previousCollector = view.flowHandle?.collector;
+            if (previousCollector) {
+                dataFlow.removeCollector(previousCollector);
+            }
+            dataFlow.addCollector(collector);
             view.flowHandle ??= {};
             view.flowHandle.collector = collector;
         }

--- a/packages/core/src/view/flowBuilder.js
+++ b/packages/core/src/view/flowBuilder.js
@@ -133,6 +133,8 @@ export function buildDataFlow(root, existingFlow) {
             currentNode = dataSource;
             nodeStack.push(dataSource);
             dataFlow.addDataSource(dataSource, view);
+            view.flowHandle ??= {};
+            view.flowHandle.dataSource = dataSource;
         }
 
         if (view.spec.transform) {
@@ -187,6 +189,8 @@ export function buildDataFlow(root, existingFlow) {
 
             appendNode(collector);
             dataFlow.addCollector(collector, view);
+            view.flowHandle ??= {};
+            view.flowHandle.collector = collector;
         }
     };
 

--- a/packages/core/src/view/flowBuilder.js
+++ b/packages/core/src/view/flowBuilder.js
@@ -24,7 +24,7 @@ import { nodesToTreesWithAccessor, visitTree } from "../utils/trees.js";
 
 /**
  * @param {View} root
- * @param {DataFlow<View>} [existingFlow] Add data flow
+ * @param {DataFlow} [existingFlow] Add data flow
  *      graphs to an existing DataFlow object.
  */
 export function buildDataFlow(root, existingFlow) {
@@ -41,7 +41,7 @@ export function buildDataFlow(root, existingFlow) {
     /** @type {FlowNode} */
     let currentNode;
 
-    /** @type {DataFlow<View>} */
+    /** @type {DataFlow} */
     const dataFlow = existingFlow ?? new DataFlow();
 
     /** @type {(function():void)[]} */

--- a/packages/core/src/view/gridView/gridView.js
+++ b/packages/core/src/view/gridView/gridView.js
@@ -133,6 +133,7 @@ export default class GridView extends ContainerView {
             (gridChild) => gridChild.view == child
         );
         if (i >= 0) {
+            child.disposeSubtree();
             this.#children[i] = new GridChild(
                 replacement,
                 this,

--- a/packages/core/src/view/gridView/gridView.js
+++ b/packages/core/src/view/gridView/gridView.js
@@ -118,6 +118,9 @@ export default class GridView extends ContainerView {
      * @param {View[]} views
      */
     setChildren(views) {
+        for (const gridChild of this.#children) {
+            gridChild.view.disposeSubtree();
+        }
         this.#children = [];
         for (const view of views) {
             this.appendChild(view);

--- a/packages/core/src/view/gridView/gridView.js
+++ b/packages/core/src/view/gridView/gridView.js
@@ -119,7 +119,7 @@ export default class GridView extends ContainerView {
      */
     setChildren(views) {
         for (const gridChild of this.#children) {
-            gridChild.view.disposeSubtree();
+            this.#disposeGridChild(gridChild);
         }
         this.#children = [];
         for (const view of views) {
@@ -136,7 +136,7 @@ export default class GridView extends ContainerView {
             (gridChild) => gridChild.view == child
         );
         if (i >= 0) {
-            child.disposeSubtree();
+            this.#disposeGridChild(this.#children[i]);
             this.#children[i] = new GridChild(
                 replacement,
                 this,
@@ -144,6 +144,15 @@ export default class GridView extends ContainerView {
             );
         } else {
             throw new Error("Not my child view!");
+        }
+    }
+
+    /**
+     * @param {GridChild} gridChild
+     */
+    #disposeGridChild(gridChild) {
+        for (const view of gridChild.getChildren()) {
+            view.disposeSubtree();
         }
     }
 

--- a/packages/core/src/view/gridView/selectionRect.js
+++ b/packages/core/src/view/gridView/selectionRect.js
@@ -152,7 +152,9 @@ export default class SelectionRect extends LayerView {
 
             const datasource =
                 /** @type {import("../../data/sources/inlineSource.js").default} */ (
-                    this.context.dataFlow.findDataSourceByKey(this)
+                    this.flowHandle && this.flowHandle.dataSource
+                        ? this.flowHandle.dataSource
+                        : this.context.dataFlow.findDataSourceByKey(this)
                 );
 
             datasource.updateDynamicData(selectionToData(selection));

--- a/packages/core/src/view/gridView/selectionRect.js
+++ b/packages/core/src/view/gridView/selectionRect.js
@@ -152,10 +152,14 @@ export default class SelectionRect extends LayerView {
 
             const datasource =
                 /** @type {import("../../data/sources/inlineSource.js").default} */ (
-                    this.flowHandle && this.flowHandle.dataSource
-                        ? this.flowHandle.dataSource
-                        : this.context.dataFlow.findDataSourceByKey(this)
+                    this.flowHandle?.dataSource
                 );
+
+            if (!datasource) {
+                throw new Error(
+                    "Cannot find selection rect data source handle!"
+                );
+            }
 
             datasource.updateDynamicData(selectionToData(selection));
         };

--- a/packages/core/src/view/gridView/selectionRect.js
+++ b/packages/core/src/view/gridView/selectionRect.js
@@ -7,6 +7,12 @@ export default class SelectionRect extends LayerView {
      * @typedef {import("../../types/selectionTypes.js").IntervalSelection} IntervalSelection
      */
 
+    /** @type {import("../paramMediator.js").ExprRefFunction} */
+    _selectionExpr;
+
+    /** @type {() => void} */
+    _selectionListener;
+
     /**
      * @param {import("./gridChild.js").default} gridChild
      * @param {import("../paramMediator.js").ExprRefFunction} selectionExpr
@@ -135,7 +141,10 @@ export default class SelectionRect extends LayerView {
             }
         );
 
-        selectionExpr.addListener(() => {
+        /** @type {import("../paramMediator.js").ExprRefFunction} */
+        this._selectionExpr = selectionExpr;
+
+        this._selectionListener = () => {
             const selection =
                 /** @type {import("../../types/selectionTypes.js").IntervalSelection} */ (
                     selectionExpr()
@@ -147,7 +156,17 @@ export default class SelectionRect extends LayerView {
                 );
 
             datasource.updateDynamicData(selectionToData(selection));
-        });
+        };
+
+        selectionExpr.addListener(this._selectionListener);
+    }
+
+    /**
+     * @override
+     */
+    dispose() {
+        this._selectionExpr.removeListener(this._selectionListener);
+        super.dispose();
     }
 }
 

--- a/packages/core/src/view/gridView/selectionRect.test.js
+++ b/packages/core/src/view/gridView/selectionRect.test.js
@@ -35,25 +35,43 @@ describe("SelectionRect", () => {
             intervals: { x: [0, 1], y: [2, 3] },
         };
 
+        /** @type {(listener: () => void) => void} */
+        const addListener = () => undefined;
+        /** @type {(listener: () => void) => void} */
+        const removeListener = () => undefined;
+        /** @type {() => void} */
+        const invalidate = () => undefined;
+
         /** @type {import("../paramMediator.js").ExprRefFunction} */
         const selectionExpr = Object.assign(() => selection, {
-            addListener: () => undefined,
-            removeListener: () => undefined,
+            addListener,
+            removeListener,
+            invalidate,
+            identifier: () => "selection",
+            fields: [],
+            globals: [],
+            code: "selection",
         });
 
-        const gridChild = {
-            layoutParent: parent,
-            view: unitView,
-        };
+        const gridChild = /** @type {import("./gridChild.js").default} */ (
+            /** @type {unknown} */ ({
+                layoutParent: parent,
+                view: unitView,
+            })
+        );
 
         const selectionRect = new SelectionRect(gridChild, selectionExpr);
 
         const flow = buildDataFlow(selectionRect, context.dataFlow);
         syncFlowHandles(selectionRect, optimizeDataFlow(flow));
 
-        const dataSource = selectionRect.flowHandle?.dataSource;
+        const dataSource =
+            /** @type {import("../../data/sources/inlineSource.js").default} */ (
+                selectionRect.flowHandle?.dataSource
+            );
         expect(dataSource).toBeDefined();
 
+        // Selection updates should push new interval data to the inline source.
         const updateSpy = vi.spyOn(dataSource, "updateDynamicData");
         selection = {
             intervals: { x: [5, 6], y: [7, 8] },

--- a/packages/core/src/view/gridView/selectionRect.test.js
+++ b/packages/core/src/view/gridView/selectionRect.test.js
@@ -6,7 +6,7 @@ import SelectionRect from "./selectionRect.js";
 import { createTestViewContext } from "../testUtils.js";
 import { buildDataFlow } from "../flowBuilder.js";
 import { optimizeDataFlow } from "../../data/flowOptimizer.js";
-import { syncFlowHandles } from "../viewUtils.js";
+import { syncFlowHandles } from "../../data/flowInit.js";
 
 describe("SelectionRect", () => {
     it("uses flow handles for dynamic data updates", () => {

--- a/packages/core/src/view/gridView/selectionRect.test.js
+++ b/packages/core/src/view/gridView/selectionRect.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+
+import ConcatView from "../concatView.js";
+import UnitView from "../unitView.js";
+import SelectionRect from "./selectionRect.js";
+import { createTestViewContext } from "../testUtils.js";
+import { buildDataFlow } from "../flowBuilder.js";
+import { optimizeDataFlow } from "../../data/flowOptimizer.js";
+import { syncFlowHandles } from "../viewUtils.js";
+
+describe("SelectionRect", () => {
+    it("uses flow handles for dynamic data updates", () => {
+        const context = createTestViewContext();
+        const parent = new ConcatView(
+            { hconcat: [] },
+            context,
+            null,
+            null,
+            "p"
+        );
+
+        /** @type {import("../../spec/view.js").UnitSpec} */
+        const unitSpec = {
+            data: { values: [{ x: 0, y: 0 }] },
+            mark: "point",
+            encoding: {
+                x: { field: "x", type: "quantitative" },
+                y: { field: "y", type: "quantitative" },
+            },
+        };
+
+        const unitView = new UnitView(unitSpec, context, parent, parent, "u");
+
+        let selection = {
+            intervals: { x: [0, 1], y: [2, 3] },
+        };
+
+        /** @type {import("../paramMediator.js").ExprRefFunction} */
+        const selectionExpr = Object.assign(() => selection, {
+            addListener: () => undefined,
+            removeListener: () => undefined,
+        });
+
+        const gridChild = {
+            layoutParent: parent,
+            view: unitView,
+        };
+
+        const selectionRect = new SelectionRect(gridChild, selectionExpr);
+
+        const flow = buildDataFlow(selectionRect, context.dataFlow);
+        optimizeDataFlow(flow);
+        syncFlowHandles(flow);
+
+        const dataSource = selectionRect.flowHandle?.dataSource;
+        expect(dataSource).toBeDefined();
+
+        const updateSpy = vi.spyOn(dataSource, "updateDynamicData");
+        selection = {
+            intervals: { x: [5, 6], y: [7, 8] },
+        };
+
+        selectionRect._selectionListener();
+
+        expect(updateSpy).toHaveBeenCalledTimes(1);
+        expect(updateSpy).toHaveBeenCalledWith([
+            { _x: 5, _x2: 6, _y: 7, _y2: 8 },
+        ]);
+    });
+});

--- a/packages/core/src/view/gridView/selectionRect.test.js
+++ b/packages/core/src/view/gridView/selectionRect.test.js
@@ -49,8 +49,7 @@ describe("SelectionRect", () => {
         const selectionRect = new SelectionRect(gridChild, selectionExpr);
 
         const flow = buildDataFlow(selectionRect, context.dataFlow);
-        optimizeDataFlow(flow);
-        syncFlowHandles(selectionRect, flow);
+        syncFlowHandles(selectionRect, optimizeDataFlow(flow));
 
         const dataSource = selectionRect.flowHandle?.dataSource;
         expect(dataSource).toBeDefined();

--- a/packages/core/src/view/gridView/selectionRect.test.js
+++ b/packages/core/src/view/gridView/selectionRect.test.js
@@ -50,7 +50,7 @@ describe("SelectionRect", () => {
 
         const flow = buildDataFlow(selectionRect, context.dataFlow);
         optimizeDataFlow(flow);
-        syncFlowHandles(flow);
+        syncFlowHandles(selectionRect, flow);
 
         const dataSource = selectionRect.flowHandle?.dataSource;
         expect(dataSource).toBeDefined();

--- a/packages/core/src/view/paramMediator.js
+++ b/packages/core/src/view/paramMediator.js
@@ -468,6 +468,7 @@ export function validateParameterName(name) {
 export function makeConstantExprRef(value) {
     return Object.assign(() => value, {
         addListener: () => /** @type {void} */ (undefined),
+        removeListener: () => /** @type {void} */ (undefined),
         invalidate: () => /** @type {void} */ (undefined),
         identifier: () => "constant",
         fields: [],

--- a/packages/core/src/view/paramMediator.js
+++ b/packages/core/src/view/paramMediator.js
@@ -16,7 +16,7 @@ import {
  * TODO: The proposed JavaScript signals may provide a better way to implement this.
  * https://github.com/proposal-signals/proposal-signals
  *
- * @typedef {import("../utils/expression.js").ExpressionFunction & { addListener: (listener: () => void) => void, invalidate: () => void, identifier: () => string}} ExprRefFunction
+ * @typedef {import("../utils/expression.js").ExpressionFunction & { addListener: (listener: () => void) => void, removeListener: (listener: () => void) => void, invalidate: () => void, identifier: () => string}} ExprRefFunction
  */
 export default class ParamMediator {
     /**
@@ -281,6 +281,16 @@ export default class ParamMediator {
         };
 
         /**
+         * @param {() => void} listener
+         */
+        fn.removeListener = (listener) => {
+            for (const [param, mediator] of mediatorsForParams) {
+                mediator.paramListeners.get(param)?.delete(listener);
+            }
+            myListeners.delete(listener);
+        };
+
+        /**
          * Detach listeners. This must be called if the expression is no longer used.
          * TODO: What if the expression is used in multiple places?
          */
@@ -290,6 +300,7 @@ export default class ParamMediator {
                     mediator.paramListeners.get(param)?.delete(listener);
                 }
             }
+            myListeners.clear();
         };
 
         // TODO: This should contain unique identifier for each parameter.

--- a/packages/core/src/view/paramMediator.test.js
+++ b/packages/core/src/view/paramMediator.test.js
@@ -87,6 +87,28 @@ describe("Single-level ParamMediator", () => {
         expect(result).toBe(51);
     });
 
+    test("Expression removeListener detaches a listener", () => {
+        const pm = new ParamMediator();
+        const setter = pm.allocateSetter("foo", 42);
+        const expr = pm.createExpression("foo + 1");
+
+        let calls = 0;
+
+        const listener = () => {
+            calls++;
+        };
+
+        expr.addListener(listener);
+
+        setter(50);
+        expect(calls).toBe(1);
+
+        expr.removeListener(listener);
+
+        setter(60);
+        expect(calls).toBe(1);
+    });
+
     test("Expression parameter handles dependencies", () => {
         const pm = new ParamMediator();
         const setter = pm.registerParam({ name: "foo", value: 42 });

--- a/packages/core/src/view/scaleResolution.js
+++ b/packages/core/src/view/scaleResolution.js
@@ -232,6 +232,16 @@ export default class ScaleResolution {
     }
 
     /**
+     * @param {UnitView} view
+     * @returns {boolean}
+     */
+    removeMembersByView(view) {
+        const before = this.members.length;
+        this.members = this.members.filter((member) => member.view !== view);
+        return this.members.length !== before;
+    }
+
+    /**
      * Returns true if the domain has been defined explicitly, i.e. not extracted from the data.
      */
     #isExplicitDomain() {

--- a/packages/core/src/view/testUtils.js
+++ b/packages/core/src/view/testUtils.js
@@ -6,7 +6,8 @@
  * @typedef {import("../types/viewContext.js").default} ViewContext
  */
 
-import { checkForDuplicateScaleNames, initializeData } from "./viewUtils.js";
+import { checkForDuplicateScaleNames } from "./viewUtils.js";
+import { initializeData } from "../data/flowInit.js";
 import DataFlow from "../data/dataFlow.js";
 import { VIEW_ROOT_NAME, ViewFactory } from "./viewFactory.js";
 import GenomeStore from "../genome/genomeStore.js";

--- a/packages/core/src/view/unitView.js
+++ b/packages/core/src/view/unitView.js
@@ -466,12 +466,7 @@ export default class UnitView extends View {
      * Returns a collector that is associated with this view.
      */
     getCollector() {
-        const handle = this.flowHandle;
-        if (handle && handle.collector) {
-            return handle.collector;
-        }
-
-        return this.context.dataFlow.findCollectorByKey(this);
+        return this.flowHandle?.collector;
     }
 
     /**

--- a/packages/core/src/view/unitView.js
+++ b/packages/core/src/view/unitView.js
@@ -61,11 +61,6 @@ export default class UnitView extends View {
     #zoomLevelSetter;
 
     /**
-     * @type {{resolution: ScaleResolution, listener: import("../types/scaleResolutionApi.js").ScaleResolutionListener}[]}
-     */
-    #scaleResolutionListeners = [];
-
-    /**
      *
      * @param {import("../spec/view.js").UnitSpec} spec
      * @param {import("../types/viewContext.js").default} context
@@ -104,10 +99,9 @@ export default class UnitView extends View {
                     this.#zoomLevelSetter(Math.sqrt(this.getZoomLevel()));
                 };
                 resolution.addEventListener("domain", listener);
-                this.#scaleResolutionListeners.push({
-                    resolution,
-                    listener,
-                });
+                this.registerDisposer(() =>
+                    resolution.removeEventListener("domain", listener)
+                );
             }
         }
 
@@ -399,10 +393,6 @@ export default class UnitView extends View {
      */
     dispose() {
         super.dispose();
-        for (const { resolution, listener } of this.#scaleResolutionListeners) {
-            resolution.removeEventListener("domain", listener);
-        }
-        this.#scaleResolutionListeners.length = 0;
 
         this.#unresolve();
         this.mark.dispose();

--- a/packages/core/src/view/unitView.js
+++ b/packages/core/src/view/unitView.js
@@ -405,7 +405,7 @@ export default class UnitView extends View {
         this.#scaleResolutionListeners.length = 0;
 
         this.#unresolve();
-        this.mark.deleteGraphicsData();
+        this.mark.dispose();
     }
 
     #unresolve() {

--- a/packages/core/src/view/unitView.js
+++ b/packages/core/src/view/unitView.js
@@ -398,6 +398,7 @@ export default class UnitView extends View {
      * @override
      */
     dispose() {
+        super.dispose();
         for (const { resolution, listener } of this.#scaleResolutionListeners) {
             resolution.removeEventListener("domain", listener);
         }

--- a/packages/core/src/view/unitView.js
+++ b/packages/core/src/view/unitView.js
@@ -466,6 +466,11 @@ export default class UnitView extends View {
      * Returns a collector that is associated with this view.
      */
     getCollector() {
+        const handle = this.flowHandle;
+        if (handle && handle.collector) {
+            return handle.collector;
+        }
+
         return this.context.dataFlow.findCollectorByKey(this);
     }
 

--- a/packages/core/src/view/view.js
+++ b/packages/core/src/view/view.js
@@ -137,6 +137,11 @@ export default class View {
         };
 
         /**
+         * @type {import("../data/flowHandle.js").FlowHandle | undefined}
+         */
+        this.flowHandle = undefined;
+
+        /**
          * Whether GridView or equivalent should draw axis and grid lines for this view.
          * TODO: Use view options for this.
          * @type {Record<import("../spec/channel.js").PrimaryPositionalChannel, boolean>}
@@ -513,6 +518,7 @@ export default class View {
      */
     dispose() {
         this.context.dataFlow.removeHost(this);
+        this.flowHandle = undefined;
     }
 
     /**

--- a/packages/core/src/view/view.js
+++ b/packages/core/src/view/view.js
@@ -87,6 +87,11 @@ export default class View {
     opacityFunction = defaultOpacityFunction;
 
     /**
+     * @type {function(import("../data/collector.js").default):void}
+     */
+    collectorObserver = undefined;
+
+    /**
      * Coords of the view for each facet, recorded during the last layout rendering pass.
      * Most views have only one facet, so the map is usually of size 1.
      *
@@ -518,14 +523,14 @@ export default class View {
      */
     dispose() {
         const handle = this.flowHandle;
-        if (handle?.collectorObserver && handle.collector) {
+        if (this.collectorObserver && handle?.collector) {
             const index = handle.collector.observers.indexOf(
-                handle.collectorObserver
+                this.collectorObserver
             );
             if (index >= 0) {
                 handle.collector.observers.splice(index, 1);
             }
-            handle.collectorObserver = undefined;
+            this.collectorObserver = undefined;
         }
 
         if (handle?.collector) {

--- a/packages/core/src/view/view.js
+++ b/packages/core/src/view/view.js
@@ -509,6 +509,25 @@ export default class View {
     }
 
     /**
+     * Release resources owned by this view.
+     */
+    dispose() {
+        // override
+    }
+
+    /**
+     * Dispose this view and all descendants in post-order.
+     */
+    disposeSubtree() {
+        /** @type {Visitor} */
+        const visitor = () => undefined;
+        visitor.postOrder = (view) => {
+            view.dispose();
+        };
+        this.visit(visitor);
+    }
+
+    /**
      * Called after all scales in the view hierarchy have been resolved.
      */
     configureViewOpacity() {

--- a/packages/core/src/view/view.js
+++ b/packages/core/src/view/view.js
@@ -517,7 +517,29 @@ export default class View {
      * Release resources owned by this view.
      */
     dispose() {
-        this.context.dataFlow.removeHost(this);
+        const handle = this.flowHandle;
+        if (handle?.collectorObserver && handle.collector) {
+            const index = handle.collector.observers.indexOf(
+                handle.collectorObserver
+            );
+            if (index >= 0) {
+                handle.collector.observers.splice(index, 1);
+            }
+            handle.collectorObserver = undefined;
+        }
+
+        if (handle?.collector) {
+            this.context.dataFlow.removeCollector(handle.collector);
+        }
+
+        if (
+            handle?.dataSource &&
+            handle.dataSource.view === this &&
+            !handle.dataSource.identifier
+        ) {
+            this.context.dataFlow.removeDataSource(handle.dataSource);
+        }
+
         this.flowHandle = undefined;
     }
 

--- a/packages/core/src/view/view.js
+++ b/packages/core/src/view/view.js
@@ -512,7 +512,7 @@ export default class View {
      * Release resources owned by this view.
      */
     dispose() {
-        // override
+        this.context.dataFlow.removeHost(this);
     }
 
     /**

--- a/packages/core/src/view/viewDispose.test.js
+++ b/packages/core/src/view/viewDispose.test.js
@@ -97,11 +97,12 @@ describe("View disposal", () => {
 
         const dataSource = new DataSource(child);
         context.dataFlow.addDataSource(dataSource, child);
+        child.flowHandle = { dataSource };
 
-        expect(context.dataFlow.findDataSourceByKey(child)).toBe(dataSource);
+        expect(child.flowHandle.dataSource).toBe(dataSource);
 
         child.disposeSubtree();
 
-        expect(context.dataFlow.findDataSourceByKey(child)).toBeUndefined();
+        expect(child.flowHandle).toBeUndefined();
     });
 });

--- a/packages/core/src/view/viewDispose.test.js
+++ b/packages/core/src/view/viewDispose.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import ConcatView from "./concatView.js";
+import DataSource from "../data/sources/dataSource.js";
 import UnitView from "./unitView.js";
 import View from "./view.js";
 import { create, createTestViewContext } from "./testUtils.js";
@@ -80,5 +81,26 @@ describe("View disposal", () => {
 
         expect(childC.disposed).toBe(true);
         expect(childD.disposed).toBe(false);
+    });
+
+    test("removes dataflow hosts on dispose", () => {
+        const context = createTestViewContext();
+        const parent = new ConcatView(
+            { hconcat: [] },
+            context,
+            null,
+            null,
+            "c"
+        );
+        const child = new DisposableView("a", context, parent, parent);
+
+        const dataSource = new DataSource(child);
+        context.dataFlow.addDataSource(dataSource, child);
+
+        expect(context.dataFlow.findDataSourceByKey(child)).toBe(dataSource);
+
+        child.disposeSubtree();
+
+        expect(context.dataFlow.findDataSourceByKey(child)).toBeUndefined();
     });
 });

--- a/packages/core/src/view/viewDispose.test.js
+++ b/packages/core/src/view/viewDispose.test.js
@@ -17,7 +17,9 @@ class DisposableView extends View {
      * @param {import("./view.js").default} dataParent
      */
     constructor(name, context, layoutParent, dataParent) {
-        super({ name }, context, layoutParent, dataParent, name);
+        /** @type {import("../spec/view.js").LayerSpec} */
+        const spec = { name, layer: [] };
+        super(spec, context, layoutParent, dataParent, name);
     }
 
     dispose() {

--- a/packages/core/src/view/viewDispose.test.js
+++ b/packages/core/src/view/viewDispose.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+
+import UnitView from "./unitView.js";
+import { create } from "./testUtils.js";
+
+describe("View disposal", () => {
+    test("removes scale and axis resolutions for disposed unit views", async () => {
+        /** @type {import("../spec/view.js").UnitSpec} */
+        const spec = {
+            data: {
+                values: [
+                    {
+                        x: 1,
+                        y: 2,
+                    },
+                ],
+            },
+            mark: "point",
+            encoding: {
+                x: { field: "x", type: "quantitative" },
+                y: { field: "y", type: "quantitative" },
+            },
+        };
+
+        const view = await create(spec, UnitView);
+
+        expect(view.getScaleResolution("x")).toBeDefined();
+        expect(view.getAxisResolution("x")).toBeDefined();
+
+        view.disposeSubtree();
+
+        expect(view.getScaleResolution("x")).toBeUndefined();
+        expect(view.getAxisResolution("x")).toBeUndefined();
+    });
+});

--- a/packages/core/src/view/viewDispose.test.js
+++ b/packages/core/src/view/viewDispose.test.js
@@ -21,6 +21,7 @@ class DisposableView extends View {
     }
 
     dispose() {
+        super.dispose();
         this.disposed = true;
     }
 }

--- a/packages/core/src/view/viewDispose.test.js
+++ b/packages/core/src/view/viewDispose.test.js
@@ -96,7 +96,7 @@ describe("View disposal", () => {
         const child = new DisposableView("a", context, parent, parent);
 
         const dataSource = new DataSource(child);
-        context.dataFlow.addDataSource(dataSource, child);
+        context.dataFlow.addDataSource(dataSource);
         child.flowHandle = { dataSource };
 
         expect(child.flowHandle.dataSource).toBe(dataSource);

--- a/packages/core/src/view/viewUtils.js
+++ b/packages/core/src/view/viewUtils.js
@@ -117,14 +117,14 @@ export async function initializeData(root, existingFlow) {
  * @param {import("../data/dataFlow.js").default<View>} flow
  */
 export function syncFlowHandles(flow) {
-    for (const [host, dataSource] of flow._dataSourcesByHost.entries()) {
+    for (const [host, dataSource] of flow.getDataSourceEntries()) {
         if (host && typeof host === "object" && "flowHandle" in host) {
             host.flowHandle ??= {};
             host.flowHandle.dataSource = dataSource;
         }
     }
 
-    for (const [host, collector] of flow._collectorsByHost.entries()) {
+    for (const [host, collector] of flow.getCollectorEntries()) {
         if (host && typeof host === "object" && "flowHandle" in host) {
             host.flowHandle ??= {};
             host.flowHandle.collector = collector;

--- a/packages/core/src/view/viewUtils.js
+++ b/packages/core/src/view/viewUtils.js
@@ -100,6 +100,7 @@ export function setImplicitScaleNames(root) {
 export async function initializeData(root, existingFlow) {
     const flow = buildDataFlow(root, existingFlow);
     optimizeDataFlow(flow);
+    syncFlowHandles(flow);
     flow.initialize();
 
     /** @type {Promise<void>[]} */
@@ -108,6 +109,27 @@ export async function initializeData(root, existingFlow) {
     await Promise.all(promises);
 
     return flow;
+}
+
+/**
+ * Synchronize flow handles with the current DataFlow host mappings.
+ *
+ * @param {import("../data/dataFlow.js").default<View>} flow
+ */
+export function syncFlowHandles(flow) {
+    for (const [host, dataSource] of flow._dataSourcesByHost.entries()) {
+        if (host && typeof host === "object" && "flowHandle" in host) {
+            host.flowHandle ??= {};
+            host.flowHandle.dataSource = dataSource;
+        }
+    }
+
+    for (const [host, collector] of flow._collectorsByHost.entries()) {
+        if (host && typeof host === "object" && "flowHandle" in host) {
+            host.flowHandle ??= {};
+            host.flowHandle.collector = collector;
+        }
+    }
 }
 
 /**

--- a/packages/core/src/view/viewUtils.js
+++ b/packages/core/src/view/viewUtils.js
@@ -146,6 +146,7 @@ export function syncFlowHandles(flow) {
  */
 export function initializeSubtree(root, flow) {
     const dataFlow = buildDataFlow(root, flow);
+    syncFlowHandles(dataFlow);
     const subtreeViews = root.getDescendants();
     const dataSources = new Set(flow.getDataSourcesForHosts(subtreeViews));
 

--- a/packages/core/src/view/viewUtils.js
+++ b/packages/core/src/view/viewUtils.js
@@ -3,8 +3,6 @@ import { isObject, isString } from "vega-util";
 import UnitView from "./unitView.js";
 // eslint-disable-next-line no-unused-vars
 import View, { VISIT_SKIP, VISIT_STOP } from "./view.js";
-import { buildDataFlow } from "./flowBuilder.js";
-import { optimizeDataFlow } from "../data/flowOptimizer.js";
 import { isFieldDef, primaryPositionalChannels } from "../encoder/encoder.js";
 import { rollup } from "d3-array";
 import { concatUrl, getDirectory } from "../utils/url.js";
@@ -90,111 +88,6 @@ export function setImplicitScaleNames(root) {
             resolution.name = `${channel}_at_root`;
         }
     }
-}
-
-/**
- * @param {View} root
- * @param {import("../data/dataFlow.js").default<View>} [existingFlow] Add data flow
- *      graphs to an existing DataFlow object.
- */
-export async function initializeData(root, existingFlow) {
-    const flow = buildDataFlow(root, existingFlow);
-    const canonicalBySource = optimizeDataFlow(flow);
-    syncFlowHandles(root, canonicalBySource);
-    flow.initialize();
-
-    /** @type {Promise<void>[]} */
-    const promises = flow.dataSources.map((dataSource) => dataSource.load());
-
-    await Promise.all(promises);
-
-    return flow;
-}
-
-/**
- * Synchronize flow handles after data flow optimization.
- *
- * @param {View} root
- * @param {Map<import("../data/sources/dataSource.js").default, import("../data/sources/dataSource.js").default>} canonicalBySource
- */
-export function syncFlowHandles(root, canonicalBySource) {
-    for (const view of root.getDescendants()) {
-        const handle = view.flowHandle;
-        if (!handle) {
-            continue;
-        }
-
-        const dataSource = handle.dataSource;
-        if (dataSource) {
-            handle.dataSource = canonicalBySource.get(dataSource) ?? dataSource;
-        }
-    }
-}
-
-/**
- * Initializes data flow and marks for a subtree without reinitializing the whole view tree.
- *
- * @param {View} root
- * @param {import("../data/dataFlow.js").default<View>} flow
- * @returns {{
- *     dataFlow: import("../data/dataFlow.js").default<View>,
- *     unitViews: UnitView[],
- *     dataSources: Set<import("../data/sources/dataSource.js").default>,
- *     graphicsPromises: Promise<import("../marks/mark.js").default>[]
- * }}
- */
-export function initializeSubtree(root, flow) {
-    const dataFlow = buildDataFlow(root, flow);
-    const canonicalBySource = optimizeDataFlow(dataFlow);
-    syncFlowHandles(root, canonicalBySource);
-    const subtreeViews = root.getDescendants();
-    /** @type {Set<import("../data/sources/dataSource.js").default>} */
-    const dataSources = new Set();
-    for (const view of subtreeViews) {
-        let current = view;
-        while (current && !current.flowHandle?.dataSource) {
-            current = current.dataParent;
-        }
-        if (current?.flowHandle?.dataSource) {
-            dataSources.add(current.flowHandle.dataSource);
-        }
-    }
-
-    for (const dataSource of dataSources) {
-        dataSource.visit((node) => node.initialize());
-    }
-
-    /** @type {UnitView[]} */
-    const unitViews = subtreeViews.filter((view) => view instanceof UnitView);
-
-    /** @type {Promise<import("../marks/mark.js").default>[]} */
-    const graphicsPromises = [];
-
-    const canInitializeGraphics = !!root.context.glHelper;
-
-    for (const view of unitViews) {
-        const mark = view.mark;
-        mark.initializeEncoders();
-        if (canInitializeGraphics) {
-            graphicsPromises.push(mark.initializeGraphics().then(() => mark));
-        }
-
-        flow.addObserver(
-            view.flowHandle.collector,
-            (collector) => {
-                mark.initializeData(); // does faceting
-                mark.updateGraphicsData();
-            },
-            view.flowHandle
-        );
-    }
-
-    return {
-        dataFlow,
-        unitViews,
-        dataSources,
-        graphicsPromises,
-    };
 }
 
 /**

--- a/packages/core/src/view/viewUtils.test.js
+++ b/packages/core/src/view/viewUtils.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, test, vi } from "vitest";
 
 import { createTestViewContext } from "./testUtils.js";
-import { finalizeSubtreeGraphics, initializeSubtree } from "./viewUtils.js";
+import { finalizeSubtreeGraphics } from "./viewUtils.js";
+import { initializeSubtree } from "../data/flowInit.js";
 
 describe("initializeSubtree", () => {
     test("initializes data flow for a subtree only", async () => {

--- a/packages/core/src/view/viewUtils.test.js
+++ b/packages/core/src/view/viewUtils.test.js
@@ -8,7 +8,7 @@ describe("initializeSubtree", () => {
     test("initializes data flow for a subtree only", async () => {
         const context = createTestViewContext();
 
-        /** @type {import("../spec/view.js").ConcatSpec} */
+        /** @type {import("../spec/view.js").HConcatSpec} */
         const spec = {
             hconcat: [
                 {
@@ -33,8 +33,11 @@ describe("initializeSubtree", () => {
         };
 
         const root = await context.createOrImportView(spec, null, null, "root");
-        const child = root.children[0];
-        const otherChild = root.children[1];
+        const concatRoot = /** @type {import("./concatView.js").default} */ (
+            root
+        );
+        const child = concatRoot.children[0];
+        const otherChild = concatRoot.children[1];
 
         const { dataSources, graphicsPromises, unitViews } = initializeSubtree(
             child,
@@ -52,8 +55,16 @@ describe("initializeSubtree", () => {
 
 describe("finalizeSubtreeGraphics", () => {
     test("finalizes marks when allowed", async () => {
-        const markA = { finalizeGraphicsInitialization: vi.fn() };
-        const markB = { finalizeGraphicsInitialization: vi.fn() };
+        const markA = /** @type {import("../marks/mark.js").default} */ (
+            /** @type {unknown} */ ({
+                finalizeGraphicsInitialization: vi.fn(),
+            })
+        );
+        const markB = /** @type {import("../marks/mark.js").default} */ (
+            /** @type {unknown} */ ({
+                finalizeGraphicsInitialization: vi.fn(),
+            })
+        );
 
         await finalizeSubtreeGraphics([
             Promise.resolve(markA),
@@ -65,7 +76,11 @@ describe("finalizeSubtreeGraphics", () => {
     });
 
     test("skips finalization when predicate is false", async () => {
-        const mark = { finalizeGraphicsInitialization: vi.fn() };
+        const mark = /** @type {import("../marks/mark.js").default} */ (
+            /** @type {unknown} */ ({
+                finalizeGraphicsInitialization: vi.fn(),
+            })
+        );
 
         await finalizeSubtreeGraphics([Promise.resolve(mark)], () => false);
 

--- a/packages/core/src/view/viewUtils.test.js
+++ b/packages/core/src/view/viewUtils.test.js
@@ -2,9 +2,9 @@ import { describe, expect, test, vi } from "vitest";
 
 import { createTestViewContext } from "./testUtils.js";
 import { finalizeSubtreeGraphics } from "./viewUtils.js";
-import { initializeSubtree } from "../data/flowInit.js";
+import { initializeViewSubtree } from "../data/flowInit.js";
 
-describe("initializeSubtree", () => {
+describe("initializeViewSubtree", () => {
     test("initializes data flow for a subtree only", async () => {
         const context = createTestViewContext();
 
@@ -39,10 +39,8 @@ describe("initializeSubtree", () => {
         const child = concatRoot.children[0];
         const otherChild = concatRoot.children[1];
 
-        const { dataSources, graphicsPromises, unitViews } = initializeSubtree(
-            child,
-            context.dataFlow
-        );
+        const { dataSources, graphicsPromises, unitViews } =
+            initializeViewSubtree(child, context.dataFlow);
 
         expect(dataSources.size).toBe(1);
         expect(unitViews.length).toBe(1);

--- a/packages/core/src/view/viewUtils.test.js
+++ b/packages/core/src/view/viewUtils.test.js
@@ -44,10 +44,8 @@ describe("initializeSubtree", () => {
         expect(unitViews.length).toBe(1);
         expect(graphicsPromises.length).toBe(0);
 
-        expect(context.dataFlow.findDataSourceByKey(child)).toBeDefined();
-        expect(
-            context.dataFlow.findDataSourceByKey(otherChild)
-        ).toBeUndefined();
+        expect(child.flowHandle?.dataSource).toBeDefined();
+        expect(otherChild.flowHandle?.dataSource).toBeUndefined();
     });
 });
 

--- a/packages/core/src/view/viewUtils.test.js
+++ b/packages/core/src/view/viewUtils.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createTestViewContext } from "./testUtils.js";
+import { finalizeSubtreeGraphics, initializeSubtree } from "./viewUtils.js";
+
+describe("initializeSubtree", () => {
+    test("initializes data flow for a subtree only", async () => {
+        const context = createTestViewContext();
+
+        /** @type {import("../spec/view.js").ConcatSpec} */
+        const spec = {
+            hconcat: [
+                {
+                    data: {
+                        values: [{ x: 1 }],
+                    },
+                    mark: "point",
+                    encoding: {
+                        x: { field: "x", type: "quantitative" },
+                    },
+                },
+                {
+                    data: {
+                        values: [{ x: 2 }],
+                    },
+                    mark: "point",
+                    encoding: {
+                        x: { field: "x", type: "quantitative" },
+                    },
+                },
+            ],
+        };
+
+        const root = await context.createOrImportView(spec, null, null, "root");
+        const child = root.children[0];
+        const otherChild = root.children[1];
+
+        const { dataSources, graphicsPromises, unitViews } = initializeSubtree(
+            child,
+            context.dataFlow
+        );
+
+        expect(dataSources.size).toBe(1);
+        expect(unitViews.length).toBe(1);
+        expect(graphicsPromises.length).toBe(0);
+
+        expect(context.dataFlow.findDataSourceByKey(child)).toBeDefined();
+        expect(
+            context.dataFlow.findDataSourceByKey(otherChild)
+        ).toBeUndefined();
+    });
+});
+
+describe("finalizeSubtreeGraphics", () => {
+    test("finalizes marks when allowed", async () => {
+        const markA = { finalizeGraphicsInitialization: vi.fn() };
+        const markB = { finalizeGraphicsInitialization: vi.fn() };
+
+        await finalizeSubtreeGraphics([
+            Promise.resolve(markA),
+            Promise.resolve(markB),
+        ]);
+
+        expect(markA.finalizeGraphicsInitialization).toHaveBeenCalledTimes(1);
+        expect(markB.finalizeGraphicsInitialization).toHaveBeenCalledTimes(1);
+    });
+
+    test("skips finalization when predicate is false", async () => {
+        const mark = { finalizeGraphicsInitialization: vi.fn() };
+
+        await finalizeSubtreeGraphics([Promise.resolve(mark)], () => false);
+
+        expect(mark.finalizeGraphicsInitialization).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Summary

- Implement subtree lifecycle helpers for view init/graphics/data and disposal; add subtree data-ready signaling and replace global dataLoaded usage.
- Remove dataflow host maps, move observer cleanup to collector.observe + disposer bag, and require flow handles in views/tests.
- Improve dynamic view cleanup (metadata/sample views, grid/facet replacements) to prevent leaks; add/extend disposal and subtree rebuild tests.
- Add app test helpers for SampleView-related tests and refresh the refactor plan.

Changes (selected)

- Subtree helpers: initializeViewSubtree, finalizeSubtreeGraphics, collectNearestViewSubtreeDataSources, loadViewSubtreeData (broadcasts subtreeDataReady).
- genomeSpy no longer broadcasts global dataLoaded; sample view listens for subtree readiness.
- Dataflow cleanup: removed host map registry, added collector.observe, synced flow handles post-optimization.
- App cleanup: metadata/sample label/sample view unsubscribe/teardown improvements.
- Tests: coverage for subtree rebuild cleanup, dataflow cleanup on dispose, sample extraction on subtree ready, metadata rebuild flow, shared app test helpers.

Tooling

- Codex was used extensively to assist with refactoring, test updates, and documentation.