### PR TITLE
feat(app): add radio groups for configurable visibility

### DIFF
--- a/docs/sample-collections/visualizing.md
+++ b/docs/sample-collections/visualizing.md
@@ -356,6 +356,18 @@ Views have two properties for controlling the visibility:
 
 APP_SCHEMA AppUnitSpec visible configurableVisibility
 
+Use object-form `configurableVisibility` to make views mutually exclusive in the
+menu. Views that share the same `group` in the same import scope are shown as
+radio buttons:
+
+```json
+{
+  "name": "rawCoverage",
+  "configurableVisibility": { "group": "coverageMode" },
+  ...
+}
+```
+
 ## Search
 
 The location/search field in the toolbar allows users to quickly navigate to

--- a/packages/app/src/app.js
+++ b/packages/app/src/app.js
@@ -26,6 +26,7 @@ import {
     buildViewSettingsPayload,
     getViewVisibilityOverride,
     normalizeViewSettingsPayload,
+    resolveRadioVisibilityConflicts,
 } from "./viewSettingsUtils.js";
 import { subscribeTo, withMicrotask } from "./state/subscribeTo.js";
 import SimpleBookmarkDatabase from "./bookmark/simpleBookmarkDatabase.js";
@@ -185,10 +186,34 @@ export default class App {
             /** @type {ReturnType<typeof this.store.getState>} */ state
         ) => state.viewSettings?.visibilities ?? EMPTY_VISIBILITIES;
 
+        /** @type {Record<string, boolean>} */
+        let cachedInput = EMPTY_VISIBILITIES;
+        /** @type {import("@genome-spy/core/view/view.js").default | undefined} */
+        let cachedRoot;
+        /** @type {Record<string, boolean>} */
+        let cachedResolved = EMPTY_VISIBILITIES;
+
+        const getResolvedVisibilities = () => {
+            const input = visibilitiesSelector(this.store.getState());
+            const root = this.genomeSpy.viewRoot;
+
+            if (input === cachedInput && root === cachedRoot) {
+                return cachedResolved;
+            }
+
+            cachedInput = input;
+            cachedRoot = root;
+            cachedResolved = root
+                ? resolveRadioVisibilityConflicts(root, input)
+                : input;
+
+            return cachedResolved;
+        };
+
         const originalPredicate = this.genomeSpy.viewVisibilityPredicate;
         this.genomeSpy.viewVisibilityPredicate = (view) => {
             const override = getViewVisibilityOverride(
-                visibilitiesSelector(this.store.getState()),
+                getResolvedVisibilities(),
                 view
             );
             if (override !== undefined) {

--- a/packages/app/src/components/toolbar/viewSettingsButton.js
+++ b/packages/app/src/components/toolbar/viewSettingsButton.js
@@ -9,9 +9,11 @@ import { queryDependency } from "../../utils/dependency.js";
 import { nestPaths } from "../../utils/nestPaths.js";
 import { viewSettingsSlice } from "../../viewSettingsSlice.js";
 import {
+    getRadioVisibilityGroupsBySelector,
     getUniqueViewSelectorKeys,
     getViewVisibilityKey,
     getViewVisibilityOverride,
+    resolveRadioVisibilityConflicts,
 } from "../../viewSettingsUtils.js";
 import { dropdownMenu } from "../../utils/ui/contextMenu.js";
 import createBindingInputs from "@genome-spy/core/utils/inputBinding.js";
@@ -139,6 +141,42 @@ class ViewSettingsButton extends LitElement {
     }
 
     /**
+     * @param {UIEvent} event
+     * @param {View} view
+     * @param {string[]} groupMemberKeys
+     */
+    #handleRadioClick(event, view, groupMemberKeys) {
+        const checked = /** @type {HTMLInputElement} */ (event.target).checked;
+        if (!checked) {
+            event.stopPropagation();
+            return;
+        }
+
+        const selectorKey = getViewVisibilityKey(view);
+        if (!selectorKey) {
+            throw new Error(
+                "Cannot toggle view visibility without an explicit name."
+            );
+        }
+
+        for (const memberKey of groupMemberKeys) {
+            this.#app.store.dispatch(
+                viewSettingsSlice.actions.setVisibility({
+                    key: memberKey,
+                    visibility: memberKey === selectorKey,
+                })
+            );
+        }
+
+        this.#restoreHoverHighlightAfterVisibilityUpdate(view);
+
+        this.requestUpdate();
+        void this.#showDropdown();
+
+        event.stopPropagation();
+    }
+
+    /**
      * Re-apply hover highlight after the visibility change has been processed.
      * The App updates layout in a microtask, so we queue this after that.
      *
@@ -198,12 +236,17 @@ class ViewSettingsButton extends LitElement {
     }
 
     #makeToggles() {
-        const visibilities = this.getVisibilities();
-
         const viewRoot = this.#app.genomeSpy.viewRoot;
+        const visibilities = this.getVisibilities();
+        const effectiveVisibilities = viewRoot
+            ? resolveRadioVisibilityConflicts(viewRoot, visibilities)
+            : visibilities;
         const uniqueSelectorKeys = viewRoot
             ? getUniqueViewSelectorKeys(viewRoot)
             : new Set();
+        const radioGroupsBySelector = viewRoot
+            ? getRadioVisibilityGroupsBySelector(viewRoot)
+            : new Map();
 
         /** @type {import("../../utils/ui/contextMenu.js").MenuItem[]} */
         const items = [];
