### PR TITLE
refactor(app-agent): support direct selection aggregation actions

### DIFF
--- a/packages/app-agent/LLM_PLAN/index.md
+++ b/packages/app-agent/LLM_PLAN/index.md
@@ -104,6 +104,9 @@
   for the interval-selection summaries used by the agent.
 - See [`selection-aggregation-workflow.md`](./selection-aggregation-workflow.md)
   for the draft selection-aggregation flow.
+- See [`selection-aggregation-action-adapter.md`](./selection-aggregation-action-adapter.md)
+  for the plan to accept selection aggregation candidates in intent actions.
+
 ## Data Access Policy
 
 - See [`infrastructure.md`](./infrastructure.md) for the public-data vs controlled-access policy and the LLM transport safeguards.

--- a/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
+++ b/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
@@ -238,6 +238,29 @@ attribute summaries still need the same conversion logic.
     should show only internal resolver/test references, not generated tool
     catalog/schema or prompt instructions.
 
+Step 7 tightens `candidateId` guidance after the model tried to invent ids.
+The prompt no longer includes schematic candidate ids, and the generated
+`SelectionAggregationCandidate.candidateId` schema says to copy the exact id
+from `selectionAggregation.fields`.
+
+- Focused source lines:
+  - `genomespy_system_prompt.md`: 567 before, 561 after
+  - `agentToolInputs.d.ts`: 424 before, 419 after
+  - `actionShapeValidator.js`: 583 before, 585 after
+  - `selectionAggregationTool.js`: 84 before, 86 after
+- Generated schema/catalog sizes:
+  - `generatedToolSchema.json`: 79,071 before, 79,009 after
+  - `generatedToolCatalog.json`: unchanged at 10,226 bytes
+- Verification target:
+  - Generated tool schema should contain the `candidateId` warning.
+  - Generated tool schema and system prompt should not contain schematic
+    examples such as `param_name@view_selector:field_name`.
+- Verification:
+  - `npx vitest run packages/app-agent/src/agent/agentTools.test.js packages/app-agent/src/agent/toolCatalog.test.js packages/app-agent/src/agent/actionShapeValidator.test.js packages/app-agent/src/agent/attributeSummaryTool.test.js`
+    passed.
+  - `npm --workspace packages/app-agent run test:tsc` passed.
+  - `npm --workspace packages/app-agent run check:agent` passed.
+
 ### LoC Assessment
 
 The line-count increase is acceptable for this refactor.

--- a/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
+++ b/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
@@ -217,6 +217,27 @@ longer described as requiring `buildSelectionAggregationAttribute`.
   - `npm --workspace packages/app-agent run test:tsc` passed.
   - `npm --workspace packages/app-agent run check:agent` passed.
 
+Step 6 removes `buildSelectionAggregationAttribute` from the exposed agent tool
+surface because the model kept selecting it despite the direct adapter path.
+The internal resolver remains because `SELECTION_AGGREGATION` normalization and
+attribute summaries still need the same conversion logic.
+
+- Focused source lines:
+  - `genomespy_system_prompt.md`: 574 before, 567 after
+  - `agentToolInputs.d.ts`: 457 before, 424 after
+  - `agentTools.js`: 570 before, 540 after
+  - `agentSessionController.js`: 1,378 before, 1,377 after
+  - `agentTools.test.js`: 1,420 before, 1,383 after
+  - `agentSessionController.test.js`: 1,721 before, 1,655 after
+  - `toolCatalog.test.js`: 329 before, 330 after
+- Generated schema/catalog sizes:
+  - `generatedToolSchema.json`: 80,738 before, 79,071 after
+  - `generatedToolCatalog.json`: 11,186 before, 10,226 after
+- Verification target:
+  - `rg "buildSelectionAggregationAttribute" packages/app-agent/src packages/app-agent/server/app/prompts`
+    should show only internal resolver/test references, not generated tool
+    catalog/schema or prompt instructions.
+
 ### LoC Assessment
 
 The line-count increase is acceptable for this refactor.
@@ -295,12 +316,11 @@ validation remain canonical while only the agent tool boundary accepts compact
      - Record line-count and schema-size deltas.
 
 6. Reconsider `buildSelectionAggregationAttribute`.
-   - Keep it initially for diagnostics and backwards compatibility.
-   - After the new path is stable, decide whether to remove it from the tool
-     surface.
+   - Removed from the exposed tool surface after the model kept selecting it.
+   - Keep the internal resolver used by candidate normalization and summaries.
    - Measure success:
-     - Either a follow-up issue/plan note records why the tool remains, or a
-       separate cleanup removes it with generated schema/tests updated.
+     - Generated tool catalog/schema no longer expose it.
+     - Prompt text no longer advertises it.
      - Record line-count and schema-size deltas.
 
 ## Risks

--- a/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
+++ b/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
@@ -197,6 +197,26 @@ normalizer.
   - `npm --workspace packages/app-agent run test:tsc` passed.
   - `npm --workspace packages/app-agent run check:agent` passed.
 
+Step 5 updates prompt and tool/action docs so direct intent action use is no
+longer described as requiring `buildSelectionAggregationAttribute`.
+
+- Focused source lines:
+  - `genomespy_system_prompt.md`: 574 before, 574 after
+  - `agentToolInputs.d.ts`: 458 before, 457 after
+  - `sampleSlice.js`: 959 before, 959 after
+  - `agentTools.test.js`: 1,420 after expanded adapter cases
+- Generated schema/catalog sizes:
+  - `generatedToolSchema.json`: 80,738 bytes
+  - `generatedToolCatalog.json`: 11,186 bytes
+  - `generatedActionCatalog.json`: 21,232 bytes
+  - `generatedActionSummaries.json`: 3,347 bytes
+  - `SubmitIntentActionsToolInput` JSON slice: 1,149 bytes
+- Verification:
+  - `npx vitest run packages/app-agent/src/agent/actionCatalog.test.js packages/app-agent/src/agent/agentTools.test.js packages/app-agent/src/agent/toolCatalog.test.js packages/app-agent/src/agent/actionShapeValidator.test.js`
+    passed.
+  - `npm --workspace packages/app-agent run test:tsc` passed.
+  - `npm --workspace packages/app-agent run check:agent` passed.
+
 1. Add the agent-facing action input type.
    - Try the recursive `AgentizeAttributes<T>` approach in
      `agentToolInputs.d.ts`.

--- a/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
+++ b/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
@@ -217,6 +217,28 @@ longer described as requiring `buildSelectionAggregationAttribute`.
   - `npm --workspace packages/app-agent run test:tsc` passed.
   - `npm --workspace packages/app-agent run check:agent` passed.
 
+### LoC Assessment
+
+The line-count increase is acceptable for this refactor.
+
+- Generated schema growth is minimal: `generatedToolSchema.json` grew by only
+  173 bytes from the implementation baseline, while
+  `SubmitIntentActionsToolInput` stayed at 1,149 bytes. This confirms that the
+  schema post-processing fallback avoided the recursive mapped-type schema
+  explosion.
+- Prompt and docs changes are effectively line-neutral:
+  `genomespy_system_prompt.md` stayed at 574 lines, `sampleSlice.js` stayed at
+  959 lines, and `agentToolInputs.d.ts` decreased by one line.
+- The main production-code increase is intentional boundary code:
+  `agentIntentActionAttributes.js` adds a 56-line normalizer, and
+  `actionShapeValidator.js` carries the cost of keeping canonical app payload
+  validation separate from relaxed agent-facing validation.
+
+If further simplification is needed, inspect `actionShapeValidator.js` first.
+However, the current explicit split is defensible because reducers and executor
+validation remain canonical while only the agent tool boundary accepts compact
+`SELECTION_AGGREGATION` candidates.
+
 1. Add the agent-facing action input type.
    - Try the recursive `AgentizeAttributes<T>` approach in
      `agentToolInputs.d.ts`.

--- a/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
+++ b/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
@@ -1,0 +1,201 @@
+# Selection Aggregation Action Adapter
+
+Plan for allowing agent-authored intent actions to use
+`SELECTION_AGGREGATION` candidates directly while keeping Redux actions and
+reducers on canonical `AttributeIdentifier` payloads.
+
+## Problem
+
+Plotting tools and `getAttributeSummary` already accept compact
+`SELECTION_AGGREGATION` candidates:
+
+```json
+{
+  "type": "SELECTION_AGGREGATION",
+  "candidateId": "brush@track:field",
+  "aggregation": "max"
+}
+```
+
+Intent actions still require resolved `AttributeIdentifier` payloads because
+the generated action schemas and Redux reducers expect app-native payload
+types. This forces the agent to call `buildSelectionAggregationAttribute` before
+actions such as deriving metadata, sorting, filtering, or grouping.
+
+## Goal
+
+Let the agent submit compact selection-derived attributes directly inside
+intent action payloads, then normalize them before validation/execution reaches
+the app layer.
+
+The app-facing action creators and reducers should continue to receive only
+canonical `AttributeIdentifier` objects.
+
+## Non-Goals
+
+- Do not change Redux reducer payload contracts.
+- Do not duplicate app action payload types in app-agent.
+- Do not teach the agent to construct `VALUE_AT_LOCUS` objects by hand.
+- Do not replace `buildSelectionAggregationAttribute` immediately; it can remain
+  as a diagnostic or compatibility tool until the new path is proven.
+
+## Existing Pieces
+
+- `attributeCandidate.js`
+  - Resolves `SAMPLE_ATTRIBUTE` and `SELECTION_AGGREGATION` candidates.
+  - Already contains the canonical conversion logic used by plots and
+    `getAttributeSummary`.
+- `agentTools.submitIntentActions(...)`
+  - Receives agent-authored action payloads and forwards them to
+    `runtime.submitIntentActions(...)`.
+- `intentProgramExecutor.js`
+  - Validates and executes canonical app intent batches.
+- `actionShapeValidator.js`
+  - Validates action payloads against generated action schemas.
+- `generatedActionTypes.ts` and `generatedActionSchema.json`
+  - Generated from app action payload typings.
+
+## Proposed Design
+
+Add an agent-side normalization boundary before intent actions enter the app
+executor:
+
+1. Accept agent-authored action payloads where `AttributeIdentifier` fields may
+   also contain `SELECTION_AGGREGATION` candidates.
+2. Walk each submitted action payload and replace every
+   `SELECTION_AGGREGATION` candidate with the resolved canonical
+   `AttributeIdentifier`.
+3. Validate and execute the normalized batch through the existing
+   `intentProgramExecutor` path.
+
+The normalizer should reuse `resolveAgentAttributeCandidate(...)` rather than
+duplicating selection aggregation construction.
+
+## Type Strategy
+
+Prefer deriving the agent-authored action input type from the generated app
+action type:
+
+```ts
+type AgentAttributeInput = AttributeIdentifier | SelectionAggregationCandidate;
+
+type AgentizeAttributes<T> =
+    T extends AttributeIdentifier ? AgentAttributeInput :
+    T extends readonly (infer U)[] ? AgentizeAttributes<U>[] :
+    T extends object ? { [K in keyof T]: AgentizeAttributes<T[K]> } :
+    T;
+```
+
+Then use a derived agent-facing action step type for `submitIntentActions`.
+
+This avoids copying payload contracts while making only `AttributeIdentifier`
+positions broader for the agent.
+
+## Schema Strategy
+
+First try generating the tool schema from the recursive mapped type above. If
+`ts-json-schema-generator` emits a clear schema, keep this path.
+
+If schema generation becomes noisy or incorrect, use schema post-processing:
+
+- Generate the canonical action schema as today.
+- For the agent tool schema and action-shape validator, replace refs to
+  `AttributeIdentifier` with an `anyOf` union:
+  - canonical `AttributeIdentifier`
+  - `SelectionAggregationCandidate`
+- Keep generated app action schema unchanged for executor-facing validation.
+
+The post-processing fallback is less elegant but still centralizes the adapter
+without duplicating payload types.
+
+## Normalization Strategy
+
+Add a small recursive normalizer, for example
+`normalizeAgentIntentActionAttributes(runtime, value)`.
+
+Rules:
+
+- If an object has `type: "SELECTION_AGGREGATION"`, string `candidateId`, and
+  string `aggregation`, resolve it with `resolveAgentAttributeCandidate(...)`.
+- Recurse into arrays and plain objects.
+- Leave all other values unchanged.
+- Fail fast on invalid candidates by reusing the existing resolver errors.
+
+This broad recursive pass is acceptable because `SELECTION_AGGREGATION` is an
+agent-only marker and should never be a legitimate non-attribute payload object.
+
+## Implementation Steps
+
+1. Add the agent-facing action input type.
+   - Try the recursive `AgentizeAttributes<T>` approach in
+     `agentToolInputs.d.ts`.
+   - Regenerate tool schemas and inspect `submitIntentActions`.
+   - Measure success:
+     - `generatedToolSchema.json` accepts `SELECTION_AGGREGATION` under action
+       payload attributes.
+     - The generated `submitIntentActions` schema remains readable and does not
+       duplicate full payload contracts by hand.
+     - `npm --workspace packages/app-agent run check:agent` passes.
+
+2. Add normalization before submission.
+   - Normalize `input.actions` in `agentTools.submitIntentActions(...)`.
+   - Pass the normalized actions to `runtime.submitIntentActions(...)`.
+   - Measure success:
+     - A focused unit test proves submitted `SELECTION_AGGREGATION` candidates
+       are converted to canonical `VALUE_AT_LOCUS` attributes before runtime
+       submission.
+     - Existing canonical action payload tests still pass unchanged.
+
+3. Keep canonical executor behavior.
+   - Do not change reducers or action creators.
+   - Keep `intentProgramExecutor` validating canonical batches.
+   - Measure success:
+     - No files under `packages/app/src/sampleView/state/` change.
+     - `intentProgramExecutor` tests still validate canonical payloads.
+
+4. Add focused tests.
+   - `submitIntentActions` accepts a `SELECTION_AGGREGATION` attribute in
+     `deriveMetadata`.
+   - The runtime receives a canonical `VALUE_AT_LOCUS` attribute.
+   - Invalid candidate ids are rejected as tool errors.
+   - Existing canonical `SAMPLE_ATTRIBUTE` and `VALUE_AT_LOCUS` payloads still
+     pass unchanged.
+   - Measure success:
+     - `npx vitest run packages/app-agent/src/agent/agentTools.test.js`
+       includes the adapter cases and passes.
+     - Any new normalizer test file is run directly and passes.
+
+5. Update prompt/tool docs.
+   - Say intent actions can use `SELECTION_AGGREGATION` candidates directly once
+     the adapter exists.
+   - Deprecate the mandatory `buildSelectionAggregationAttribute` step in the
+     workflow text.
+   - Measure success:
+     - `rg "buildSelectionAggregationAttribute" packages/app-agent/server/app/prompts`
+       shows it is no longer described as mandatory for intent actions.
+     - Tool docs and generated schema describe direct action use without
+       claiming Redux reducers accept compact candidates.
+
+6. Reconsider `buildSelectionAggregationAttribute`.
+   - Keep it initially for diagnostics and backwards compatibility.
+   - After the new path is stable, decide whether to remove it from the tool
+     surface.
+   - Measure success:
+     - Either a follow-up issue/plan note records why the tool remains, or a
+       separate cleanup removes it with generated schema/tests updated.
+
+## Risks
+
+- Recursive mapped types may generate poor JSON Schema.
+- A broad recursive normalizer may resolve objects in unexpected payload
+  locations, though the marker shape is specific enough to keep this low risk.
+- Action-shape validation currently happens before runtime execution; the
+  agent-facing schema must accept compact candidates or the tool call will be
+  rejected before normalization.
+
+## Success Criteria
+
+- The agent can submit `SELECTION_AGGREGATION` directly in an action payload.
+- Redux reducers receive only canonical app payloads.
+- Generated schemas remain understandable.
+- No app action payload typings are duplicated in app-agent.

