### PR TITLE
feat(core): add eager parquet format support with optimized object-row reader

### DIFF
--- a/docs/grammar/data/eager.md
+++ b/docs/grammar/data/eager.md
@@ -6,10 +6,11 @@ support partial loading or loading in response to user interactions. However,
 eager data sources are often more flexible and straightforward than
 [lazy](lazy.md) ones.
 
-GenomeSpy inputs eager data as tabular `"csv"`, `"tsv"`, and `"json"` files or
-as non-indexed [`"fasta"`](#fasta) files. Data can be loaded from URLs or
-provided inline. You can also use generators to generate data on the fly and
-further modify them using [transforms](../transform/index.md).
+GenomeSpy inputs eager data as tabular `"csv"`, `"tsv"`, `"json"`, and
+[`"parquet"`](#parquet) files or as non-indexed [`"fasta"`](#fasta) files. Data
+can be loaded from URLs or provided inline. You can also use generators to
+generate data on the fly and further modify them using
+[transforms](../transform/index.md).
 
 The `data` property of the view specification describes a data source. The
 following example loads a tab-delimited file. By default, GenomeSpy infers the
@@ -115,10 +116,40 @@ named data, check the
 [embed-examples](https://github.com/genome-spy/genome-spy/tree/master/packages/embed-examples)
 package.
 
-## Bioinformatic Formats
+## Additional Formats
 
 Most bioinformatic data formats are supported through [lazy](lazy.md) data. The
-following formats are supported as eager data with the `url` source.
+following additional formats are supported as eager data with the `url` source.
+
+### Parquet
+
+[_Apache Parquet_](https://en.wikipedia.org/wiki/Apache_Parquet) is a
+column-oriented binary storage format designed for efficient analytics on large
+tables. Compared to row-oriented text formats, it usually provides better
+compression and faster column scans.
+In GenomeSpy, Parquet is decoded into row objects similarly to `"csv"` and
+`"tsv"` formats supported by the `url` data source.
+
+The type of _Parquet_ format is `"parquet"`:
+
+```json
+{
+  "data": {
+    "url": "data.parquet",
+    "format": {
+      "type": "parquet"
+    }
+  }
+}
+```
+
+Current constraints:
+
+- Only Snappy-compressed Parquet files are supported.
+- 64-bit integer values that require JavaScript `BigInt` are not supported.
+
+The implementation is based on
+[hyparquet](https://github.com/hyparam/hyparquet).
 
 ### FASTA
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7939,6 +7939,12 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/hyparquet": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.25.0.tgz",
+      "integrity": "sha512-isJx+RplYT3aJc5yhaG5CeOZSBJecHZgYsUi7NE6P/nAbxxA0hZcyul0tUsWCQLc9QXYQ2uFyYBrk61JbJO0cg==",
+      "license": "MIT"
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -15172,6 +15178,7 @@
         "flatqueue": "^3.0.0",
         "generic-filehandle2": "^2.0.14",
         "gff-nostream": "^2.0.0",
+        "hyparquet": "^1.25.0",
         "internmap": "^2.0.3",
         "lit": "^3.3.0",
         "twgl.js": "^4.19.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
     "flatqueue": "^3.0.0",
     "generic-filehandle2": "^2.0.14",
     "gff-nostream": "^2.0.0",
+    "hyparquet": "^1.25.0",
     "internmap": "^2.0.3",
     "lit": "^3.3.0",
     "twgl.js": "^4.19.1",

--- a/packages/core/src/data/formats/parquet.js
+++ b/packages/core/src/data/formats/parquet.js
@@ -1,0 +1,20 @@
+/*
+ * Adapted from: https://github.com/vega/vega-loader-parquet/blob/main/src/index.js
+ */
+
+/**
+ * Load a data set in Apache Parquet format for use in Vega.
+ * @param {ArrayBuffer|Uint8Array} data Parquet binary data.
+ * @returns {Promise<Record<string,any>[]>} A promise that resolves to an array of data objects representing
+ *  rows of a data table.
+ */
+export default async function parquet(data) {
+    const hyparquet = await import("hyparquet");
+    const buffer =
+        data instanceof Uint8Array
+            ? /** @type {ArrayBuffer} */ (data.buffer)
+            : data;
+    return await hyparquet.parquetReadObjects({ file: buffer });
+}
+
+parquet.responseType = "arrayBuffer";

--- a/packages/core/src/data/formats/parquet.js
+++ b/packages/core/src/data/formats/parquet.js
@@ -1,6 +1,16 @@
 /*
  * Adapted from: https://github.com/vega/vega-loader-parquet/blob/main/src/index.js
+ * Parquet parsing is lazy-loaded from ./parquetRead.js to avoid pulling
+ * hyparquet internals into the initial bundle.
  */
+
+/**
+ * @returns {Promise<typeof import("./parquetRead.js").parquetReadObjects>}
+ */
+async function loadParquetReadObjects() {
+    const { parquetReadObjects } = await import("./parquetRead.js");
+    return parquetReadObjects;
+}
 
 /**
  * Load a data set in Apache Parquet format for use in Vega.
@@ -9,12 +19,13 @@
  *  rows of a data table.
  */
 export default async function parquet(data) {
-    const hyparquet = await import("hyparquet");
+    const parquetReadObjects = await loadParquetReadObjects();
     const buffer =
         data instanceof Uint8Array
             ? /** @type {ArrayBuffer} */ (data.buffer)
             : data;
-    return await hyparquet.parquetReadObjects({ file: buffer });
+
+    return await parquetReadObjects({ file: buffer });
 }
 
 parquet.responseType = "arrayBuffer";

--- a/packages/core/src/data/formats/parquet.js
+++ b/packages/core/src/data/formats/parquet.js
@@ -1,7 +1,5 @@
 /*
  * Adapted from: https://github.com/vega/vega-loader-parquet/blob/main/src/index.js
- * Parquet parsing is lazy-loaded from ./parquetRead.js to avoid pulling
- * hyparquet internals into the initial bundle.
  */
 
 /**

--- a/packages/core/src/data/formats/parquetRead.js
+++ b/packages/core/src/data/formats/parquetRead.js
@@ -1,7 +1,33 @@
+/*
+ * Adapted from hyparquet internals:
+ * https://github.com/hyparam/hyparquet (notably src/read.js and src/rowgroup.js).
+ *
+ * GenomeSpy-specific changes in this copy:
+ * - object-row output only (array row format removed)
+ * - filtering support removed
+ * - hot row transpose path optimized with cached codegen for typical schemas
+ * - fallback to interpreted row builder for very wide schemas
+ */
+
 import { parquetMetadataAsync, parquetSchema } from "hyparquet/src/metadata.js";
 import { parquetPlan, prefetchAsyncBuffer } from "hyparquet/src/plan.js";
 import { assembleAsync, readRowGroup } from "hyparquet/src/rowgroup.js";
 import { concat } from "hyparquet/src/utils.js";
+
+/**
+ * @typedef {(
+ *  groupData: Record<string, any>[],
+ *  selectStart: number,
+ *  selectCount: number,
+ *  columnData: import("hyparquet").DecodedArray[],
+ *  columnSkipped: number[]
+ * ) => Record<string, any>[]} RowGroupObjectBuilder
+ */
+
+/** @type {Map<string, RowGroupObjectBuilder>} */
+const rowGroupObjectBuilderCache = new Map();
+
+const MAX_CODEGEN_COLUMNS = 200;
 
 /**
  * @param {Omit<import("hyparquet").ParquetReadOptions, "rowFormat" | "filter" | "filterStrict">} options
@@ -54,6 +80,84 @@ function flattenColumnChunks(chunks) {
 }
 
 /**
+ * @param {string[]} columnNames
+ * @returns {RowGroupObjectBuilder}
+ */
+function getRowGroupObjectBuilder(columnNames) {
+    // Compile one builder per column layout to keep object writes monomorphic.
+    const signature = columnNames.join("\u001f");
+    const cached = rowGroupObjectBuilderCache.get(signature);
+    if (cached) {
+        return cached;
+    }
+
+    const assignments = columnNames
+        .map(
+            (columnName, i) =>
+                JSON.stringify(columnName) +
+                ": columnData[" +
+                i +
+                "][row - columnSkipped[" +
+                i +
+                "]]"
+        )
+        .join(",\n");
+
+    const builder = /** @type {RowGroupObjectBuilder} */ (
+        new Function(
+            "groupData",
+            "selectStart",
+            "selectCount",
+            "columnData",
+            "columnSkipped",
+            // Keep generated code focused on the tight row loop only.
+            "for (let selectRow = 0; selectRow < selectCount; selectRow++) {\n" +
+                "    const row = selectStart + selectRow;\n" +
+                "    groupData[selectRow] = {\n" +
+                assignments +
+                "\n" +
+                "    };\n" +
+                "}\n" +
+                "return groupData;"
+        )
+    );
+
+    rowGroupObjectBuilderCache.set(signature, builder);
+
+    return builder;
+}
+
+/**
+ * @param {Record<string, any>[]} groupData
+ * @param {number} selectStart
+ * @param {number} selectCount
+ * @param {string[]} columnNames
+ * @param {import("hyparquet").DecodedArray[]} columnData
+ * @param {number[]} columnSkipped
+ * @returns {Record<string, any>[]}
+ */
+function buildRowsInterpreted(
+    groupData,
+    selectStart,
+    selectCount,
+    columnNames,
+    columnData,
+    columnSkipped
+) {
+    for (let selectRow = 0; selectRow < selectCount; selectRow++) {
+        const row = selectStart + selectRow;
+        /** @type {Record<string, any>} */
+        const rowData = {};
+        for (let i = 0; i < columnNames.length; i++) {
+            rowData[columnNames[i]] = columnData[i][row - columnSkipped[i]];
+        }
+        groupData[selectRow] = rowData;
+    }
+
+    return groupData;
+}
+
+/**
  * Object-only copy of hyparquet's asyncGroupToRows.
  *
  * @param {import("hyparquet").AsyncRowGroup} asyncGroup
@@ -66,33 +170,50 @@ async function asyncGroupToRowsObject(
     selectStart,
     selectEnd
 ) {
-    const asyncPages = await Promise.all(
-        asyncColumns.map(async ({ data }) => {
-            const pages = await data;
-            return {
-                skipped: pages.skipped,
-                data: flattenColumnChunks(pages.data),
-            };
-        })
-    );
+    // Resolve all async column pages once before entering the hot transpose loop.
+    const pages = await Promise.all(asyncColumns.map((column) => column.data));
+    const columnCount = asyncColumns.length;
 
-    const columnNames = asyncColumns.map((column) => column.pathInSchema[0]);
+    /** @type {string[]} */
+    const columnNames = Array(columnCount);
+    /** @type {import("hyparquet").DecodedArray[]} */
+    const columnData = Array(columnCount);
+    /** @type {number[]} */
+    const columnSkipped = Array(columnCount);
+
+    // Precompute all indirections outside the generated function.
+    for (let i = 0; i < columnCount; i++) {
+        columnNames[i] = asyncColumns[i].pathInSchema[0];
+        columnData[i] = flattenColumnChunks(pages[i].data);
+        columnSkipped[i] = pages[i].skipped;
+    }
+
     const selectCount = selectEnd - selectStart;
 
     /** @type {Record<string, any>[]} */
     const groupData = Array(selectCount);
-    for (let selectRow = 0; selectRow < selectCount; selectRow++) {
-        const row = selectStart + selectRow;
-        /** @type {Record<string, any>} */
-        const rowData = {};
-        for (let i = 0; i < asyncColumns.length; i++) {
-            const { data, skipped } = asyncPages[i];
-            rowData[columnNames[i]] = data[row - skipped];
-        }
-        groupData[selectRow] = rowData;
+
+    // Avoid excessively large generated functions for very wide schemas.
+    if (columnCount > MAX_CODEGEN_COLUMNS) {
+        return buildRowsInterpreted(
+            groupData,
+            selectStart,
+            selectCount,
+            columnNames,
+            columnData,
+            columnSkipped
+        );
     }
 
-    return groupData;
+    const buildRows = getRowGroupObjectBuilder(columnNames);
+
+    return buildRows(
+        groupData,
+        selectStart,
+        selectCount,
+        columnData,
+        columnSkipped
+    );
 }
 
 /**

--- a/packages/core/src/data/formats/parquetRead.js
+++ b/packages/core/src/data/formats/parquetRead.js
@@ -15,6 +15,17 @@ import { assembleAsync, readRowGroup } from "hyparquet/src/rowgroup.js";
 import { concat } from "hyparquet/src/utils.js";
 
 /**
+ * Object-row variant of Parquet read options used by this trimmed reader.
+ *
+ * @typedef {Omit<
+ *  import("hyparquet").ParquetReadOptions,
+ *  "rowFormat" | "filter" | "filterStrict" | "onComplete"
+ * > & {
+ *  onComplete?: (rows: Record<string, any>[]) => void
+ * }} ObjectParquetReadOptions
+ */
+
+/**
  * @typedef {(
  *  groupData: Record<string, any>[],
  *  selectStart: number,
@@ -30,7 +41,7 @@ const rowGroupObjectBuilderCache = new Map();
 const MAX_CODEGEN_COLUMNS = 200;
 
 /**
- * @param {Omit<import("hyparquet").ParquetReadOptions, "rowFormat" | "filter" | "filterStrict">} options
+ * @param {ObjectParquetReadOptions} options
  * @returns {import("hyparquet").AsyncRowGroup[]}
  */
 function parquetReadAsync(options) {
@@ -217,7 +228,7 @@ async function asyncGroupToRowsObject(
 }
 
 /**
- * @param {Omit<import("hyparquet").ParquetReadOptions, "rowFormat" | "filter" | "filterStrict">} options
+ * @param {ObjectParquetReadOptions} options
  * @returns {Promise<void>}
  */
 export async function parquetRead(options) {
@@ -253,18 +264,24 @@ export async function parquetRead(options) {
     if (onChunk) {
         for (const asyncGroup of assembled) {
             for (const asyncColumn of asyncGroup.asyncColumns) {
-                asyncColumn.data.then(({ data, skipped }) => {
-                    let chunkRowStart = asyncGroup.groupStart + skipped;
-                    for (const columnData of data) {
-                        onChunk({
-                            columnName: asyncColumn.pathInSchema[0],
-                            columnData,
-                            rowStart: chunkRowStart,
-                            rowEnd: chunkRowStart + columnData.length,
-                        });
-                        chunkRowStart += columnData.length;
+                asyncColumn.data.then(
+                    /**
+                     * @param {{ data: import("hyparquet").DecodedArray[]; skipped: number }} chunk
+                     */
+                    (chunk) => {
+                        let chunkRowStart =
+                            asyncGroup.groupStart + chunk.skipped;
+                        for (const columnData of chunk.data) {
+                            onChunk({
+                                columnName: asyncColumn.pathInSchema[0],
+                                columnData,
+                                rowStart: chunkRowStart,
+                                rowEnd: chunkRowStart + columnData.length,
+                            });
+                            chunkRowStart += columnData.length;
+                        }
                     }
-                });
+                );
             }
         }
     }
@@ -296,7 +313,7 @@ export async function parquetRead(options) {
 }
 
 /**
- * @param {Omit<import("hyparquet").ParquetReadOptions, "onComplete" | "rowFormat" | "filter" | "filterStrict">} options
+ * @param {Omit<ObjectParquetReadOptions, "onComplete">} options
  * @returns {Promise<Record<string, any>[]>}
  */
 export function parquetReadObjects(options) {

--- a/packages/core/src/data/formats/parquetRead.js
+++ b/packages/core/src/data/formats/parquetRead.js
@@ -1,0 +1,188 @@
+import { parquetMetadataAsync, parquetSchema } from "hyparquet/src/metadata.js";
+import { parquetPlan, prefetchAsyncBuffer } from "hyparquet/src/plan.js";
+import { assembleAsync, readRowGroup } from "hyparquet/src/rowgroup.js";
+import { concat } from "hyparquet/src/utils.js";
+
+/**
+ * @param {Omit<import("hyparquet").ParquetReadOptions, "rowFormat" | "filter" | "filterStrict">} options
+ * @returns {import("hyparquet").AsyncRowGroup[]}
+ */
+function parquetReadAsync(options) {
+    if (!options.metadata) {
+        throw new Error("parquet requires metadata");
+    }
+
+    const plan = parquetPlan(options);
+    options.file = prefetchAsyncBuffer(options.file, plan);
+
+    return plan.groups.map((groupPlan) =>
+        readRowGroup(options, plan, groupPlan)
+    );
+}
+
+/**
+ * Flatten decoded data pages into a single decoded array.
+ * This local version avoids chunked slice/push overhead in hot paths.
+ *
+ * @param {import("hyparquet").DecodedArray[] | undefined} chunks
+ * @returns {import("hyparquet").DecodedArray}
+ */
+function flattenColumnChunks(chunks) {
+    if (!chunks) {
+        return [];
+    }
+
+    if (chunks.length === 1) {
+        return chunks[0];
+    }
+
+    let totalLength = 0;
+    for (const chunk of chunks) {
+        totalLength += chunk.length;
+    }
+
+    const output = Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+        for (let i = 0; i < chunk.length; i++) {
+            output[offset + i] = chunk[i];
+        }
+        offset += chunk.length;
+    }
+
+    return output;
+}
+
+/**
+ * Object-only copy of hyparquet's asyncGroupToRows.
+ *
+ * @param {import("hyparquet").AsyncRowGroup} asyncGroup
+ * @param {number} selectStart
+ * @param {number} selectEnd
+ * @returns {Promise<Record<string, any>[]>}
+ */
+async function asyncGroupToRowsObject(
+    { asyncColumns },
+    selectStart,
+    selectEnd
+) {
+    const asyncPages = await Promise.all(
+        asyncColumns.map(async ({ data }) => {
+            const pages = await data;
+            return {
+                skipped: pages.skipped,
+                data: flattenColumnChunks(pages.data),
+            };
+        })
+    );
+
+    const columnNames = asyncColumns.map((column) => column.pathInSchema[0]);
+    const selectCount = selectEnd - selectStart;
+
+    /** @type {Record<string, any>[]} */
+    const groupData = Array(selectCount);
+    for (let selectRow = 0; selectRow < selectCount; selectRow++) {
+        const row = selectStart + selectRow;
+        /** @type {Record<string, any>} */
+        const rowData = {};
+        for (let i = 0; i < asyncColumns.length; i++) {
+            const { data, skipped } = asyncPages[i];
+            rowData[columnNames[i]] = data[row - skipped];
+        }
+        groupData[selectRow] = rowData;
+    }
+
+    return groupData;
+}
+
+/**
+ * @param {Omit<import("hyparquet").ParquetReadOptions, "rowFormat" | "filter" | "filterStrict">} options
+ * @returns {Promise<void>}
+ */
+export async function parquetRead(options) {
+    if ("rowFormat" in options) {
+        throw new Error(
+            'parquetRead supports only object rows; use rowFormat: "object" implicitly'
+        );
+    }
+    if ("filter" in options || "filterStrict" in options) {
+        throw new Error("parquetRead does not support filtering");
+    }
+
+    options.metadata ??= await parquetMetadataAsync(options.file, options);
+
+    const { rowStart = 0, rowEnd, onChunk, onComplete } = options;
+
+    const asyncGroups = parquetReadAsync(options);
+
+    if (!onComplete && !onChunk) {
+        for (const { asyncColumns } of asyncGroups) {
+            for (const { data } of asyncColumns) {
+                await data;
+            }
+        }
+        return;
+    }
+
+    const schemaTree = parquetSchema(options.metadata);
+    const assembled = asyncGroups.map((group) =>
+        assembleAsync(group, schemaTree, options.parsers)
+    );
+
+    if (onChunk) {
+        for (const asyncGroup of assembled) {
+            for (const asyncColumn of asyncGroup.asyncColumns) {
+                asyncColumn.data.then(({ data, skipped }) => {
+                    let chunkRowStart = asyncGroup.groupStart + skipped;
+                    for (const columnData of data) {
+                        onChunk({
+                            columnName: asyncColumn.pathInSchema[0],
+                            columnData,
+                            rowStart: chunkRowStart,
+                            rowEnd: chunkRowStart + columnData.length,
+                        });
+                        chunkRowStart += columnData.length;
+                    }
+                });
+            }
+        }
+    }
+
+    if (onComplete) {
+        /** @type {Record<string, any>[]} */
+        const rows = [];
+        for (const asyncGroup of assembled) {
+            const selectStart = Math.max(rowStart - asyncGroup.groupStart, 0);
+            const selectEnd = Math.min(
+                (rowEnd ?? Infinity) - asyncGroup.groupStart,
+                asyncGroup.groupRows
+            );
+            const groupData = await asyncGroupToRowsObject(
+                asyncGroup,
+                selectStart,
+                selectEnd
+            );
+            concat(rows, groupData);
+        }
+        onComplete(rows);
+    } else {
+        for (const { asyncColumns } of assembled) {
+            for (const { data } of asyncColumns) {
+                await data;
+            }
+        }
+    }
+}
+
+/**
+ * @param {Omit<import("hyparquet").ParquetReadOptions, "onComplete" | "rowFormat" | "filter" | "filterStrict">} options
+ * @returns {Promise<Record<string, any>[]>}
+ */
+export function parquetReadObjects(options) {
+    return new Promise((onComplete, reject) => {
+        parquetRead({
+            ...options,
+            onComplete,
+        }).catch(reject);
+    });
+}

--- a/packages/core/src/data/sources/urlSource.js
+++ b/packages/core/src/data/sources/urlSource.js
@@ -110,15 +110,20 @@ export default class UrlSource extends DataSource {
          * @param {any} content
          * @param {string} [url]
          */
-        const readAndParse = (content, url) => {
+        const readAndParse = async (content, url) => {
             try {
-                /** @type {any[]} */
-                const data = read(content, format);
+                /** @type {any[] | Promise<any[]>} */
+                const dataOrPromise = read(content, format);
+                const data =
+                    dataOrPromise instanceof Promise
+                        ? await dataOrPromise
+                        : dataOrPromise;
                 this.beginBatch({ type: "file", url: url });
                 for (const d of data) {
                     this._propagate(d);
                 }
             } catch (e) {
+                console.warn(e);
                 throw new Error(`Cannot parse: ${url}: ${e.message}`);
             }
         };

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -44,6 +44,7 @@ import { validateSelectorConstraints } from "./view/viewSelectors.js";
  */
 
 vegaFormats("fasta", fasta);
+vegaFormats("parquet", parquet);
 
 export default class GenomeSpy {
     /** @type {(() => void)[]} */

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -37,6 +37,7 @@ import {
 } from "./genomeSpy/viewHierarchyConfig.js";
 import { exportCanvas } from "./genomeSpy/canvasExport.js";
 import { validateSelectorConstraints } from "./view/viewSelectors.js";
+import parquet from "./data/formats/parquet.js";
 
 /**
  * Events that are broadcasted to all views.

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "skipLibCheck": true
   },
 
   "include": ["src/**/*", "../../external-typings/**/*"],


### PR DESCRIPTION
This PR adds eager Parquet loading to GenomeSpy and optimizes hyparquet's row-materialization performance.

* Adds eager "parquet" format support via the url data source path.
* Introduces a local, lazy-loaded Parquet reader module based on hyparquet internals.
* Optimizes hot row-object assembly with cached codegen for typical schemas, with a safe interpreted fallback for very wide schemas.
* Restricts the local reader to object-row output and removes filter support.

Note: this PR introduces only eagerly loaded data. Parquet (and hyparquet) could be used for parameterized lazy loading in future. For example, only a subset of columns or pages could be loaded. 

Closes #277