### PR TITLE
fix(app): enable sample actions for data with categorical `x` scale

### DIFF
--- a/docs/sample-collections/visualizing.md
+++ b/docs/sample-collections/visualizing.md
@@ -298,10 +298,14 @@ make it available to all users. A simplified example:
 
 When working with a complex visualization that includes multiple tracks and
 extensive metadata, it may not always be necessary to display all views
-simultaneously. The GenomeSpy app offers users the ability to toggle the
-visibility of nodes within the view hierarchy. This visibility state is also
-included in shareable links and bookmarks, allowing users to easily access their
-preferred configurations.
+simultaneously. GenomeSpy App allows for interactive toggling of the visibility
+of nodes within the view hierarchy. This visibility state is also included in
+shareable links and bookmarks, allowing users to easily access their preferred
+configurations.
+
+Toggleable visibility requires each view to have an explicit unique `name`.
+GenomeSpy uses the name to address visibility state in bookmarks and shared
+state, and to keep views unambiguous within the import scope.
 
 Views have two properties for controlling the visibility:
 
@@ -318,6 +322,16 @@ radio buttons:
   ...
 }
 ```
+
+## Actions
+
+The app provides context-menu actions for sorting, filtering, grouping, and
+other sample-collection operations. For an overview, see
+[Analyzing Sample Collections](analyzing.md).
+
+Actions in sample collections also require each view to have an explicit unique
+`name`. GenomeSpy uses the name to address the view in action definitions and
+to replay those actions from bookmarks, shared state, and provenance history.
 
 ## Search
 

--- a/examples/app/copy-numbers.json
+++ b/examples/app/copy-numbers.json
@@ -42,6 +42,8 @@
   "samples": {},
 
   "spec": {
+    "name": "copy-numbers",
+
     "view": { "fill": "#f4f4f4" },
 
     "mark": {

--- a/examples/app/expression-zscores.json
+++ b/examples/app/expression-zscores.json
@@ -68,6 +68,8 @@
   "samples": {},
 
   "spec": {
+    "name": "expression-zscores",
+
     "view": { "fill": "#f4f4f4" },
     "mark": {
       "type": "rect",

--- a/examples/app/samples.json
+++ b/examples/app/samples.json
@@ -33,6 +33,7 @@
   "samples": {},
 
   "spec": {
+    "name": "segments",
     "mark": "rect",
     "view": { "fill": "#f0f0f0" },
     "encoding": {

--- a/packages/app/src/sampleView/attributeAggregation/attributeAccessors.js
+++ b/packages/app/src/sampleView/attributeAggregation/attributeAccessors.js
@@ -66,7 +66,10 @@ function normalizeInterval(scaleResolution, specifier, root) {
  */
 export function createViewAttributeAccessor(view, specifier) {
     const xType = /** @type {any} */ (view.getEncoding()?.x)?.type;
-    if (!xType || !["quantitative", "index", "locus"].includes(xType)) {
+    if (
+        "aggregation" in specifier &&
+        (!xType || !["quantitative", "index", "locus"].includes(xType))
+    ) {
         throw new Error(
             "Interval aggregation requires an x encoding of type quantitative, index, or locus!"
         );

--- a/packages/app/src/sampleView/attributeAggregation/attributeAccessors.test.js
+++ b/packages/app/src/sampleView/attributeAggregation/attributeAccessors.test.js
@@ -14,9 +14,11 @@ const createViewAttributeAccessorAny = /** @type {any} */ (
 
 /**
  * @param {object} options
- * @param {Array<{ pos: number, value: number }>} options.data
+ * @param {Array<Record<string, import("@genome-spy/core/spec/channel.js").Scalar>>} options.data
  * @param {import("@genome-spy/core/types/encoder.js").Accessor} options.xAccessor
- * @param {import("@genome-spy/core/types/encoder.js").Accessor} options.x2Accessor
+ * @param {import("@genome-spy/core/types/encoder.js").Accessor} [options.x2Accessor]
+ * @param {import("@genome-spy/core/spec/channel.js").Type} [options.xType]
+ * @param {string} [options.scaleType]
  * @param {string} [options.hitTestMode]
  * @param {object} [options.root]
  */
@@ -24,6 +26,8 @@ function createView({
     data,
     xAccessor,
     x2Accessor,
+    xType = "quantitative",
+    scaleType = "linear",
     hitTestMode = "intersects",
     root,
 }) {
@@ -33,8 +37,8 @@ function createView({
     const collector = { facetBatches };
 
     return {
-        getEncoding: () => ({ x: { type: "quantitative" } }),
-        getScaleResolution: () => ({ getScale: () => ({ type: "linear" }) }),
+        getEncoding: () => ({ x: { type: xType } }),
+        getScaleResolution: () => ({ getScale: () => ({ type: scaleType }) }),
         getCollector: () => collector,
         getDataAccessor: (channel) => {
             if (channel === "x") {
@@ -147,5 +151,32 @@ describe("createViewAttributeAccessor", () => {
         });
 
         expect(() => accessor("sample-1")).toThrow("is empty");
+    });
+
+    test("supports categorical point queries without interval aggregation", () => {
+        const paramRuntime = new ViewParamRuntime(() => undefined);
+        const xAccessor = createAccessor(
+            "x",
+            { field: "category" },
+            paramRuntime
+        );
+        const view = createView({
+            data: [
+                { category: "A", value: 10 },
+                { category: "B", value: 20 },
+            ],
+            xAccessor,
+            x2Accessor: undefined,
+            xType: "nominal",
+            scaleType: "band",
+        });
+
+        const accessor = createViewAttributeAccessorAny(view, {
+            view: "test",
+            field: "value",
+            locus: "B",
+        });
+
+        expect(accessor("sample-1")).toBe(20);
     });
 });

--- a/packages/app/src/sampleView/contextMenuBuilder.js
+++ b/packages/app/src/sampleView/contextMenuBuilder.js
@@ -95,35 +95,24 @@ export function resolveIntervalSelection(selectionInfo, selectionPoint) {
  */
 export function getContextMenuFieldInfos(view, layoutRoot, hasInterval) {
     const uniqueViewKeys = getUniqueViewRefKeys(layoutRoot);
-
-    /** @type {import("@genome-spy/core/view/unitView.js").default[]} */
-    const unitViews = [];
-    view.visit((child) => {
-        if (child instanceof UnitView) {
-            unitViews.push(child);
-        }
-    });
-
-    let fieldInfos = findEncodedFields(view)
-        .filter((d) => !["sample", "x", "x2"].includes(d.channel))
-        // TODO: Log a warning if the view reference is not unique.
-        .filter((info) => {
-            const viewKey = getViewRefKey(info.view);
-            return viewKey && uniqueViewKeys.has(viewKey);
-        })
-        .filter((info) => info.view.isVisible());
+    let fieldInfos = getVisibleNonPositionalFieldInfos(view).filter((info) =>
+        isAddressableView(info.view, uniqueViewKeys)
+    );
 
     if (hasInterval) {
+        /** @type {import("@genome-spy/core/view/unitView.js").default[]} */
+        const unitViews = [];
+        view.visit((child) => {
+            if (
+                child instanceof UnitView &&
+                child.isVisible() &&
+                isAddressableView(child, uniqueViewKeys)
+            ) {
+                unitViews.push(child);
+            }
+        });
+
         for (const unitView of unitViews) {
-            if (!unitView.isVisible()) {
-                continue;
-            }
-
-            const viewKey = getViewRefKey(unitView);
-            if (!viewKey || !uniqueViewKeys.has(viewKey)) {
-                continue;
-            }
-
             const encoding = unitView.getEncoding();
             const hasXField = encoding?.x && "field" in encoding.x;
             const hasNonPositionalField = Object.entries(encoding).some(
@@ -145,16 +134,7 @@ export function getContextMenuFieldInfos(view, layoutRoot, hasInterval) {
     }
 
     if (!hasInterval) {
-        fieldInfos = fieldInfos.filter((info) => {
-            if (info.view.getEncoding()?.x2) {
-                return true;
-            }
-
-            const scaleType = info.view
-                .getScaleResolution("x")
-                ?.getScale()?.type;
-            return scaleType ? isDiscrete(scaleType) : false;
-        });
+        fieldInfos = fieldInfos.filter(isPointQueryable);
     }
 
     // The same field may be used on multiple channels.
@@ -169,6 +149,56 @@ export function getContextMenuFieldInfos(view, layoutRoot, hasInterval) {
             })
         ).values()
     );
+}
+
+/**
+ * @param {import("@genome-spy/core/view/view.js").default} view
+ * @param {import("@genome-spy/core/view/view.js").default} layoutRoot
+ * @returns {import("@genome-spy/core/view/unitView.js").default[]}
+ */
+export function getUnavailablePointQueryViews(view, layoutRoot) {
+    const uniqueViewKeys = getUniqueViewRefKeys(layoutRoot);
+    return Array.from(
+        new Set(
+            getVisibleNonPositionalFieldInfos(view)
+                .filter((info) => !isAddressableView(info.view, uniqueViewKeys))
+                .filter(isPointQueryable)
+                .map((info) => info.view)
+        )
+    );
+}
+
+/**
+ * @param {FieldInfo} info
+ * @returns {boolean}
+ */
+function isPointQueryable(info) {
+    if (info.view.getEncoding()?.x2) {
+        return true;
+    }
+
+    const scaleType = info.view.getScaleResolution("x")?.getScale()?.type;
+    return scaleType ? isDiscrete(scaleType) : false;
+}
+
+/**
+ * @param {import("@genome-spy/core/view/view.js").default} view
+ * @returns {FieldInfo[]}
+ */
+function getVisibleNonPositionalFieldInfos(view) {
+    return findEncodedFields(view)
+        .filter((info) => !["sample", "x", "x2"].includes(info.channel))
+        .filter((info) => info.view.isVisible());
+}
+
+/**
+ * @param {import("@genome-spy/core/view/unitView.js").default} view
+ * @param {Set<string>} uniqueViewKeys
+ * @returns {boolean}
+ */
+function isAddressableView(view, uniqueViewKeys) {
+    const viewKey = getViewRefKey(view);
+    return !!viewKey && uniqueViewKeys.has(viewKey);
 }
 
 /**

--- a/packages/app/src/sampleView/contextMenuBuilder.js
+++ b/packages/app/src/sampleView/contextMenuBuilder.js
@@ -1,4 +1,5 @@
 import { html } from "lit";
+import { isDiscrete } from "vega-scale";
 import { isChromosomalLocus } from "@genome-spy/core/genome/genome.js";
 import { locusOrNumberToString } from "@genome-spy/core/genome/locusFormat.js";
 import { selectionContainsPoint } from "@genome-spy/core/selection/selection.js";
@@ -144,7 +145,16 @@ export function getContextMenuFieldInfos(view, layoutRoot, hasInterval) {
     }
 
     if (!hasInterval) {
-        fieldInfos = fieldInfos.filter((info) => info.view.getEncoding()?.x2);
+        fieldInfos = fieldInfos.filter((info) => {
+            if (info.view.getEncoding()?.x2) {
+                return true;
+            }
+
+            const scaleType = info.view
+                .getScaleResolution("x")
+                ?.getScale()?.type;
+            return scaleType ? isDiscrete(scaleType) : false;
+        });
     }
 
     // The same field may be used on multiple channels.

--- a/packages/app/src/sampleView/contextMenuBuilder.test.js
+++ b/packages/app/src/sampleView/contextMenuBuilder.test.js
@@ -1,0 +1,53 @@
+// @ts-check
+import { describe, expect, test } from "vitest";
+import { createSampleViewForTest } from "../testUtils/appTestUtils.js";
+import { getUnavailablePointQueryViews } from "./contextMenuBuilder.js";
+
+describe("contextMenuBuilder", () => {
+    test("reports unnamed categorical point-query views as unavailable", async () => {
+        /** @type {import("@genome-spy/app/spec/sampleView.js").SampleSpec} */
+        const spec = {
+            data: {
+                values: [
+                    { sample: "S1", gene: "EGFR", zScore: 1.2 },
+                    { sample: "S2", gene: "TP53", zScore: -0.4 },
+                ],
+            },
+            samples: {},
+            spec: {
+                mark: "rect",
+                encoding: {
+                    sample: { field: "sample" },
+                    x: { field: "gene", type: "nominal" },
+                    fill: { field: "zScore", type: "quantitative" },
+                },
+            },
+        };
+
+        const { view } = await createSampleViewForTest({
+            spec,
+        });
+
+        /** @type {import("@genome-spy/core/view/unitView.js").default | undefined} */
+        let targetView;
+        view.visit((child) => {
+            const fillDef = /** @type {any} */ (child.getEncoding?.()?.fill);
+            if (
+                child.getEncoding &&
+                fillDef &&
+                "field" in fillDef &&
+                fillDef.field === "zScore"
+            ) {
+                targetView =
+                    /** @type {import("@genome-spy/core/view/unitView.js").default} */ (
+                        child
+                    );
+            }
+        });
+
+        expect(targetView).toBeDefined();
+        expect(
+            getUnavailablePointQueryViews(targetView, /** @type {any} */ (view))
+        ).toEqual([targetView]);
+    });
+});

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -75,6 +75,7 @@ import {
     getParamSelector,
     resolveParamSelector,
 } from "@genome-spy/core/view/viewSelectors.js";
+import { isContinuous, isDiscrete } from "vega-scale";
 import {
     MULTIPLE_POINT_SELECTION_PARAMS_REASON,
     resolveSelectionExpansionContext,
@@ -410,10 +411,19 @@ export default class SampleView extends ContainerView {
      */
     async ensureViewAttributeAvailability(specifier, context = {}) {
         const view = this.#resolveViewForSpecifier(specifier);
+        const resolution = view.getScaleResolution("x");
+        if (!resolution) {
+            throw new Error(
+                `No x scale resolution found for view: ${view.name}`
+            );
+        }
 
         this.#ensureViewVisible(view);
-        const domain = this.#resolveViewAttributeDomain(specifier);
-        await this.#zoomToDomain(view, domain);
+        const scale = resolution.getScale();
+        if (isContinuous(scale.type) && !isDiscrete(scale.type)) {
+            const domain = this.#resolveViewAttributeDomain(specifier);
+            await this.#zoomToDomain(view, domain);
+        }
         // Assumes the main sample subtree shares the x-scale resolution; if
         // that changes, switch to per-view readiness requests.
         await this.#awaitSubtreeDataReady(

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -1168,6 +1168,7 @@ export default class SampleView extends ContainerView {
     #handleContextMenu(event) {
         // TODO: Allow for registering listeners
         const mouseEvent = /** @type {MouseEvent} */ (event.uiEvent);
+        const layoutRoot = this.getLayoutAncestors().at(-1);
 
         const normalizedXPos = this.childCoords.normalizePoint(
             event.point.x,
@@ -1210,15 +1211,12 @@ export default class SampleView extends ContainerView {
 
         const uniqueFieldInfos = getContextMenuFieldInfos(
             view,
-            this.getLayoutAncestors().at(-1),
+            layoutRoot,
             !!selectionInterval
         );
         const unavailablePointQueryViews = selectionInterval
             ? []
-            : getUnavailablePointQueryViews(
-                  view,
-                  this.getLayoutAncestors().at(-1)
-              );
+            : getUnavailablePointQueryViews(view, layoutRoot);
 
         /** @type {import("../utils/ui/contextMenu.js").MenuItem[]} */
         let items = [
@@ -1257,6 +1255,13 @@ export default class SampleView extends ContainerView {
             selectionExpansionContext = selectionExpansionResolution.context;
         }
 
+        const attributeMenuBase = {
+            sample,
+            sampleHierarchy: this.sampleHierarchy,
+            attributeInfoSource: this.compositeAttributeInfoSource,
+            attributeType: VALUE_AT_LOCUS,
+            sampleView: this,
+        };
         let previousContextTitle = "";
         let selectionExpansionItemInserted = false;
 
@@ -1291,11 +1296,7 @@ export default class SampleView extends ContainerView {
                         fieldInfo,
                         selectionIntervalComplex,
                         selectionIntervalSource,
-                        sample,
-                        sampleHierarchy: this.sampleHierarchy,
-                        attributeInfoSource: this.compositeAttributeInfoSource,
-                        attributeType: VALUE_AT_LOCUS,
-                        sampleView: this,
+                        ...attributeMenuBase,
                     }),
                 });
                 continue;
@@ -1306,11 +1307,7 @@ export default class SampleView extends ContainerView {
                 submenu: buildPointQueryMenu({
                     fieldInfo,
                     complexX,
-                    sample,
-                    sampleHierarchy: this.sampleHierarchy,
-                    attributeInfoSource: this.compositeAttributeInfoSource,
-                    attributeType: VALUE_AT_LOCUS,
-                    sampleView: this,
+                    ...attributeMenuBase,
                 }),
             });
 

--- a/packages/app/src/sampleView/sampleView.js
+++ b/packages/app/src/sampleView/sampleView.js
@@ -1,4 +1,5 @@
 import ContainerView from "@genome-spy/core/view/containerView.js";
+import { html } from "lit";
 import {
     FlexDimensions,
     mapToPixelCoords,
@@ -67,6 +68,7 @@ import {
     buildPointQueryMenu,
     formatPointContextLabel,
     getContextMenuFieldInfos,
+    getUnavailablePointQueryViews,
     resolveIntervalSelection,
 } from "./contextMenuBuilder.js";
 import { ReadyWaiterSet } from "../utils/readyGate.js";
@@ -1211,6 +1213,12 @@ export default class SampleView extends ContainerView {
             this.getLayoutAncestors().at(-1),
             !!selectionInterval
         );
+        const unavailablePointQueryViews = selectionInterval
+            ? []
+            : getUnavailablePointQueryViews(
+                  view,
+                  this.getLayoutAncestors().at(-1)
+              );
 
         /** @type {import("../utils/ui/contextMenu.js").MenuItem[]} */
         let items = [
@@ -1340,6 +1348,21 @@ export default class SampleView extends ContainerView {
                     (action) => this.intentExecutor.dispatch(action)
                 )
             );
+        }
+
+        for (const unavailableView of unavailablePointQueryViews) {
+            if (items.at(-1)?.type !== "divider") {
+                items.push(DIVIDER);
+            }
+
+            items.push({
+                label: getUnitViewContextTitle(unavailableView),
+                type: "header",
+            });
+            items.push({
+                label: html`Actions unavailable.<br />
+                    Add a unique explicit "name" to this view.`,
+            });
         }
 
         contextMenu({ items }, mouseEvent);

--- a/packages/app/src/sampleView/sampleViewEnsureAvailability.test.js
+++ b/packages/app/src/sampleView/sampleViewEnsureAvailability.test.js
@@ -50,6 +50,7 @@ describe("SampleView ensureViewAttributeAvailability", () => {
         // Non-obvious: patch zoomTo to control the async sequence.
         target.getScaleResolution = () =>
             /** @type {any} */ ({
+                getScale: () => ({ type: "linear" }),
                 getDomain: () => [0, 10],
                 zoomTo,
             });
@@ -71,6 +72,64 @@ describe("SampleView ensureViewAttributeAvailability", () => {
 
         zoomDeferred.resolve();
         await zoomDeferred.promise;
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        view.handleBroadcast({
+            type: "subtreeDataReady",
+            payload: { subtreeRoot: view },
+        });
+
+        await ensurePromise;
+        expect(resolved).toBe(true);
+    });
+
+    it("skips zoom for categorical x scales and still awaits subtree readiness", async () => {
+        /** @type {import("@genome-spy/app/spec/sampleView.js").SampleSpec} */
+        const spec = {
+            data: {
+                values: [{ sample: "S1", category: "A" }],
+            },
+            samples: {},
+            spec: {
+                name: "target-view",
+                mark: "rect",
+                encoding: {
+                    sample: { field: "sample" },
+                    x: { field: "category", type: "nominal" },
+                },
+            },
+        };
+
+        const { view } = await createSampleViewForTest({
+            spec,
+            initializeFlow: false,
+        });
+
+        // Prevent sample extraction from running during subtree readiness.
+        view.getSamples = () =>
+            /** @type {any} */ ([
+                { id: "dummy", displayName: "dummy", indexNumber: 0 },
+            ]);
+
+        const target = view.findDescendantByName("target-view");
+        target.getScaleResolution = () =>
+            /** @type {any} */ ({
+                getScale: () => ({ type: "band" }),
+                getDomain: () => ["A", "B"],
+            });
+
+        let resolved = false;
+        const ensurePromise = view
+            .ensureViewAttributeAvailability({
+                view: "target-view",
+                field: "category",
+                locus: "A",
+            })
+            .then(() => {
+                resolved = true;
+            });
+
         await Promise.resolve();
         expect(resolved).toBe(false);
 


### PR DESCRIPTION
This PR:
* Enables actions for categorical-x data (like gene expression matrix)
* Adds an actionable notice to context menu when views lack explicit `name`s to make the name requirement more discoverable
* Adds names to examples in `examples/app`
* Updates docs, emphasizes the view name requirement
* Does minor refactoring