--- a/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
+++ b/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
@@ -261,6 +261,30 @@ from `selectionAggregation.fields`.
   - `npm --workspace packages/app-agent run test:tsc` passed.
   - `npm --workspace packages/app-agent run check:agent` passed.
 
+Step 8 removes `VALUE_AT_LOCUS` from agent-facing docs and rejects hand-written
+internal attributes at the agent boundary. `VALUE_AT_LOCUS` remains in the
+canonical app action schema because reducers and normalized payloads still use
+it internally.
+
+- Focused source lines:
+  - `generateAgentToolSchema.mjs`: 98
+  - `actionShapeValidator.js`: 642
+  - `actionShapeValidator.test.js`: 182
+  - `actionCatalog.test.js`: 202
+  - `sampleSlice.js`: 944
+  - `types.d.ts`: 124
+- Generated schema/catalog sizes:
+  - `generatedToolSchema.json`: 78,002 bytes
+  - `generatedActionCatalog.json`: 20,805 bytes
+  - `generatedActionSchema.json`: 61,134 bytes
+- Verification:
+  - `rg "VALUE_AT_LOCUS" packages/app-agent/src/agent/generated/generatedActionCatalog.json packages/app-agent/src/agent/generated/generatedToolSchema.json packages/app-agent/src/agent/generated/generatedToolCatalog.json packages/app-agent/server/app/prompts/genomespy_system_prompt.md`
+    returns no matches.
+  - `npx vitest run packages/app-agent/src/agent/actionShapeValidator.test.js packages/app-agent/src/agent/actionCatalog.test.js packages/app-agent/src/agent/toolCatalog.test.js packages/app-agent/src/agent/agentTools.test.js`
+    passed.
+  - `npm --workspace packages/app-agent run test:tsc` passed.
+  - `npm --workspace packages/app-agent run check:agent` passed.
+
 ### LoC Assessment
 
 The line-count increase is acceptable for this refactor.

--- a/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
+++ b/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
@@ -151,6 +151,52 @@ commit notes or plan update:
     definition, also record a short qualitative note about whether the
     `submitIntentActions` schema remained readable.
 
+### Measurement Log
+
+Baseline before implementation:
+
+- Focused source lines:
+  - `agentToolInputs.d.ts`: 458
+  - `agentTools.js`: 565
+  - `attributeCandidate.js`: 191
+- Generated schema sizes:
+  - `generatedToolSchema.json`: 80,565 bytes
+  - `generatedActionSchema.json`: 61,188 bytes
+  - `SubmitIntentActionsToolInput` JSON slice: 1,149 bytes
+
+Step 1 attempted the recursive mapped type strategy. Result: rejected. It made
+`generatedToolSchema.json` smaller, but produced many noisy
+`AgentizeAttributes<...>` definitions and made the action schema hard to read.
+
+- Focused source lines:
+  - `agentToolInputs.d.ts`: 477
+  - `agentTools.js`: 565
+  - `attributeCandidate.js`: 191
+- Generated schema sizes:
+  - `generatedToolSchema.json`: 79,902 bytes
+  - `generatedActionSchema.json`: 61,188 bytes
+  - `SubmitIntentActionsToolInput` JSON slice: 1,151 bytes
+
+Step 2 uses the schema post-processing fallback and adds the runtime
+normalizer.
+
+- Focused source lines:
+  - `agentToolInputs.d.ts`: 458
+  - `agentTools.js`: 570
+  - `attributeCandidate.js`: 191
+  - `agentIntentActionAttributes.js`: 56
+  - `actionShapeValidator.js`: 583
+  - `submitIntentActionsValidator.js`: 89
+- Generated schema sizes:
+  - `generatedToolSchema.json`: 80,803 bytes
+  - `generatedActionSchema.json`: 61,188 bytes
+  - `SubmitIntentActionsToolInput` JSON slice: 1,149 bytes
+- Verification:
+  - `npx vitest run packages/app-agent/src/agent/toolCatalog.test.js packages/app-agent/src/agent/actionShapeValidator.test.js packages/app-agent/src/agent/agentTools.test.js`
+    passed.
+  - `npm --workspace packages/app-agent run test:tsc` passed.
+  - `npm --workspace packages/app-agent run check:agent` passed.
+
 1. Add the agent-facing action input type.
    - Try the recursive `AgentizeAttributes<T>` approach in
      `agentToolInputs.d.ts`.

--- a/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
+++ b/packages/app-agent/LLM_PLAN/selection-aggregation-action-adapter.md
@@ -126,6 +126,31 @@ agent-only marker and should never be a legitimate non-attribute payload object.
 
 ## Implementation Steps
 
+Before each implementation step, record the baseline measurements listed below.
+After the step, record the same measurements again and include the delta in the
+commit notes or plan update:
+
+- Focused source line counts:
+  - `wc -l packages/app-agent/src/agent/agentToolInputs.d.ts`
+  - `wc -l packages/app-agent/src/agent/agentTools.js`
+  - `wc -l packages/app-agent/src/agent/attributeCandidate.js`
+  - any new adapter/normalizer files
+- Generated schema size:
+  - `wc -c packages/app-agent/src/agent/generated/generatedToolSchema.json`
+  - `wc -c packages/app-agent/src/agent/generated/generatedActionSchema.json`
+- Relevant generated schema slice size:
+  - byte count or line count for the `submitIntentActions` schema/definition
+    section in `generatedToolSchema.json`.
+  - One repeatable way to measure it:
+
+    ```sh
+    node -e 'const s=require("./packages/app-agent/src/agent/generated/generatedToolSchema.json"); console.log(JSON.stringify(s.definitions.SubmitIntentActionsToolInput).length)'
+    ```
+
+  - If schema generation moves the relevant action-step detail outside that
+    definition, also record a short qualitative note about whether the
+    `submitIntentActions` schema remained readable.
+
 1. Add the agent-facing action input type.
    - Try the recursive `AgentizeAttributes<T>` approach in
      `agentToolInputs.d.ts`.
@@ -136,6 +161,7 @@ agent-only marker and should never be a legitimate non-attribute payload object.
      - The generated `submitIntentActions` schema remains readable and does not
        duplicate full payload contracts by hand.
      - `npm --workspace packages/app-agent run check:agent` passes.
+     - Record line-count and schema-size deltas.
 
 2. Add normalization before submission.
    - Normalize `input.actions` in `agentTools.submitIntentActions(...)`.
@@ -145,6 +171,7 @@ agent-only marker and should never be a legitimate non-attribute payload object.
        are converted to canonical `VALUE_AT_LOCUS` attributes before runtime
        submission.
      - Existing canonical action payload tests still pass unchanged.
+     - Record line-count and schema-size deltas.
 
 3. Keep canonical executor behavior.
    - Do not change reducers or action creators.
@@ -152,6 +179,7 @@ agent-only marker and should never be a legitimate non-attribute payload object.
    - Measure success:
      - No files under `packages/app/src/sampleView/state/` change.
      - `intentProgramExecutor` tests still validate canonical payloads.
+     - Record line-count and schema-size deltas.
 
 4. Add focused tests.
    - `submitIntentActions` accepts a `SELECTION_AGGREGATION` attribute in
@@ -164,6 +192,7 @@ agent-only marker and should never be a legitimate non-attribute payload object.
      - `npx vitest run packages/app-agent/src/agent/agentTools.test.js`
        includes the adapter cases and passes.
      - Any new normalizer test file is run directly and passes.
+     - Record line-count and schema-size deltas.
 
 5. Update prompt/tool docs.
    - Say intent actions can use `SELECTION_AGGREGATION` candidates directly once
@@ -175,6 +204,7 @@ agent-only marker and should never be a legitimate non-attribute payload object.
        shows it is no longer described as mandatory for intent actions.
      - Tool docs and generated schema describe direct action use without
        claiming Redux reducers accept compact candidates.
+     - Record line-count and schema-size deltas.
 
 6. Reconsider `buildSelectionAggregationAttribute`.
    - Keep it initially for diagnostics and backwards compatibility.