@@ -215,7 +258,7 @@ class ViewSettingsButton extends LitElement {
         const nestedItemToHtml = (/** */ item, depth = -1) => {
             const view = item.item;
             const visibilityOverride = getViewVisibilityOverride(
-                visibilities,
+                effectiveVisibilities,
                 view
             );
             const checked =
@@ -223,6 +266,13 @@ class ViewSettingsButton extends LitElement {
                     ? visibilityOverride
                     : view.isVisibleInSpec();
             const selectorKey = getViewVisibilityKey(view);
+            const radioGroup =
+                selectorKey && radioGroupsBySelector.has(selectorKey)
+                    ? radioGroupsBySelector.get(selectorKey)
+                    : undefined;
+            const isRadioGroup = Boolean(
+                radioGroup && radioGroup.memberKeys.length > 1
+            );
 
             /** @type {import("../../utils/ui/contextMenu.js").MenuItem[]} */
             const submenuItems = [];
@@ -298,13 +348,21 @@ class ViewSettingsButton extends LitElement {
                 >
                     <input
                         style=${`margin-left: ${depth * 1.5}em;`}
-                        type="checkbox"
+                        type=${isRadioGroup ? "radio" : "checkbox"}
                         ?disabled=${!selectorKey ||
                         !uniqueSelectorKeys.has(selectorKey) ||
                         !isVisibilityConfigurable(view)}
                         .checked=${live(checked)}
                         @change=${(/** @type {UIEvent} */ event) =>
-                            this.#handleCheckboxClick(event, view)}
+                            isRadioGroup
+                                ? this.#handleRadioClick(
+                                      event,
+                                      view,
+                                      /** @type {{ memberKeys: string[] }} */ (
+                                          radioGroup
+                                      ).memberKeys
+                                  )
+                                : this.#handleCheckboxClick(event, view)}
                     />${label}
                 </label>`;
 

--- a/packages/app/src/configurableVisibilityUtils.js
+++ b/packages/app/src/configurableVisibilityUtils.js
@@ -1,14 +1,33 @@
 /**
  * @typedef {import("@genome-spy/core/view/view.js").default} View
+ * @typedef {import("./spec/view.js").AppVisibilityGroupSpec} AppVisibilityGroupSpec
+ * @typedef {boolean | AppVisibilityGroupSpec} ConfigurableVisibilitySpec
  */
 
 /**
  * @param {View} view
- * @returns {boolean | undefined}
+ * @returns {ConfigurableVisibilitySpec | undefined}
  */
-function getConfigurableVisibility(view) {
-    return /** @type {{ configurableVisibility?: boolean }} */ (view.spec)
-        .configurableVisibility;
+export function getConfigurableVisibility(view) {
+    return /** @type {{ configurableVisibility?: ConfigurableVisibilitySpec }} */ (
+        view.spec
+    ).configurableVisibility;
+}
+
+/**
+ * @param {View} view
+ * @returns {string | undefined}
+ */
+export function getVisibilityGroup(view) {
+    const configurable = getConfigurableVisibility(view);
+    if (
+        configurable &&
+        typeof configurable == "object" &&
+        typeof configurable.group == "string" &&
+        configurable.group.length
+    ) {
+        return configurable.group;
+    }
 }
 
 /**
@@ -20,7 +39,7 @@ function getConfigurableVisibility(view) {
 export function isVisibilityConfigurable(view) {
     const explicit = getConfigurableVisibility(view);
     if (explicit !== undefined) {
-        return explicit;
+        return explicit !== false;
     }
 
     return !(
@@ -37,5 +56,5 @@ export function isVisibilityConfigurable(view) {
  * @returns {boolean}
  */
 export function isExplicitlyVisibilityConfigurable(view) {
-    return getConfigurableVisibility(view) === true;
+    return getConfigurableVisibility(view) !== undefined;
 }

--- a/packages/app/src/spec/view.d.ts
+++ b/packages/app/src/spec/view.d.ts
@@ -28,6 +28,19 @@ export interface AggregateSamplesSpec {
 /**
  * App-only visibility setting exposed in the view visibility menu.
  */
+export interface AppVisibilityGroupSpec {
+    /**
+     * Name of a mutually exclusive visibility group.
+     *
+     * Views with the same group name in the same import scope are controlled
+     * with radio buttons in the view visibility menu.
+     */
+    group: string;
+}
+
+/**
+ * App-only visibility setting exposed in the view visibility menu.
+ */
 export interface AppConfigurableVisibilitySpec {
     /**
      * Is the visibility configurable from the GenomeSpy App view visibility menu.
@@ -35,9 +48,12 @@ export interface AppConfigurableVisibilitySpec {
      * Configurability requires an explicit view name that is unique in its import
      * scope.
      *
+     * Set to an object with `group` to make configurable views mutually
+     * exclusive in the menu (radio buttons) within the same import scope.
+     *
      * __Default value:__ `false` for children of `layer`, `true` for others
      */
-    configurableVisibility?: boolean;
+    configurableVisibility?: boolean | AppVisibilityGroupSpec;
 }
 
 export type AppUnitSpec = Omit<CoreUnitSpec, "aggregateSamples" | "templates"> &

--- a/packages/app/src/viewSelectorConstraints.js
+++ b/packages/app/src/viewSelectorConstraints.js
@@ -6,6 +6,7 @@ import {
 } from "@genome-spy/core/view/viewSelectors.js";
 import { VISIT_STOP } from "@genome-spy/core/view/view.js";
 import {
+    getConfigurableVisibility,
     isExplicitlyVisibilityConfigurable,
     isVisibilityConfigurable,
 } from "./configurableVisibilityUtils.js";
@@ -25,10 +26,40 @@ export function validateSelectorConstraints(root) {
     /** @type {SelectorValidationIssue[]} */
     const issues = [...validateCoreSelectorConstraints(root)];
 
+    validateConfigurableVisibilityGroupSpecs(root, issues);
     validateConfigurableViewNames(root, issues);
     validateConfigurableImportInstanceNames(root, issues);
 
     return issues;
+}
+
+/**
+ * @param {View} root
+ * @param {SelectorValidationIssue[]} issues
+ */
+function validateConfigurableVisibilityGroupSpecs(root, issues) {
+    visitAddressableViews(root, (view) => {
+        const configurable = getConfigurableVisibility(view);
+        if (!configurable || typeof configurable != "object") {
+            return;
+        }
+
+        if (
+            typeof configurable.group != "string" ||
+            configurable.group.length === 0
+        ) {
+            const scope = getViewScopeChain(view);
+            issues.push({
+                message:
+                    "Configurable visibility group must be a non-empty string in " +
+                    formatScope(scope) +
+                    " for " +
+                    view.getPathString() +
+                    ".",
+                scope,
+            });
+        }
+    });
 }
 
 /**

--- a/packages/app/src/viewSelectorConstraints.test.js
+++ b/packages/app/src/viewSelectorConstraints.test.js
@@ -176,6 +176,62 @@ describe("app selector constraints", () => {
         ).toBeTruthy();
     });
 
+    test("flags invalid configurable visibility group definitions", async () => {
+        const context = createTestViewContext();
+
+        const spec = {
+            vconcat: [
+                {
+                    ...makeUnitSpec("coverage"),
+                    configurableVisibility: {
+                        group: "",
+                    },
+                },
+            ],
+        };
+
+        const root = await context.createOrImportView(
+            spec,
+            null,
+            null,
+            VIEW_ROOT_NAME
+        );
+
+        const issues = validateSelectorConstraints(root);
+        expect(
+            issues.some((issue) =>
+                issue.message.includes(
+                    "Configurable visibility group must be a non-empty string"
+                )
+            )
+        ).toBeTruthy();
+    });
+
+    test("accepts configurable visibility group definitions", async () => {
+        const context = createTestViewContext();
+
+        const spec = {
+            vconcat: [
+                {
+                    ...makeUnitSpec("coverage"),
+                    configurableVisibility: {
+                        group: "mode",
+                    },
+                },
+            ],
+        };
+
+        const root = await context.createOrImportView(
+            spec,
+            null,
+            null,
+            VIEW_ROOT_NAME
+        );
+
+        const issues = validateSelectorConstraints(root);
+        expect(issues.length).toBe(0);
+    });
+
     test("flags duplicate import instance names for configurable views", async () => {
         const context = createTestViewContext();
 

--- a/packages/app/src/viewSettingsUtils.js
+++ b/packages/app/src/viewSettingsUtils.js
@@ -1,7 +1,12 @@
 import {
+    getImportScopeInfo,
     getViewSelector,
     visitAddressableViews,
 } from "@genome-spy/core/view/viewSelectors.js";
+import {
+    getVisibilityGroup,
+    isVisibilityConfigurable,
+} from "./configurableVisibilityUtils.js";
 
 export const VIEW_SELECTOR_KEY_PREFIX = "v:";
 
@@ -208,10 +213,11 @@ export function buildViewVisibilityEntries(viewRoot, visibilities) {
  * @returns {import("./state.js").ViewSettingsPayload | undefined}
  */
 export function buildViewSettingsPayload(viewRoot, viewSettings) {
-    const entries = buildViewVisibilityEntries(
+    const resolvedVisibilities = resolveRadioVisibilityConflicts(
         viewRoot,
         viewSettings.visibilities
     );
+    const entries = buildViewVisibilityEntries(viewRoot, resolvedVisibilities);
     if (!entries.length) {
         return;
     }
@@ -248,6 +254,118 @@ export function getUniqueViewSelectorKeys(viewRoot) {
     }
 
     return uniqueKeys;
+}
+
+/**
+ * Returns radio-group membership information by selector key.
+ *
+ * @param {import("@genome-spy/core/view/view.js").default} viewRoot
+ * @returns {Map<string, { groupKey: string, memberKeys: string[] }>}
+ */
+export function getRadioVisibilityGroupsBySelector(viewRoot) {
+    /** @type {Map<string, { groupKey: string, memberKeys: string[] }>} */
+    const bySelector = new Map();
+
+    for (const [groupKey, members] of collectRadioVisibilityGroups(viewRoot)) {
+        const memberKeys = members.map((member) => member.selectorKey);
+        for (const member of members) {
+            bySelector.set(member.selectorKey, {
+                groupKey,
+                memberKeys,
+            });
+        }
+    }
+
+    return bySelector;
+}
+
+/**
+ * Resolves conflicts in mutually exclusive visibility groups so at most one
+ * view is visible in each radio group.
+ *
+ * @param {import("@genome-spy/core/view/view.js").default} viewRoot
+ * @param {Record<string, boolean>} visibilities
+ * @returns {Record<string, boolean>}
+ */
+export function resolveRadioVisibilityConflicts(viewRoot, visibilities) {
+    /** @type {Record<string, boolean>} */
+    const resolved = { ...visibilities };
+
+    for (const members of collectRadioVisibilityGroups(viewRoot).values()) {
+        const visibleMembers = members.filter((member) => {
+            const override = getViewVisibilityOverride(
+                visibilities,
+                member.view
+            );
+            if (override !== undefined) {
+                return override;
+            }
+
+            return member.view.isVisibleInSpec();
+        });
+
+        if (visibleMembers.length <= 1) {
+            continue;
+        }
+
+        const winner = visibleMembers[0].selectorKey;
+
+        for (const member of members) {
+            if (member.selectorKey === winner) {
+                continue;
+            }
+
+            resolved[member.selectorKey] = false;
+        }
+    }
+
+    return resolved;
+}
+
+/**
+ * @param {import("@genome-spy/core/view/view.js").default} viewRoot
+ * @returns {Map<string, { view: import("@genome-spy/core/view/view.js").default, selectorKey: string }[]>}
+ */
+function collectRadioVisibilityGroups(viewRoot) {
+    /**
+     * @type {Map<string, { view: import("@genome-spy/core/view/view.js").default, selectorKey: string }[]>}
+     */
+    const groups = new Map();
+
+    visitAddressableViews(viewRoot, (view) => {
+        if (!isVisibilityConfigurable(view)) {
+            return;
+        }
+
+        if (!view.explicitName) {
+            return;
+        }
+
+        const group = getVisibilityGroup(view);
+        if (!group) {
+            return;
+        }
+
+        const selector = getViewSelector(view);
+        const selectorKey = makeViewSelectorKey(selector);
+        const groupScope =
+            getImportScopeInfo(view)?.name && selector.scope.length
+                ? selector.scope.slice(0, selector.scope.length - 1)
+                : selector.scope;
+        const groupKey = JSON.stringify({
+            scope: groupScope,
+            group,
+        });
+
+        const members = groups.get(groupKey);
+        if (members) {
+            members.push({ view, selectorKey });
+        } else {
+            groups.set(groupKey, [{ view, selectorKey }]);
+        }
+    });
+
+    return groups;
 }
 
 /**

--- a/packages/app/src/viewSettingsUtils.test.js
+++ b/packages/app/src/viewSettingsUtils.test.js
@@ -2,7 +2,11 @@
 import { describe, expect, test, vi } from "vitest";
 import { createTestViewContext } from "@genome-spy/core/view/testUtils.js";
 import { VIEW_ROOT_NAME } from "@genome-spy/core/view/viewFactory.js";
-import { buildViewVisibilityEntries } from "./viewSettingsUtils.js";
+import {
+    buildViewVisibilityEntries,
+    getRadioVisibilityGroupsBySelector,
+    resolveRadioVisibilityConflicts,
+} from "./viewSettingsUtils.js";
 
 /**
  * @param {string} name
@@ -75,5 +79,132 @@ describe("view visibility entries", () => {
         expect(warn).toHaveBeenCalled();
 
         warn.mockRestore();
+    });
+
+    test("resolves conflicting radio-group visibilities deterministically", async () => {
+        const context = createTestViewContext();
+
+        const spec = {
+            vconcat: [
+                {
+                    ...makeUnitSpec("coverageA"),
+                    configurableVisibility: { group: "mode" },
+                },
+                {
+                    ...makeUnitSpec("coverageB"),
+                    configurableVisibility: { group: "mode" },
+                },
+            ],
+        };
+
+        const root = await context.createOrImportView(
+            spec,
+            null,
+            null,
+            VIEW_ROOT_NAME
+        );
+
+        const bySelector = getRadioVisibilityGroupsBySelector(root);
+        const [{ memberKeys }] = Array.from(bySelector.values());
+
+        const resolved = resolveRadioVisibilityConflicts(root, {});
+
+        expect(resolved[memberKeys[0]]).toBeUndefined();
+        expect(resolved[memberKeys[1]]).toBe(false);
+    });
+
+    test("keeps radio groups scoped to import instances", async () => {
+        const context = createTestViewContext();
+
+        const spec = {
+            templates: {
+                panel: {
+                    vconcat: [
+                        {
+                            ...makeUnitSpec("coverageA"),
+                            configurableVisibility: { group: "mode" },
+                        },
+                        {
+                            ...makeUnitSpec("coverageB"),
+                            configurableVisibility: { group: "mode" },
+                        },
+                    ],
+                },
+            },
+            vconcat: [
+                {
+                    import: { template: "panel" },
+                    name: "panelA",
+                },
+                {
+                    import: { template: "panel" },
+                    name: "panelB",
+                },
+            ],
+        };
+
+        const root = await context.createOrImportView(
+            spec,
+            null,
+            null,
+            VIEW_ROOT_NAME
+        );
+
+        const bySelector = getRadioVisibilityGroupsBySelector(root);
+        const groupKeys = new Set(
+            Array.from(bySelector.values(), (entry) => entry.groupKey)
+        );
+
+        expect(groupKeys.size).toBe(2);
+        for (const entry of bySelector.values()) {
+            expect(entry.memberKeys.length).toBe(2);
+        }
+    });
+
+    test("groups named imported root views within their parent scope", async () => {
+        const context = createTestViewContext();
+
+        const spec = {
+            templates: {
+                panel: {
+                    ...makeUnitSpec("coverage"),
+                    configurableVisibility: { group: "mode" },
+                },
+            },
+            vconcat: [
+                {
+                    import: { template: "panel" },
+                    name: "panelA",
+                },
+                {
+                    import: { template: "panel" },
+                    name: "panelB",
+                },
+            ],
+        };
+
+        const root = await context.createOrImportView(
+            spec,
+            null,
+            null,
+            VIEW_ROOT_NAME
+        );
+
+        const bySelector = getRadioVisibilityGroupsBySelector(root);
+        expect(bySelector.size).toBe(2);
+
+        const groupKeys = new Set(
+            Array.from(bySelector.values(), (entry) => entry.groupKey)
+        );
+        expect(groupKeys.size).toBe(1);
+
+        for (const entry of bySelector.values()) {
+            expect(entry.memberKeys.length).toBe(2);
+        }
+
+        const resolved = resolveRadioVisibilityConflicts(root, {});
+        const entries = Array.from(bySelector.values());
+        expect(resolved[entries[0].memberKeys[0]]).toBeUndefined();
+        expect(resolved[entries[0].memberKeys[1]]).toBe(false);
     });
 });


### PR DESCRIPTION
This PR adds mutually exclusive visibility groups to the App view visibility menu. Authors can now use object-form `configurableVisibility` to render radio controls for related views. Bookmark/state formats remain unchanged. 

## An example use case

Toggling between copy-number segmentations performed using different tools. Displaying multiple segmentations at the same time makes no sense.

<img width="507" height="205" alt="image" src="https://github.com/user-attachments/assets/db64f328-b2e8-4033-8a04-eaa64bc50688" />

## Key points

- Extended App spec for `configurableVisibility` to support object form: `boolean | { group: string }`.
- Added App-side parsing/validation for grouped visibility config, including checks for invalid group definitions.
- Implemented radio-group behavior in the toolbar view settings menu:
  - grouped items render as radio inputs
  - selecting one view hides other views in the same group
- Kept backward/forward bookmark compatibility by preserving existing `viewSettings.visibilities` structure (`Record<string, boolean>`), with runtime conflict reconciliation for radio groups.
- Fixed grouping semantics for named imported root views so sibling imports (for example, template instances named differently) still belong to the same radio group in their parent scope.
- Updated docs (`sample-collections/visualizing.md`) with object-form `configurableVisibility` usage.

Closes #185