@@ -183,6 +213,7 @@ agent-only marker and should never be a legitimate non-attribute payload object.
    - Measure success:
      - Either a follow-up issue/plan note records why the tool remains, or a
        separate cleanup removes it with generated schema/tests updated.
+     - Record line-count and schema-size deltas.
 
 ## Risks
 

--- a/packages/app-agent/scripts/generateAgentToolSchema.mjs
+++ b/packages/app-agent/scripts/generateAgentToolSchema.mjs
@@ -25,9 +25,10 @@ function normalizeSchemaText(text) {
 
 /**
  * The intent executor accepts canonical app action payloads, but the agent tool
- * contract also allows compact selection-aggregation candidates in action
- * payload attributes. Keep the TypeScript source tied to the app payload types
- * and relax only the generated agent-facing tool schema.
+ * contract accepts only agent-facing attribute candidates in action payloads:
+ * sample metadata attributes and compact selection-aggregation candidates.
+ * Keep the TypeScript source tied to the app payload types and relax only the
+ * generated agent-facing tool schema.
  *
  * @param {Record<string, any>} schema
  * @returns {Record<string, any>}
@@ -41,13 +42,13 @@ function relaxAgentAttributeIdentifiers(schema) {
         return schema;
     }
 
-    definitions.CanonicalAttributeIdentifier = definitions.AttributeIdentifier;
     definitions.AttributeIdentifier = {
         anyOf: [
-            { $ref: "#/definitions/CanonicalAttributeIdentifier" },
+            { $ref: "#/definitions/SampleAttributeIdentifier" },
             { $ref: "#/definitions/SelectionAggregationCandidate" },
         ],
     };
+    delete definitions.AttributeIdentifierType;
 
     return schema;
 }

--- a/packages/app-agent/scripts/generateAgentToolSchema.mjs
+++ b/packages/app-agent/scripts/generateAgentToolSchema.mjs
@@ -24,6 +24,35 @@ function normalizeSchemaText(text) {
 }
 
 /**
+ * The intent executor accepts canonical app action payloads, but the agent tool
+ * contract also allows compact selection-aggregation candidates in action
+ * payload attributes. Keep the TypeScript source tied to the app payload types
+ * and relax only the generated agent-facing tool schema.
+ *
+ * @param {Record<string, any>} schema
+ * @returns {Record<string, any>}
+ */
+function relaxAgentAttributeIdentifiers(schema) {
+    const definitions = schema.definitions;
+    if (
+        !definitions?.AttributeIdentifier ||
+        !definitions?.SelectionAggregationCandidate
+    ) {
+        return schema;
+    }
+
+    definitions.CanonicalAttributeIdentifier = definitions.AttributeIdentifier;
+    definitions.AttributeIdentifier = {
+        anyOf: [
+            { $ref: "#/definitions/CanonicalAttributeIdentifier" },
+            { $ref: "#/definitions/SelectionAggregationCandidate" },
+        ],
+    };
+
+    return schema;
+}
+
+/**
  * @returns {Promise<string>}
  */
 export async function generateToolSchemaText() {
@@ -45,8 +74,10 @@ export async function generateToolSchemaText() {
         }
     );
 
+    const schema = relaxAgentAttributeIdentifiers(JSON.parse(stdout));
+
     return formatGeneratedSource(
-        normalizeSchemaText(stdout),
+        normalizeSchemaText(JSON.stringify(schema, null, 2)),
         fileURLToPath(schemaPath)
     );
 }

--- a/packages/app-agent/server/app/prompts/genomespy_system_prompt.md
+++ b/packages/app-agent/server/app/prompts/genomespy_system_prompt.md
@@ -139,12 +139,12 @@ candidates can derive one value per sample from data in the selected interval.
 Because a selection covers one interval at a time, workflows over multiple
 intervals must handle them sequentially with context refreshes between them.
 
-Example attribute candidate:
+An example of a schematic attribute candidate:
 
 ```json
 {
   "type": "SELECTION_AGGREGATION",
-  "candidateId": "brush@CNV:purifiedLogR",
+  "candidateId": "param_name@view_selector:field_name",
   "aggregation": "min"
 }
 ```

--- a/packages/app-agent/server/app/prompts/genomespy_system_prompt.md
+++ b/packages/app-agent/server/app/prompts/genomespy_system_prompt.md
@@ -217,7 +217,9 @@ when later steps depend on refreshed context from an earlier state change.
 
 Use selections, brushes, and parameter changes proactively when they are needed
 to complete the request and the required state can be inferred from the user's
-request.
+request. If the user asks for selection-derived metadata or analysis for a
+named locus, gene, or interval and no matching interval selection is active,
+create the needed interval selection yourself before continuing.
 Only the provided tools are callable. Intent actions are not callable tools;
 use intent action types only inside `submitIntentActions`.
 
@@ -417,6 +419,8 @@ For interval-derived metadata or aggregation:
 1. Ensure that there is a selection matching the interval. If none exists or it
    is empty, create one with the `paramProvenance/paramChange` action type.
    If a selection is declared but not active, use `paramProvenance/paramChange`.
+   Do not stop to tell the user that a selection is missing when the requested
+   interval can be found or inferred from searchable data.
 2. Inspect `parameterDeclarations` and `selectionAggregation.fields` in the
    current context.
 3. For plotting or `getAttributeSummary`, use the
@@ -476,6 +480,9 @@ other searchable records.
   matches.
 - Use the returned datums to answer analysis questions without changing the
   visualization.
+- If a returned datum provides the interval needed for a requested selection-
+  derived workflow, use that interval to submit a selection action instead of
+  stopping because no active selection exists.
 
 If a search returns no results or too few results for the user's request, retry
 once with a broader field or mode before concluding that no matching record is
@@ -537,8 +544,9 @@ answer questions and change the visualization.
 - The user asks: "I'd like to have mean MYC copy number as a metadata column."
   1. Search for MYC in searchable views
   2. Select the gene region using a selection param
-  3. Build an aggregated attribute for (weighted) mean copy number over the selection
-  4. Derive a new metadata column with the aggregated attribute
+  3. Use the matching `SELECTION_AGGREGATION` candidate with `weightedMean`
+     directly in `deriveMetadata`
+  4. Wait for refreshed context and verify that the metadata column exists
 - The user asks: "Which of several selected regions has the highest variability
   across samples?"
   1. Handle each region one at a time because the selection is mutable.

--- a/packages/app-agent/server/app/prompts/genomespy_system_prompt.md
+++ b/packages/app-agent/server/app/prompts/genomespy_system_prompt.md
@@ -165,8 +165,8 @@ authoritative inventory. In particular, check:
   grouping, and derived columns. Use metadata attributes from `attributes` as
   metadata-backed `SAMPLE_ATTRIBUTE` identifiers. Use selected-region
   attributes from `selectionAggregation.fields` as `SELECTION_AGGREGATION`
-  candidates; plotting and `getAttributeSummary` accept them directly, while
-  intent actions require `buildSelectionAggregationAttribute(...)` first.
+  candidates; plotting, `getAttributeSummary`, and intent action payloads
+  accept them directly.
 - `viewRoot.parameterDeclarations` for selections, brushes, and parameters.
 - provenance history for the current analysis state and possible rollback
   points.
@@ -295,8 +295,9 @@ over segmented data can indicate breakpoints: one segment means no breakpoint,
 two segments means one breakpoint, and so on.
 
 - `buildSelectionAggregationAttribute(candidateId, aggregation)`: resolve a
-  candidate into a sample-specific `AttributeIdentifier` for sample actions.
-  The tool does not compute values immediately.
+  candidate into a sample-specific `AttributeIdentifier` for diagnostics or
+  explicit inspection. Intent actions can use `SELECTION_AGGREGATION`
+  candidates directly. The tool does not compute values immediately.
 
 ### Attribute summary tool
 
@@ -432,15 +433,14 @@ For interval-derived metadata or aggregation:
    current context.
 3. For plotting or `getAttributeSummary`, use the
    `SELECTION_AGGREGATION` candidate id and aggregation directly.
-4. For intent actions, call `buildSelectionAggregationAttribute(candidateId,
-   aggregation)`.
-5. Use the returned `attribute` in a later `submitIntentActions` action such as
-   derivation, sorting, or filtering.
+4. For intent actions, use the same `SELECTION_AGGREGATION` candidate directly
+   in `payload.attribute` for derivation, sorting, filtering, or grouping.
 
 If computed values are needed but absent from context, call
 `getAttributeSummary` for the relevant attribute or `SELECTION_AGGREGATION`
 candidate. Do not stop just because only candidates are visible in context.
-`buildSelectionAggregationAttribute` only builds the identifier.
+`buildSelectionAggregationAttribute` only builds the identifier and is not
+required before intent actions.
 
 Do not materialize a metadata column first unless the user asks for a reusable
 column or a later workflow requires persistent metadata.

--- a/packages/app-agent/server/app/prompts/genomespy_system_prompt.md
+++ b/packages/app-agent/server/app/prompts/genomespy_system_prompt.md
@@ -142,7 +142,14 @@ intervals must handle them sequentially with context refreshes between them.
 Do not construct `candidateId` values. Copy the exact candidate object or exact
 `candidateId` from `selectionAggregation.fields`. The `aggregation` property
 then chooses how each sample is represented within the selected interval; for
-example, `"min"` means each sample is represented by its minimum selected value.
+example, `"min"` means each sample is represented by its minimum value within
+the interval.
+
+Samples form a multi-level hierarchy of arbitrary groups. If the user asks for
+group-level comparisons or summaries, first group the samples with intent
+actions, then query statistics or create plots. If the current grouping doesn't
+satisfy the request, change the grouping. If current selection isn't correct,
+change the selection.
 
 ## Tools
 

--- a/packages/app-agent/server/app/prompts/genomespy_system_prompt.md
+++ b/packages/app-agent/server/app/prompts/genomespy_system_prompt.md
@@ -139,18 +139,10 @@ candidates can derive one value per sample from data in the selected interval.
 Because a selection covers one interval at a time, workflows over multiple
 intervals must handle them sequentially with context refreshes between them.
 
-An example of a schematic attribute candidate:
-
-```json
-{
-  "type": "SELECTION_AGGREGATION",
-  "candidateId": "param_name@view_selector:field_name",
-  "aggregation": "min"
-}
-```
-
-Here, `"min"` means each sample is represented by its minimum value in the
-selected interval.
+Do not construct `candidateId` values. Copy the exact candidate object or exact
+`candidateId` from `selectionAggregation.fields`. The `aggregation` property
+then chooses how each sample is represented within the selected interval; for
+example, `"min"` means each sample is represented by its minimum selected value.
 
 ## Tools
 
@@ -281,7 +273,8 @@ Example:
 Selection aggregation derives one value per sample from data items that overlap
 the current genomic interval selection. Use it for sample-level properties of a
 selected region. Available fields depend on the visualization; use only
-candidates in `selectionAggregation.fields`.
+candidates copied from `selectionAggregation.fields`. Never invent or assemble
+`candidateId` values from parameter, view, or field names.
 
 Every `SELECTION_AGGREGATION` first aggregates data within the selected
 interval for each sample; any later summary or plot uses those per-sample
@@ -427,7 +420,8 @@ For interval-derived metadata or aggregation:
 2. Inspect `parameterDeclarations` and `selectionAggregation.fields` in the
    current context.
 3. For plotting or `getAttributeSummary`, use the
-   `SELECTION_AGGREGATION` candidate id and aggregation directly.
+   `SELECTION_AGGREGATION` candidate id and aggregation directly from
+   `selectionAggregation.fields`.
 4. For intent actions, use the same `SELECTION_AGGREGATION` candidate directly
    in `payload.attribute` for derivation, sorting, filtering, or grouping.
 

--- a/packages/app-agent/server/app/prompts/genomespy_system_prompt.md
+++ b/packages/app-agent/server/app/prompts/genomespy_system_prompt.md
@@ -294,11 +294,6 @@ each segment's length clipped to the selected interval as the weight. `count`
 over segmented data can indicate breakpoints: one segment means no breakpoint,
 two segments means one breakpoint, and so on.
 
-- `buildSelectionAggregationAttribute(candidateId, aggregation)`: resolve a
-  candidate into a sample-specific `AttributeIdentifier` for diagnostics or
-  explicit inspection. Intent actions can use `SELECTION_AGGREGATION`
-  candidates directly. The tool does not compute values immediately.
-
 ### Attribute summary tool
 
 - `getAttributeSummary(attribute, scope)`: return a compact summary of
@@ -439,8 +434,6 @@ For interval-derived metadata or aggregation:
 If computed values are needed but absent from context, call
 `getAttributeSummary` for the relevant attribute or `SELECTION_AGGREGATION`
 candidate. Do not stop just because only candidates are visible in context.
-`buildSelectionAggregationAttribute` only builds the identifier and is not
-required before intent actions.
 
 Do not materialize a metadata column first unless the user asks for a reusable
 column or a later workflow requires persistent metadata.

--- a/packages/app-agent/src/agent/actionCatalog.test.js
+++ b/packages/app-agent/src/agent/actionCatalog.test.js
@@ -144,7 +144,7 @@ describe("actionCatalog", () => {
         ]);
     });
 
-    it("keeps the full selection aggregation example in one action only", () => {
+    it("does not expose internal value-at-locus examples in action docs", () => {
         const actionsWithSelectionAggregationExamples = generatedActionCatalog
             .filter((entry) =>
                 entry.examples.some(
@@ -153,9 +153,7 @@ describe("actionCatalog", () => {
             )
             .map((entry) => entry.actionType);
 
-        expect(actionsWithSelectionAggregationExamples).toEqual([
-            "sampleView/deriveMetadata",
-        ]);
+        expect(actionsWithSelectionAggregationExamples).toEqual([]);
     });
 
     it("summarizes batches using action titles", () => {

--- a/packages/app-agent/src/agent/actionCatalog.test.js
+++ b/packages/app-agent/src/agent/actionCatalog.test.js
@@ -115,7 +115,7 @@ describe("actionCatalog", () => {
             "Use this for numeric filters such as values greater than, less than, or equal to a chosen threshold."
         );
         expect(entry.usage).toContain(
-            "selection-derived aggregation returned by `buildSelectionAggregationAttribute`"
+            "selection-derived aggregation candidate from `selectionAggregation.fields`"
         );
         expect(entry.payloadFields).toEqual([
             expect.objectContaining({

--- a/packages/app-agent/src/agent/actionShapeValidator.js
+++ b/packages/app-agent/src/agent/actionShapeValidator.js
@@ -101,6 +101,8 @@ const selectionAggregationCandidateSchema = {
                 "Aggregation op applied within the current interval selection for each sample.",
         },
         candidateId: {
+            description:
+                "Exact candidate id copied from selectionAggregation.fields. Do not construct this from parameter, view, or field names.",
             type: "string",
         },
         type: {

--- a/packages/app-agent/src/agent/actionShapeValidator.js
+++ b/packages/app-agent/src/agent/actionShapeValidator.js
@@ -24,6 +24,29 @@ function createSchemaWrapper(schema) {
     };
 }
 
+/**
+ * @param {Record<string, any>} schema
+ * @returns {Record<string, any>}
+ */
+function createAgentSchemaWrapper(schema) {
+    return {
+        $schema: generatedActionSchema.$schema,
+        definitions: {
+            ...generatedActionSchema.definitions,
+            AttributeIdentifier: {
+                anyOf: [
+                    { $ref: "#/definitions/CanonicalAttributeIdentifier" },
+                    { $ref: "#/definitions/SelectionAggregationCandidate" },
+                ],
+            },
+            CanonicalAttributeIdentifier:
+                generatedActionSchema.definitions.AttributeIdentifier,
+            SelectionAggregationCandidate: selectionAggregationCandidateSchema,
+        },
+        ...schema,
+    };
+}
+
 const intentBatchContainerSchema = createSchemaWrapper({
     ...generatedActionSchema.definitions.AgentIntentBatch,
     properties: {
@@ -65,6 +88,38 @@ const payloadValidatorsByActionType = new Map(
         const actionType = entry.properties.actionType.const;
         const payloadSchema = entry.properties.payload;
         return [actionType, ajv.compile(createSchemaWrapper(payloadSchema))];
+    })
+);
+
+/** @type {Record<string, any>} */
+const selectionAggregationCandidateSchema = {
+    additionalProperties: false,
+    properties: {
+        aggregation: {
+            $ref: "#/definitions/AggregationOp",
+            description:
+                "Aggregation op applied within the current interval selection for each sample.",
+        },
+        candidateId: {
+            type: "string",
+        },
+        type: {
+            const: "SELECTION_AGGREGATION",
+            type: "string",
+        },
+    },
+    required: ["type", "candidateId", "aggregation"],
+    type: "object",
+};
+
+/** @type {Map<string, import("ajv").ValidateFunction>} */
+const agentPayloadValidatorsByActionType = new Map(
+    stepVariants.map((entry) => {
+        const actionType = entry.properties.actionType.const;
+        return [
+            actionType,
+            ajv.compile(createAgentSchemaWrapper(entry.properties.payload)),
+        ];
     })
 );
 
@@ -165,22 +220,77 @@ export function validateIntentBatchShape(batch) {
  * @returns {import("./types.js").ShapeValidationResult}
  */
 export function validateActionPayloadShape(actionType, payload, prefix = "$") {
+    return validateActionPayloadShapeWithSchemas(
+        actionType,
+        payload,
+        prefix,
+        payloadValidatorsByActionType,
+        /** @type {Record<string, any>} */ (
+            generatedActionSchema.definitions ?? {}
+        )
+    );
+}
+
+/**
+ * Validates the agent-facing action payload shape. This accepts canonical
+ * AttributeIdentifiers and compact SELECTION_AGGREGATION candidates, which are
+ * normalized before the reducer-facing intent batch is submitted.
+ *
+ * @param {import("./types.js").AgentActionType} actionType
+ * @param {unknown} payload
+ * @param {string} [prefix]
+ * @returns {import("./types.js").ShapeValidationResult}
+ */
+export function validateAgentActionPayloadShape(
+    actionType,
+    payload,
+    prefix = "$"
+) {
+    return validateActionPayloadShapeWithSchemas(
+        actionType,
+        payload,
+        prefix,
+        agentPayloadValidatorsByActionType,
+        {
+            ...generatedActionSchema.definitions,
+            AttributeIdentifier: {
+                anyOf: [
+                    { $ref: "#/definitions/CanonicalAttributeIdentifier" },
+                    { $ref: "#/definitions/SelectionAggregationCandidate" },
+                ],
+            },
+            CanonicalAttributeIdentifier:
+                generatedActionSchema.definitions.AttributeIdentifier,
+            SelectionAggregationCandidate: selectionAggregationCandidateSchema,
+        }
+    );
+}
+
+/**
+ * @param {import("./types.js").AgentActionType} actionType
+ * @param {unknown} payload
+ * @param {string} prefix
+ * @param {Map<string, import("ajv").ValidateFunction>} validatorsByActionType
+ * @param {Record<string, any>} definitions
+ * @returns {import("./types.js").ShapeValidationResult}
+ */
+function validateActionPayloadShapeWithSchemas(
+    actionType,
+    payload,
+    prefix,
+    validatorsByActionType,
+    definitions
+) {
     if (actionType === "paramProvenance/paramChange") {
         return validateParamProvenanceEntryShape(payload, prefix);
     }
 
     const payloadSchema = getActionPayloadSchema(actionType);
     if (payloadSchema) {
-        repairJsonEncodedObjects(
-            payload,
-            payloadSchema,
-            /** @type {Record<string, any>} */ (
-                generatedActionSchema.definitions ?? {}
-            )
-        );
+        repairJsonEncodedObjects(payload, payloadSchema, definitions);
     }
 
-    const validator = payloadValidatorsByActionType.get(actionType);
+    const validator = validatorsByActionType.get(actionType);
     if (!validator) {
         return {
             ok: false,

--- a/packages/app-agent/src/agent/actionShapeValidator.js
+++ b/packages/app-agent/src/agent/actionShapeValidator.js
@@ -35,12 +35,11 @@ function createAgentSchemaWrapper(schema) {
             ...generatedActionSchema.definitions,
             AttributeIdentifier: {
                 anyOf: [
-                    { $ref: "#/definitions/CanonicalAttributeIdentifier" },
+                    { $ref: "#/definitions/SampleAttributeIdentifier" },
                     { $ref: "#/definitions/SelectionAggregationCandidate" },
                 ],
             },
-            CanonicalAttributeIdentifier:
-                generatedActionSchema.definitions.AttributeIdentifier,
+            SampleAttributeIdentifier: sampleAttributeIdentifierSchema,
             SelectionAggregationCandidate: selectionAggregationCandidateSchema,
         },
         ...schema,
@@ -111,6 +110,22 @@ const selectionAggregationCandidateSchema = {
         },
     },
     required: ["type", "candidateId", "aggregation"],
+    type: "object",
+};
+
+/** @type {Record<string, any>} */
+const sampleAttributeIdentifierSchema = {
+    additionalProperties: false,
+    properties: {
+        specifier: {
+            type: "string",
+        },
+        type: {
+            const: "SAMPLE_ATTRIBUTE",
+            type: "string",
+        },
+    },
+    required: ["type", "specifier"],
     type: "object",
 };
 
@@ -248,6 +263,21 @@ export function validateAgentActionPayloadShape(
     payload,
     prefix = "$"
 ) {
+    const internalAttributePaths = findInternalValueAtLocusAttributes(
+        payload,
+        prefix
+    );
+    if (internalAttributePaths.length > 0) {
+        return {
+            ok: false,
+            errors: internalAttributePaths.map(
+                (path) =>
+                    path +
+                    " uses internal VALUE_AT_LOCUS syntax. Use a SAMPLE_ATTRIBUTE from context or a SELECTION_AGGREGATION candidate copied from selectionAggregation.fields."
+            ),
+        };
+    }
+
     return validateActionPayloadShapeWithSchemas(
         actionType,
         payload,
@@ -257,12 +287,11 @@ export function validateAgentActionPayloadShape(
             ...generatedActionSchema.definitions,
             AttributeIdentifier: {
                 anyOf: [
-                    { $ref: "#/definitions/CanonicalAttributeIdentifier" },
+                    { $ref: "#/definitions/SampleAttributeIdentifier" },
                     { $ref: "#/definitions/SelectionAggregationCandidate" },
                 ],
             },
-            CanonicalAttributeIdentifier:
-                generatedActionSchema.definitions.AttributeIdentifier,
+            SampleAttributeIdentifier: sampleAttributeIdentifierSchema,
             SelectionAggregationCandidate: selectionAggregationCandidateSchema,
         }
     );
@@ -311,6 +340,32 @@ function validateActionPayloadShapeWithSchemas(
         ok: false,
         errors: formatAjvErrors(prefix, validator.errors),
     };
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} path
+ * @returns {string[]}
+ */
+function findInternalValueAtLocusAttributes(value, path) {
+    if (Array.isArray(value)) {
+        return value.flatMap((item, index) =>
+            findInternalValueAtLocusAttributes(item, path + "[" + index + "]")
+        );
+    }
+
+    if (!isObject(value)) {
+        return [];
+    }
+
+    const errors =
+        value.type === "VALUE_AT_LOCUS" ? [path] : /** @type {string[]} */ ([]);
+
+    return errors.concat(
+        Object.entries(value).flatMap(([key, child]) =>
+            findInternalValueAtLocusAttributes(child, path + "." + key)
+        )
+    );
 }
 
 /**

--- a/packages/app-agent/src/agent/actionShapeValidator.test.js
+++ b/packages/app-agent/src/agent/actionShapeValidator.test.js
@@ -105,6 +105,27 @@ describe("actionShapeValidator", () => {
         expect(agentFacing.ok).toBe(true);
     });
 
+    it("rejects hand-written value-at-locus attributes in agent-facing action payloads", () => {
+        const result = validateAgentActionPayloadShape("sampleView/sortBy", {
+            attribute: {
+                type: "VALUE_AT_LOCUS",
+                selector: {
+                    scope: [],
+                    param: "brush",
+                },
+                aggregation: "count",
+            },
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.errors.join("\n")).toContain(
+            "uses internal VALUE_AT_LOCUS syntax"
+        );
+        expect(result.errors.join("\n")).toContain(
+            "SELECTION_AGGREGATION candidate copied from selectionAggregation.fields"
+        );
+    });
+
     it("rejects malformed intent batches", () => {
         const result = validateIntentBatchShape({
             schemaVersion: 1,

--- a/packages/app-agent/src/agent/actionShapeValidator.test.js
+++ b/packages/app-agent/src/agent/actionShapeValidator.test.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { describe, expect, it } from "vitest";
 import {
+    validateAgentActionPayloadShape,
     validateActionPayloadShape,
     validateIntentBatchShape,
 } from "./actionShapeValidator.js";
@@ -80,6 +81,28 @@ describe("actionShapeValidator", () => {
             type: "SAMPLE_ATTRIBUTE",
             specifier: "mutations",
         });
+    });
+
+    it("accepts selection aggregation candidates only in agent-facing action payloads", () => {
+        const payload = {
+            attribute: {
+                type: "SELECTION_AGGREGATION",
+                candidateId: "brush@track:beta",
+                aggregation: "max",
+            },
+        };
+
+        const canonical = validateActionPayloadShape(
+            "sampleView/sortBy",
+            payload
+        );
+        const agentFacing = validateAgentActionPayloadShape(
+            "sampleView/sortBy",
+            payload
+        );
+
+        expect(canonical.ok).toBe(false);
+        expect(agentFacing.ok).toBe(true);
     });
 
     it("rejects malformed intent batches", () => {

--- a/packages/app-agent/src/agent/agentIntentActionAttributes.js
+++ b/packages/app-agent/src/agent/agentIntentActionAttributes.js
@@ -1,0 +1,56 @@
+// @ts-check
+import { resolveAgentAttributeCandidate } from "./attributeCandidate.js";
+
+/**
+ * Resolves agent-facing selection aggregation candidates inside intent action
+ * payloads into the canonical AttributeIdentifier shape expected by reducers.
+ *
+ * @param {{
+ *     getAgentVolatileContext(): import("./types.d.ts").AgentVolatileContext;
+ *     agentApi?: Pick<import("@genome-spy/app/agentApi").AgentApi, "materializeAttributeIdentifier">;
+ * }} runtime
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+export function normalizeAgentIntentActionAttributes(runtime, value) {
+    if (Array.isArray(value)) {
+        return value.map((item) =>
+            normalizeAgentIntentActionAttributes(runtime, item)
+        );
+    }
+
+    if (!isObject(value)) {
+        return value;
+    }
+
+    if (isSelectionAggregationCandidate(value)) {
+        return resolveAgentAttributeCandidate(runtime, value);
+    }
+
+    return Object.fromEntries(
+        Object.entries(value).map(([key, child]) => [
+            key,
+            normalizeAgentIntentActionAttributes(runtime, child),
+        ])
+    );
+}
+
+/**
+ * @param {Record<string, any>} value
+ * @returns {value is import("./agentToolInputs.d.ts").SelectionAggregationCandidate}
+ */
+function isSelectionAggregationCandidate(value) {
+    return (
+        value.type === "SELECTION_AGGREGATION" &&
+        typeof value.candidateId === "string" &&
+        typeof value.aggregation === "string"
+    );
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, any>}
+ */
+function isObject(value) {
+    return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/app-agent/src/agent/agentSessionController.js
+++ b/packages/app-agent/src/agent/agentSessionController.js
@@ -132,7 +132,6 @@ import { agentTools } from "./agentTools.js";
 
 const PREFLIGHT_MESSAGE = 'Preflight check: answer with just "I\'m here".';
 const INFORMATION_TOOL_NAMES = new Set([
-    "buildSelectionAggregationAttribute",
     "getIntentActionDocs",
     "resolveMetadataAttributeValues",
     "searchViewDatums",

--- a/packages/app-agent/src/agent/agentSessionController.test.js
+++ b/packages/app-agent/src/agent/agentSessionController.test.js
@@ -943,36 +943,8 @@ describe("createAgentSessionController", () => {
         ]);
     });
 
-    it("resolves a selection aggregation candidate into the canonical attribute", async () => {
+    it("rejects removed selection aggregation resolution tool calls", async () => {
         const runtime = createRuntimeMock();
-        runtime.getAgentVolatileContext.mockReturnValue({
-            selectionAggregation: {
-                fields: [
-                    {
-                        candidateId: "brush@track:beta",
-                        view: "track",
-                        viewSelector: {
-                            scope: [],
-                            view: "track",
-                        },
-                        field: "beta",
-                        dataType: "quantitative",
-                        selectionSelector: {
-                            scope: [],
-                            param: "brush",
-                        },
-                        supportedAggregations: [
-                            "count",
-                            "min",
-                            "max",
-                            "weightedMean",
-                            "variance",
-                        ],
-                    },
-                ],
-            },
-        });
-
         const controller = createAgentSessionController(runtime);
         const results = await controller.executeToolCalls([
             {
@@ -985,40 +957,13 @@ describe("createAgentSessionController", () => {
             },
         ]);
 
-        expect(runtime.getAgentVolatileContext).toHaveBeenCalledTimes(1);
+        expect(runtime.getAgentVolatileContext).not.toHaveBeenCalled();
         expect(results).toEqual([
             expect.objectContaining({
-                rejected: false,
-                text: "Built an AttributeIdentifier for max(beta) from brush@track:beta. No aggregated value was computed. Use a SELECTION_AGGREGATION candidate in plotting tools or content.attribute as payload.attribute in `submitIntentActions`. If you need a different locus or interval, update the selection first.",
-                content: expect.objectContaining({
-                    kind: "selection_aggregation_resolution",
-                    candidateId: "brush@track:beta",
-                    aggregation: "max",
-                    field: "beta",
-                    title: "max(beta)",
-                    description:
-                        "Aggregated beta values over the brush selection",
-                    attribute: expect.objectContaining({
-                        type: "VALUE_AT_LOCUS",
-                        specifier: expect.objectContaining({
-                            view: {
-                                scope: [],
-                                view: "track",
-                            },
-                            field: "beta",
-                            interval: {
-                                type: "selection",
-                                selector: {
-                                    scope: [],
-                                    param: "brush",
-                                },
-                            },
-                            aggregation: {
-                                op: "max",
-                            },
-                        }),
-                    }),
-                }),
+                rejected: true,
+                text: expect.stringContaining(
+                    "Unsupported agent tool buildSelectionAggregationAttribute."
+                ),
             }),
         ]);
     });

--- a/packages/app-agent/src/agent/agentSessionController.test.js
+++ b/packages/app-agent/src/agent/agentSessionController.test.js
@@ -712,6 +712,39 @@ describe("createAgentSessionController", () => {
         ).not.toHaveBeenCalled();
     });
 
+    it("returns invalid selection aggregation candidates as rejected tool results", async () => {
+        const runtime = createRuntimeMock();
+        const controller = createAgentSessionController(runtime);
+
+        const results = await controller.executeToolCalls([
+            {
+                callId: "call-plot",
+                name: "showAttributeDistributionPlot",
+                arguments: {
+                    kind: "boxplot",
+                    attribute: {
+                        type: "SELECTION_AGGREGATION",
+                        candidateId: "invented-candidate",
+                        aggregation: "max",
+                    },
+                },
+            },
+        ]);
+
+        expect(results).toEqual([
+            expect.objectContaining({
+                toolCallId: "call-plot",
+                rejected: true,
+                text: expect.stringContaining(
+                    "Use an exact candidateId from selectionAggregation.fields."
+                ),
+            }),
+        ]);
+        expect(
+            runtime.agentApi.buildSampleAttributePlot
+        ).not.toHaveBeenCalled();
+    });
+
     it("summarizes intent batch tool results for sample-view actions", async () => {
         const runtime = createRuntimeMock();
         runtime.submitIntentActions.mockResolvedValue({

--- a/packages/app-agent/src/agent/agentToolInputs.d.ts
+++ b/packages/app-agent/src/agent/agentToolInputs.d.ts
@@ -130,15 +130,14 @@ export type JumpToInitialProvenanceStateToolInput = Record<string, never>;
 
 /**
  * Build an `AttributeIdentifier` for a selection-derived aggregation so it can
- * be used in a later intent action or inspected for diagnostics. Selection
+ * be inspected for diagnostics or explicit payload construction. Selection
  * aggregation derives one value per sample from data items that overlap the
  * current genomic interval selection. Plotting and summary tools can usually
- * use `SELECTION_AGGREGATION` candidates directly. Before using this tool, you
- * must make an interval selection using a parameter or ensure that one already
- * exists. This tool does not compute or return an aggregated value. Use the
- * returned `content.attribute` as the plotted attribute or as
- * `payload.attribute` in `submitIntentActions`. If the requested locus or
- * interval is not the current selection, update the selection first.
+ * use `SELECTION_AGGREGATION` candidates directly, and intent action payloads
+ * accept them directly. Before using this tool, you must make an interval
+ * selection using a parameter or ensure that one already exists. This tool does
+ * not compute or return an aggregated value. If the requested locus or interval
+ * is not the current selection, update the selection first.
  *
  * @example
  * {

--- a/packages/app-agent/src/agent/agentToolInputs.d.ts
+++ b/packages/app-agent/src/agent/agentToolInputs.d.ts
@@ -16,6 +16,11 @@ type SampleAttributeIdentifier = {
 
 type SelectionAggregationCandidate = {
     type: "SELECTION_AGGREGATION";
+
+    /**
+     * Exact candidate id copied from `selectionAggregation.fields`. Do not
+     * construct this from parameter, view, or field names.
+     */
     candidateId: string;
 
     /**
@@ -345,16 +350,6 @@ export interface ShowCategoryCountsPlotToolInput {
  *   "attribute": {
  *     "type": "SAMPLE_ATTRIBUTE",
  *     "specifier": "age"
- *   }
- * }
- *
- * @example
- * {
- *   "kind": "boxplot",
- *   "attribute": {
- *     "type": "SELECTION_AGGREGATION",
- *     "candidateId": "brush@track:beta",
- *     "aggregation": "max"
  *   }
  * }
  */

--- a/packages/app-agent/src/agent/agentToolInputs.d.ts
+++ b/packages/app-agent/src/agent/agentToolInputs.d.ts
@@ -129,38 +129,6 @@ export interface JumpToProvenanceStateToolInput {
 export type JumpToInitialProvenanceStateToolInput = Record<string, never>;
 
 /**
- * Build an `AttributeIdentifier` for a selection-derived aggregation so it can
- * be inspected for diagnostics or explicit payload construction. Selection
- * aggregation derives one value per sample from data items that overlap the
- * current genomic interval selection. Plotting and summary tools can usually
- * use `SELECTION_AGGREGATION` candidates directly, and intent action payloads
- * accept them directly. Before using this tool, you must make an interval
- * selection using a parameter or ensure that one already exists. This tool does
- * not compute or return an aggregated value. If the requested locus or interval
- * is not the current selection, update the selection first.
- *
- * @example
- * {
- *   "candidateId": "brush@foo:bar",
- *   "aggregation": "max"
- * }
- */
-export interface BuildSelectionAggregationAttributeToolInput {
-    /**
-     * Stable identifier for the selected candidate row. The identifiers are
-     * available in `selectionAggregation.fields` in the volatile context.
-     * They become available after a selection is made with a successful
-     * `paramChange` action.
-     */
-    candidateId: string;
-
-    /**
-     * Aggregation op to apply to the candidate field.
-     */
-    aggregation: AggregationOp;
-}
-
-/**
  * Return a compact summary of one attribute (metadata or selection-derived)
  * across visible samples or within each current visible group.
  * When summarizing a `SELECTION_AGGREGATION`, the candidate aggregation is
@@ -444,7 +412,6 @@ export interface AgentToolInputs {
     setViewVisibility: SetViewVisibilityToolInput;
     jumpToProvenanceState: JumpToProvenanceStateToolInput;
     jumpToInitialProvenanceState: JumpToInitialProvenanceStateToolInput;
-    buildSelectionAggregationAttribute: BuildSelectionAggregationAttributeToolInput;
     getAttributeSummary: GetAttributeSummaryToolInput;
     resolveMetadataAttributeValues: ResolveMetadataAttributeValuesToolInput;
     searchViewDatums: SearchViewDatumsToolInput;

--- a/packages/app-agent/src/agent/agentTools.js
+++ b/packages/app-agent/src/agent/agentTools.js
@@ -6,6 +6,7 @@ import { searchViewDatumsTool } from "./searchViewDatumsTool.js";
 import { getActionCatalogEntry } from "./actionCatalog.js";
 import generatedActionSchema from "./generated/generatedActionSchema.json" with { type: "json" };
 import { resolveAgentAttributeCandidateRecord } from "./attributeCandidate.js";
+import { normalizeAgentIntentActionAttributes } from "./agentIntentActionAttributes.js";
 
 /*
  * Tool behavior lives here. The input shapes and user-facing descriptions are
@@ -307,10 +308,14 @@ export const agentTools = {
      */
     async submitIntentActions(runtime, input) {
         try {
+            const steps =
+                /** @type {import("./types.d.ts").AgentIntentBatchStep[]} */ (
+                    normalizeAgentIntentActionAttributes(runtime, input.actions)
+                );
             const result = await runtime.submitIntentActions(
                 {
                     schemaVersion: 1,
-                    steps: input.actions,
+                    steps,
                     rationale: input.note,
                 },
                 {

--- a/packages/app-agent/src/agent/agentTools.js
+++ b/packages/app-agent/src/agent/agentTools.js
@@ -1,4 +1,3 @@
-import { buildSelectionAggregationAttribute } from "./selectionAggregationTool.js";
 import { ToolCallRejectionError } from "./agentToolErrors.js";
 import { getAttributeSummaryTool } from "./attributeSummaryTool.js";
 import { resolveMetadataAttributeValuesTool } from "./resolveMetadataAttributeValuesTool.js";
@@ -123,35 +122,6 @@ export const agentTools = {
                 changed
             ),
         };
-    },
-
-    /**
-     * @param {AgentToolRuntime} runtime
-     * @param {import("./agentToolInputs.d.ts").BuildSelectionAggregationAttributeToolInput} input
-     */
-    buildSelectionAggregationAttribute(runtime, input) {
-        try {
-            const resolution = buildSelectionAggregationAttribute(
-                runtime.getAgentVolatileContext(),
-                input.candidateId,
-                input.aggregation
-            );
-
-            return {
-                text:
-                    `Built an AttributeIdentifier for ${resolution.title} from ` +
-                    `${input.candidateId}. No aggregated value was computed. ` +
-                    "Use a SELECTION_AGGREGATION candidate in plotting tools " +
-                    "or content.attribute as payload.attribute in " +
-                    "`submitIntentActions`. If you need a different locus or " +
-                    "interval, update the selection first.",
-                content: resolution,
-            };
-        } catch (error) {
-            throw new ToolCallRejectionError(
-                error instanceof Error ? error.message : String(error)
-            );
-        }
     },
 
     /**

--- a/packages/app-agent/src/agent/agentTools.test.js
+++ b/packages/app-agent/src/agent/agentTools.test.js
@@ -1275,6 +1275,56 @@ describe("agentTools", () => {
         expect(runtime.summarizeExecutionResult).toHaveBeenCalledTimes(1);
     });
 
+    it("normalizes selection aggregation candidates before submitting actions", async () => {
+        const runtime = createRuntimeStub();
+        const tools = agentTools;
+
+        await tools.submitIntentActions(runtime, {
+            actions: [
+                {
+                    actionType: "sampleView/sortBy",
+                    payload: {
+                        attribute: {
+                            type: "SELECTION_AGGREGATION",
+                            candidateId: "brush@track:beta",
+                            aggregation: "max",
+                        },
+                    },
+                },
+            ],
+        });
+
+        expect(runtime.submitIntentActions).toHaveBeenCalledWith(
+            expect.objectContaining({
+                steps: [
+                    {
+                        actionType: "sampleView/sortBy",
+                        payload: {
+                            attribute: {
+                                type: "VALUE_AT_LOCUS",
+                                specifier: {
+                                    view: {
+                                        scope: [],
+                                        view: "track",
+                                    },
+                                    field: "beta",
+                                    interval: [
+                                        { chrom: "chr17", pos: 7565097 },
+                                        { chrom: "chr17", pos: 7590856 },
+                                    ],
+                                    aggregation: { op: "max" },
+                                },
+                            },
+                        },
+                    },
+                ],
+            }),
+            expect.objectContaining({
+                submissionKind: "agent",
+            })
+        );
+    });
+
     it("rethrows intent action failures as rejected tool calls", async () => {
         const runtime = createRuntimeStub();
         runtime.submitIntentActions.mockRejectedValue(

--- a/packages/app-agent/src/agent/agentTools.test.js
+++ b/packages/app-agent/src/agent/agentTools.test.js
@@ -351,7 +351,7 @@ describe("agentTools", () => {
                 actionType: "sampleView/sortBy",
                 description:
                     "Sort samples in descending order by a selected attribute.",
-                usage: "Use this when samples should be ranked by one quantitative or ordinal attribute before further filtering or grouping. The attribute may be metadata or a selection-derived aggregation returned by `buildSelectionAggregationAttribute`.",
+                usage: "Use this when samples should be ranked by one quantitative or ordinal attribute before further filtering or grouping. The attribute may be metadata or a selection-derived aggregation candidate from `selectionAggregation.fields`.",
                 payloadFields: [
                     expect.objectContaining({
                         name: "attribute",
@@ -1282,13 +1282,14 @@ describe("agentTools", () => {
         await tools.submitIntentActions(runtime, {
             actions: [
                 {
-                    actionType: "sampleView/sortBy",
+                    actionType: "sampleView/deriveMetadata",
                     payload: {
                         attribute: {
                             type: "SELECTION_AGGREGATION",
                             candidateId: "brush@track:beta",
                             aggregation: "max",
                         },
+                        name: "max_beta",
                     },
                 },
             ],
@@ -1298,7 +1299,7 @@ describe("agentTools", () => {
             expect.objectContaining({
                 steps: [
                     {
-                        actionType: "sampleView/sortBy",
+                        actionType: "sampleView/deriveMetadata",
                         payload: {
                             attribute: {
                                 type: "VALUE_AT_LOCUS",
@@ -1315,6 +1316,7 @@ describe("agentTools", () => {
                                     aggregation: { op: "max" },
                                 },
                             },
+                            name: "max_beta",
                         },
                     },
                 ],
@@ -1386,5 +1388,33 @@ describe("agentTools", () => {
                 aggregation: "max",
             })
         ).toThrow(ToolCallRejectionError);
+    });
+
+    it("rejects unknown selection aggregation candidates in submitted actions", async () => {
+        const runtime = createRuntimeStub();
+        runtime.getAgentVolatileContext.mockReturnValueOnce({
+            selectionAggregation: {
+                fields: [],
+            },
+        });
+        const tools = agentTools;
+
+        await expect(
+            tools.submitIntentActions(runtime, {
+                actions: [
+                    {
+                        actionType: "sampleView/sortBy",
+                        payload: {
+                            attribute: {
+                                type: "SELECTION_AGGREGATION",
+                                candidateId: "missing-candidate",
+                                aggregation: "max",
+                            },
+                        },
+                    },
+                ],
+            })
+        ).rejects.toThrow(ToolCallRejectionError);
+        expect(runtime.submitIntentActions).not.toHaveBeenCalled();
     });
 });

--- a/packages/app-agent/src/agent/agentTools.test.js
+++ b/packages/app-agent/src/agent/agentTools.test.js
@@ -397,26 +397,6 @@ describe("agentTools", () => {
         });
     });
 
-    it("resolves selection aggregation candidates through the current context", () => {
-        const runtime = createRuntimeStub();
-        const tools = agentTools;
-
-        const result = tools.buildSelectionAggregationAttribute(runtime, {
-            candidateId: "brush@track:beta",
-            aggregation: "max",
-        });
-
-        expect(result.text).toContain("Built an AttributeIdentifier");
-        expect(result.content).toEqual(
-            expect.objectContaining({
-                kind: "selection_aggregation_resolution",
-                candidateId: "brush@track:beta",
-                aggregation: "max",
-            })
-        );
-        expect(runtime.getAgentVolatileContext).toHaveBeenCalledTimes(1);
-    });
-
     it("shows relationship plots through the host API", async () => {
         const runtime = createRuntimeStub();
         const tools = agentTools;
@@ -1369,23 +1349,6 @@ describe("agentTools", () => {
                     view: "missing",
                 },
                 visibility: false,
-            })
-        ).toThrow(ToolCallRejectionError);
-    });
-
-    it("rejects unknown selection aggregation candidates as tool errors", () => {
-        const runtime = createRuntimeStub();
-        runtime.getAgentVolatileContext.mockReturnValueOnce({
-            selectionAggregation: {
-                fields: [],
-            },
-        });
-        const tools = agentTools;
-
-        expect(() =>
-            tools.buildSelectionAggregationAttribute(runtime, {
-                candidateId: "missing-candidate",
-                aggregation: "max",
             })
         ).toThrow(ToolCallRejectionError);
     });

--- a/packages/app-agent/src/agent/agentTools.test.js
+++ b/packages/app-agent/src/agent/agentTools.test.js
@@ -1377,7 +1377,9 @@ describe("agentTools", () => {
                     },
                 ],
             })
-        ).rejects.toThrow(ToolCallRejectionError);
+        ).rejects.toThrow(
+            "Use an exact candidateId from selectionAggregation.fields."
+        );
         expect(runtime.submitIntentActions).not.toHaveBeenCalled();
     });
 });

--- a/packages/app-agent/src/agent/generated/generatedActionCatalog.json
+++ b/packages/app-agent/src/agent/generated/generatedActionCatalog.json
@@ -153,7 +153,7 @@
   {
     "actionType": "sampleView/sortBy",
     "description": "Sort samples in descending order by a selected attribute.",
-    "usage": "Use this when samples should be ranked by one quantitative or ordinal attribute before further filtering or grouping. The attribute may be metadata or a selection-derived aggregation returned by `buildSelectionAggregationAttribute`.",
+    "usage": "Use this when samples should be ranked by one quantitative or ordinal attribute before further filtering or grouping. The attribute may be metadata or a selection-derived aggregation candidate from `selectionAggregation.fields`.",
     "payloadType": "SortBy",
     "payloadFields": [
       {
@@ -245,7 +245,7 @@
   {
     "actionType": "sampleView/filterByQuantitative",
     "description": "Retain samples whose selected quantitative value satisfies a threshold comparison.",
-    "usage": "Use this for numeric filters such as values greater than, less than, or equal to a chosen threshold. The attribute may be metadata or a selection-derived aggregation returned by `buildSelectionAggregationAttribute`.",
+    "usage": "Use this for numeric filters such as values greater than, less than, or equal to a chosen threshold. The attribute may be metadata or a selection-derived aggregation candidate from `selectionAggregation.fields`.",
     "payloadType": "FilterByQuantitative",
     "payloadFields": [
       {
@@ -331,7 +331,7 @@
   {
     "actionType": "sampleView/removeUndefined",
     "description": "Remove samples whose selected attribute value is missing.",
-    "usage": "Use this before later analysis steps when samples with `undefined` or `null` values should be excluded. The attribute may be metadata or a selection-derived aggregation returned by `buildSelectionAggregationAttribute`.",
+    "usage": "Use this before later analysis steps when samples with `undefined` or `null` values should be excluded. The attribute may be metadata or a selection-derived aggregation candidate from `selectionAggregation.fields`.",
     "payloadType": "RemoveUndefined",
     "payloadFields": [
       {
@@ -429,7 +429,7 @@
   {
     "actionType": "sampleView/groupToQuartiles",
     "description": "Add a grouping level to the sample hierarchy using quartile-based bins of a quantitative attribute.",
-    "usage": "Use this for a quick quantitative stratification. Quartiles are computed from the current samples in each group using the R-7 method, and tied values may collapse adjacent quartiles. The attribute may be metadata or a selection-derived aggregation returned by `buildSelectionAggregationAttribute`.",
+    "usage": "Use this for a quick quantitative stratification. Quartiles are computed from the current samples in each group using the R-7 method, and tied values may collapse adjacent quartiles. The attribute may be metadata or a selection-derived aggregation candidate from `selectionAggregation.fields`.",
     "payloadType": "GroupToQuartiles",
     "payloadFields": [
       {
@@ -457,7 +457,7 @@
   {
     "actionType": "sampleView/groupByThresholds",
     "description": "Add a grouping level to the sample hierarchy using threshold-defined numeric intervals of a quantitative attribute.",
-    "usage": "Use this when quantitative bins should follow explicit thresholds instead of quartiles. The resulting groups are ordered from the highest interval to the lowest. The attribute may be metadata or a selection-derived aggregation returned by `buildSelectionAggregationAttribute`.",
+    "usage": "Use this when quantitative bins should follow explicit thresholds instead of quartiles. The resulting groups are ordered from the highest interval to the lowest. The attribute may be metadata or a selection-derived aggregation candidate from `selectionAggregation.fields`.",
     "payloadType": "GroupByThresholds",
     "payloadFields": [
       {

--- a/packages/app-agent/src/agent/generated/generatedActionCatalog.json
+++ b/packages/app-agent/src/agent/generated/generatedActionCatalog.json
@@ -42,7 +42,7 @@
   {
     "actionType": "sampleView/deriveMetadata",
     "description": "Add a derived metadata column from a selected or aggregated attribute.",
-    "usage": "Use this when an existing attribute should be materialized as sample metadata under a new column name.",
+    "usage": "Use this when an existing attribute should be materialized as sample metadata under a new column name. For selection-derived values, use a `SELECTION_AGGREGATION` candidate from `selectionAggregation.fields`.",
     "payloadType": "DeriveMetadata",
     "payloadFields": [
       {
@@ -84,29 +84,6 @@
           "specifier": "purity"
         },
         "name": "purity_copy"
-      },
-      {
-        "attribute": {
-          "type": "VALUE_AT_LOCUS",
-          "specifier": {
-            "view": {
-              "scope": [],
-              "view": "track"
-            },
-            "field": "beta",
-            "interval": {
-              "type": "selection",
-              "selector": {
-                "scope": [],
-                "param": "brush"
-              }
-            },
-            "aggregation": {
-              "op": "max"
-            }
-          }
-        },
-        "name": "tp53_region_beta"
       }
     ]
   },

--- a/packages/app-agent/src/agent/generated/generatedActionSchema.json
+++ b/packages/app-agent/src/agent/generated/generatedActionSchema.json
@@ -314,7 +314,7 @@
       "type": "object"
     },
     "AttributeIdentifierType": {
-      "description": "Stable identifier for an abstract attribute used by actions and agent context.\n\n`type` identifies the attribute source kind, and `specifier` contains the concrete lookup information for that source.\n\nExamples:\n- `{ type: \"SAMPLE_ATTRIBUTE\", specifier: \"age\" }`\n- `{ type: \"VALUE_AT_LOCUS\", specifier: { ... } }`",
+      "description": "Stable identifier for an abstract attribute used by actions and agent context.\n\n`type` identifies the attribute source kind, and `specifier` contains the concrete lookup information for that source.\n\nExamples:\n- `{ type: \"SAMPLE_ATTRIBUTE\", specifier: \"age\" }`",
       "enum": [
         "SAMPLE_ATTRIBUTE",
         "VALUE_AT_LOCUS",

--- a/packages/app-agent/src/agent/generated/generatedToolCatalog.json
+++ b/packages/app-agent/src/agent/generated/generatedToolCatalog.json
@@ -92,30 +92,6 @@
     "strict": true
   },
   {
-    "toolName": "buildSelectionAggregationAttribute",
-    "description": "Build an `AttributeIdentifier` for a selection-derived aggregation so it can be inspected for diagnostics or explicit payload construction.",
-    "inputType": "BuildSelectionAggregationAttributeToolInput",
-    "inputFields": [
-      {
-        "name": "candidateId",
-        "type": "string",
-        "description": "Stable identifier for the selected candidate row. The identifiers are available in `selectionAggregation.fields` in the volatile context. They become available after a selection is made with a successful `paramChange` action.",
-        "required": true
-      },
-      {
-        "name": "aggregation",
-        "type": "AggregationOp",
-        "description": "Aggregation op to apply to the candidate field.",
-        "required": true
-      }
-    ],
-    "exampleInput": {
-      "candidateId": "brush@foo:bar",
-      "aggregation": "max"
-    },
-    "strict": true
-  },
-  {
     "toolName": "getAttributeSummary",
     "description": "Return a compact summary of one attribute (metadata or selection-derived) across visible samples or within each current visible group.",
     "inputType": "GetAttributeSummaryToolInput",

--- a/packages/app-agent/src/agent/generated/generatedToolCatalog.json
+++ b/packages/app-agent/src/agent/generated/generatedToolCatalog.json
@@ -93,7 +93,7 @@
   },
   {
     "toolName": "buildSelectionAggregationAttribute",
-    "description": "Build an `AttributeIdentifier` for a selection-derived aggregation so it can be used in a later intent action or inspected for diagnostics.",
+    "description": "Build an `AttributeIdentifier` for a selection-derived aggregation so it can be inspected for diagnostics or explicit payload construction.",
     "inputType": "BuildSelectionAggregationAttributeToolInput",
     "inputFields": [
       {

--- a/packages/app-agent/src/agent/generated/generatedToolSchema.json
+++ b/packages/app-agent/src/agent/generated/generatedToolSchema.json
@@ -365,22 +365,12 @@
     "AttributeIdentifier": {
       "anyOf": [
         {
-          "$ref": "#/definitions/CanonicalAttributeIdentifier"
+          "$ref": "#/definitions/SampleAttributeIdentifier"
         },
         {
           "$ref": "#/definitions/SelectionAggregationCandidate"
         }
       ]
-    },
-    "AttributeIdentifierType": {
-      "description": "Stable identifier for an abstract attribute used by actions and agent context.\n\n`type` identifies the attribute source kind, and `specifier` contains the concrete lookup information for that source.\n\nExamples:\n- `{ type: \"SAMPLE_ATTRIBUTE\", specifier: \"age\" }`\n- `{ type: \"VALUE_AT_LOCUS\", specifier: { ... } }`",
-      "enum": [
-        "SAMPLE_ATTRIBUTE",
-        "VALUE_AT_LOCUS",
-        "SAMPLE_NAME",
-        "VIEW_ATTRIBUTE"
-      ],
-      "type": "string"
     },
     "AttributeSummaryScope": {
       "enum": ["visible_samples", "visible_groups"],
@@ -2147,26 +2137,6 @@
         }
       },
       "required": ["scaleName", "domain"],
-      "type": "object"
-    },
-    "CanonicalAttributeIdentifier": {
-      "additionalProperties": false,
-      "properties": {
-        "specifier": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/ViewAttributeSpecifier"
-            }
-          ]
-        },
-        "type": {
-          "$ref": "#/definitions/AttributeIdentifierType"
-        }
-      },
-      "required": ["type"],
       "type": "object"
     }
   }

--- a/packages/app-agent/src/agent/generated/generatedToolSchema.json
+++ b/packages/app-agent/src/agent/generated/generatedToolSchema.json
@@ -392,7 +392,7 @@
     },
     "BuildSelectionAggregationAttributeToolInput": {
       "additionalProperties": false,
-      "description": "Build an `AttributeIdentifier` for a selection-derived aggregation so it can be used in a later intent action or inspected for diagnostics. Selection aggregation derives one value per sample from data items that overlap the current genomic interval selection. Plotting and summary tools can usually use `SELECTION_AGGREGATION` candidates directly. Before using this tool, you must make an interval selection using a parameter or ensure that one already exists. This tool does not compute or return an aggregated value. Use the returned `content.attribute` as the plotted attribute or as `payload.attribute` in `submitIntentActions`. If the requested locus or interval is not the current selection, update the selection first.",
+      "description": "Build an `AttributeIdentifier` for a selection-derived aggregation so it can be inspected for diagnostics or explicit payload construction. Selection aggregation derives one value per sample from data items that overlap the current genomic interval selection. Plotting and summary tools can usually use `SELECTION_AGGREGATION` candidates directly, and intent action payloads accept them directly. Before using this tool, you must make an interval selection using a parameter or ensure that one already exists. This tool does not compute or return an aggregated value. If the requested locus or interval is not the current selection, update the selection first.",
       "examples": [
         {
           "aggregation": "max",

--- a/packages/app-agent/src/agent/generated/generatedToolSchema.json
+++ b/packages/app-agent/src/agent/generated/generatedToolSchema.json
@@ -367,24 +367,14 @@
       "type": "object"
     },
     "AttributeIdentifier": {
-      "additionalProperties": false,
-      "properties": {
-        "specifier": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/ViewAttributeSpecifier"
-            }
-          ]
+      "anyOf": [
+        {
+          "$ref": "#/definitions/CanonicalAttributeIdentifier"
         },
-        "type": {
-          "$ref": "#/definitions/AttributeIdentifierType"
+        {
+          "$ref": "#/definitions/SelectionAggregationCandidate"
         }
-      },
-      "required": ["type"],
-      "type": "object"
+      ]
     },
     "AttributeIdentifierType": {
       "description": "Stable identifier for an abstract attribute used by actions and agent context.\n\n`type` identifies the attribute source kind, and `specifier` contains the concrete lookup information for that source.\n\nExamples:\n- `{ type: \"SAMPLE_ATTRIBUTE\", specifier: \"age\" }`\n- `{ type: \"VALUE_AT_LOCUS\", specifier: { ... } }`",
@@ -2190,6 +2180,26 @@
         }
       },
       "required": ["scaleName", "domain"],
+      "type": "object"
+    },
+    "CanonicalAttributeIdentifier": {
+      "additionalProperties": false,
+      "properties": {
+        "specifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ViewAttributeSpecifier"
+            }
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/AttributeIdentifierType"
+        }
+      },
+      "required": ["type"],
       "type": "object"
     }
   }

--- a/packages/app-agent/src/agent/generated/generatedToolSchema.json
+++ b/packages/app-agent/src/agent/generated/generatedToolSchema.json
@@ -1686,6 +1686,7 @@
           "description": "Aggregation applied within the selected interval separately for each sample, not across samples."
         },
         "candidateId": {
+          "description": "Exact candidate id copied from `selectionAggregation.fields`. Do not construct this from parameter, view, or field names.",
           "type": "string"
         },
         "type": {
@@ -1894,14 +1895,6 @@
           "attribute": {
             "specifier": "age",
             "type": "SAMPLE_ATTRIBUTE"
-          },
-          "kind": "boxplot"
-        },
-        {
-          "attribute": {
-            "aggregation": "max",
-            "candidateId": "brush@track:beta",
-            "type": "SELECTION_AGGREGATION"
           },
           "kind": "boxplot"
         }

--- a/packages/app-agent/src/agent/generated/generatedToolSchema.json
+++ b/packages/app-agent/src/agent/generated/generatedToolSchema.json
@@ -285,9 +285,6 @@
       "additionalProperties": false,
       "description": "Tool inputs exposed to the agent.",
       "properties": {
-        "buildSelectionAggregationAttribute": {
-          "$ref": "#/definitions/BuildSelectionAggregationAttributeToolInput"
-        },
         "collapseViewNode": {
           "$ref": "#/definitions/CollapseViewNodeToolInput"
         },
@@ -337,7 +334,6 @@
         "setViewVisibility",
         "jumpToProvenanceState",
         "jumpToInitialProvenanceState",
-        "buildSelectionAggregationAttribute",
         "getAttributeSummary",
         "resolveMetadataAttributeValues",
         "searchViewDatums",
@@ -389,28 +385,6 @@
     "AttributeSummaryScope": {
       "enum": ["visible_samples", "visible_groups"],
       "type": "string"
-    },
-    "BuildSelectionAggregationAttributeToolInput": {
-      "additionalProperties": false,
-      "description": "Build an `AttributeIdentifier` for a selection-derived aggregation so it can be inspected for diagnostics or explicit payload construction. Selection aggregation derives one value per sample from data items that overlap the current genomic interval selection. Plotting and summary tools can usually use `SELECTION_AGGREGATION` candidates directly, and intent action payloads accept them directly. Before using this tool, you must make an interval selection using a parameter or ensure that one already exists. This tool does not compute or return an aggregated value. If the requested locus or interval is not the current selection, update the selection first.",
-      "examples": [
-        {
-          "aggregation": "max",
-          "candidateId": "brush@foo:bar"
-        }
-      ],
-      "properties": {
-        "aggregation": {
-          "$ref": "#/definitions/AggregationOp",
-          "description": "Aggregation op to apply to the candidate field."
-        },
-        "candidateId": {
-          "description": "Stable identifier for the selected candidate row. The identifiers are available in `selectionAggregation.fields` in the volatile context. They become available after a selection is made with a successful `paramChange` action.",
-          "type": "string"
-        }
-      },
-      "required": ["candidateId", "aggregation"],
-      "type": "object"
     },
     "ChromosomalLocus": {
       "additionalProperties": false,

--- a/packages/app-agent/src/agent/selectionAggregationTool.js
+++ b/packages/app-agent/src/agent/selectionAggregationTool.js
@@ -22,7 +22,9 @@ export function buildSelectionAggregationAttribute(
     );
     if (!candidate) {
         throw new Error(
-            "Unknown selection aggregation candidate: " + candidateId + "."
+            "Unknown selection aggregation candidate: " +
+                candidateId +
+                ". Use an exact candidateId from selectionAggregation.fields."
         );
     }
 

--- a/packages/app-agent/src/agent/selectionAggregationTool.js
+++ b/packages/app-agent/src/agent/selectionAggregationTool.js
@@ -2,6 +2,7 @@ import {
     buildSelectionAggregationAttributeIdentifier,
     formatAggregationExpression,
 } from "@genome-spy/app/agentShared";
+import { ToolCallRejectionError } from "./agentToolErrors.js";
 
 /**
  * Resolves a selection-aggregation candidate into an `AttributeIdentifier`
@@ -21,7 +22,7 @@ export function buildSelectionAggregationAttribute(
         (field) => field.candidateId === candidateId
     );
     if (!candidate) {
-        throw new Error(
+        throw new ToolCallRejectionError(
             "Unknown selection aggregation candidate: " +
                 candidateId +
                 ". Use an exact candidateId from selectionAggregation.fields."
@@ -29,19 +30,19 @@ export function buildSelectionAggregationAttribute(
     }
 
     if (!candidate.viewSelector) {
-        throw new Error(
+        throw new ToolCallRejectionError(
             "Selection aggregation candidate is missing a view selector."
         );
     }
 
     if (!candidate.selectionSelector) {
-        throw new Error(
+        throw new ToolCallRejectionError(
             "Selection aggregation candidate is missing a selection selector."
         );
     }
 
     if (!candidate.supportedAggregations.includes(aggregation)) {
-        throw new Error(
+        throw new ToolCallRejectionError(
             "Aggregation " +
                 aggregation +
                 " is not supported for candidate " +

--- a/packages/app-agent/src/agent/submitIntentActionsValidator.js
+++ b/packages/app-agent/src/agent/submitIntentActionsValidator.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { validateActionPayloadShape } from "./actionShapeValidator.js";
+import { validateAgentActionPayloadShape } from "./actionShapeValidator.js";
 
 /**
  * Validates submitIntentActions without surfacing the raw union-branch noise
@@ -60,7 +60,7 @@ export function validateSubmitIntentActionsToolShape(toolArguments) {
                 continue;
             }
 
-            const payloadValidation = validateActionPayloadShape(
+            const payloadValidation = validateAgentActionPayloadShape(
                 /** @type {import("./types.js").AgentActionType} */ (
                     action.actionType
                 ),

--- a/packages/app-agent/src/agent/toolCatalog.test.js
+++ b/packages/app-agent/src/agent/toolCatalog.test.js
@@ -18,6 +18,7 @@ describe("toolCatalog", () => {
         expect(toolNames).toContain("showAttributeDistributionPlot");
         expect(toolNames).toContain("showAttributeRelationshipPlot");
         expect(toolNames).toContain("submitIntentActions");
+        expect(toolNames).not.toContain("buildSelectionAggregationAttribute");
     });
 
     it("builds Responses API function tool definitions", () => {

--- a/packages/app-agent/src/agent/toolCatalog.test.js
+++ b/packages/app-agent/src/agent/toolCatalog.test.js
@@ -211,6 +211,25 @@ describe("toolCatalog", () => {
         });
     });
 
+    it("accepts selection aggregation candidates in submitIntentActions payload attributes", () => {
+        const validation = validateToolArgumentsShape("submitIntentActions", {
+            actions: [
+                {
+                    actionType: "sampleView/sortBy",
+                    payload: {
+                        attribute: {
+                            type: "SELECTION_AGGREGATION",
+                            candidateId: "brush@track:beta",
+                            aggregation: "max",
+                        },
+                    },
+                },
+            ],
+        });
+
+        expect(validation.ok).toBe(true);
+    });
+
     it("keeps string values as strings when a tool schema expects a string", () => {
         const toolArguments = {
             query: '{"type":"SAMPLE_ATTRIBUTE","specifier":"mutations"}',

--- a/packages/app/src/sampleView/state/sampleSlice.js
+++ b/packages/app/src/sampleView/state/sampleSlice.js
@@ -301,8 +301,8 @@ export const sampleSlice = createSlice({
          *
          * Use this when samples should be ranked by one quantitative or
          * ordinal attribute before further filtering or grouping. The
-         * attribute may be metadata or a selection-derived aggregation returned
-         * by `buildSelectionAggregationAttribute`.
+         * attribute may be metadata or a selection-derived aggregation
+         * candidate from `selectionAggregation.fields`.
          *
          * @agent.payloadType SortBy
          * @agent.category sorting
@@ -384,8 +384,8 @@ export const sampleSlice = createSlice({
          *
          * Use this for numeric filters such as values greater than, less than,
          * or equal to a chosen threshold. The attribute may be metadata or a
-         * selection-derived aggregation returned by
-         * `buildSelectionAggregationAttribute`.
+         * selection-derived aggregation candidate from
+         * `selectionAggregation.fields`.
          *
          * @agent.payloadType FilterByQuantitative
          * @agent.category filtering
@@ -450,8 +450,8 @@ export const sampleSlice = createSlice({
          *
          * Use this before later analysis steps when samples with `undefined`
          * or `null` values should be excluded. The attribute may be metadata or
-         * a selection-derived aggregation returned by
-         * `buildSelectionAggregationAttribute`.
+         * a selection-derived aggregation candidate from
+         * `selectionAggregation.fields`.
          *
          * @agent.payloadType RemoveUndefined
          * @agent.category filtering
@@ -554,8 +554,8 @@ export const sampleSlice = createSlice({
          * Use this for a quick quantitative stratification. Quartiles are
          * computed from the current samples in each group using the R-7
          * method, and tied values may collapse adjacent quartiles. The
-         * attribute may be metadata or a selection-derived aggregation returned
-         * by `buildSelectionAggregationAttribute`.
+         * attribute may be metadata or a selection-derived aggregation
+         * candidate from `selectionAggregation.fields`.
          *
          * @agent.payloadType GroupToQuartiles
          * @agent.category grouping
@@ -589,8 +589,8 @@ export const sampleSlice = createSlice({
          * Use this when quantitative bins should follow explicit thresholds
          * instead of quartiles. The resulting groups are ordered from the
          * highest interval to the lowest. The attribute may be metadata or a
-         * selection-derived aggregation returned by
-         * `buildSelectionAggregationAttribute`.
+         * selection-derived aggregation candidate from
+         * `selectionAggregation.fields`.
          *
          * @agent.payloadType GroupByThresholds
          * @agent.category grouping

--- a/packages/app/src/sampleView/state/sampleSlice.js
+++ b/packages/app/src/sampleView/state/sampleSlice.js
@@ -228,7 +228,8 @@ export const sampleSlice = createSlice({
          * Add a derived metadata column from a selected or aggregated attribute.
          *
          * Use this when an existing attribute should be materialized as sample
-         * metadata under a new column name.
+         * metadata under a new column name. For selection-derived values, use
+         * a `SELECTION_AGGREGATION` candidate from `selectionAggregation.fields`.
          *
          * @agent.payloadType DeriveMetadata
          * @agent.category metadata
@@ -237,22 +238,6 @@ export const sampleSlice = createSlice({
          * {
          *   "attribute": { "type": "SAMPLE_ATTRIBUTE", "specifier": "purity" },
          *   "name": "purity_copy"
-         * }
-         * @example
-         * {
-         *   "attribute": {
-         *     "type": "VALUE_AT_LOCUS",
-         *     "specifier": {
-         *       "view": { "scope": [], "view": "track" },
-         *       "field": "beta",
-         *       "interval": {
-         *         "type": "selection",
-         *         "selector": { "scope": [], "param": "brush" }
-         *       },
-         *       "aggregation": { "op": "max" }
-         *     }
-         *   },
-         *   "name": "tp53_region_beta"
          * }
          */
         deriveMetadata: (

--- a/packages/app/src/sampleView/types.d.ts
+++ b/packages/app/src/sampleView/types.d.ts
@@ -12,7 +12,6 @@ import { Scale } from "@genome-spy/core/spec/scale.js";
  *
  * Examples:
  * - `{ type: "SAMPLE_ATTRIBUTE", specifier: "age" }`
- * - `{ type: "VALUE_AT_LOCUS", specifier: { ... } }`
  */
 export type AttributeIdentifierType =
     | "SAMPLE_ATTRIBUTE"


### PR DESCRIPTION
This refactors the app-agent selection aggregation workflow so the agent can use `SELECTION_AGGREGATION` candidates directly in intent action payloads instead of resolving internal attributes by hand.

Key changes:
- Added an agent-side adapter that normalizes `SELECTION_AGGREGATION` candidates to canonical reducer-facing attributes before intent execution.
- Removed the exposed `buildSelectionAggregationAttribute` tool so the model is steered toward direct candidate use.
- Hid internal `VALUE_AT_LOCUS` syntax from agent-facing docs/schema and reject hand-written internal attributes at the agent boundary.
- Tightened candidate id guidance so ids must be copied from `selectionAggregation.fields`.
- Updated the system prompt so named-gene interval workflows proactively create missing selections before deriving metadata.

Validation:
- `npx vitest run packages/app-agent/src/agent/actionShapeValidator.test.js packages/app-agent/src/agent/actionCatalog.test.js packages/app-agent/src/agent/toolCatalog.test.js packages/app-agent/src/agent/agentTools.test.js`
- `npx vitest run packages/app-agent/src/agent/agentSessionController.test.js packages/app-agent/src/agent/agentTools.test.js packages/app-agent/src/agent/attributeSummaryTool.test.js`
- `npm --workspace packages/app-agent run check:agent`
- `npm --workspace packages/app-agent run test:tsc`