### PR TITLE
Security: Unsafe HTML rendering in aboutDialog.js using packageJson values

### DIFF
--- a/packages/app/src/components/dialogs/aboutDialog.js
+++ b/packages/app/src/components/dialogs/aboutDialog.js
@@ -3,6 +3,15 @@ import BaseDialog from "../generic/baseDialog.js";
 import bowtie from "@genome-spy/core/img/bowtie.svg";
 import { renderVersionLink, packageJson } from "../../utils/version.js";
 
+function escapeHtml(str) {
+    return str
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
 export default class AboutDialog extends BaseDialog {
     constructor() {
         super();
@@ -17,21 +26,21 @@ export default class AboutDialog extends BaseDialog {
 
             <div style="max-width: 28em">
                 <p>
-                    ${packageJson.description}<br />
+                    ${escapeHtml(packageJson.description)}<br />
                     Read more about it on
-                    <a href="${packageJson.homepage}" target="_blank"
-                        >${packageJson.homepage}</a
+                    <a href="${escapeHtml(packageJson.homepage)}" target="_blank" rel="noopener noreferrer"
+                        >${escapeHtml(packageJson.homepage)}</a
                     >.
                 </p>
                 <p>
-                    Copyright 2026 ${packageJson.author?.name ?? "The author"}
+                    Copyright 2026 ${escapeHtml(packageJson.author?.name ?? "The author")}
                     and contributors.<br />
-                    ${packageJson.license} license.
+                    ${escapeHtml(packageJson.license)} license.
                 </p>
                 <p>
                     Version: ${renderVersionLink(packageJson.version)}
                     ${"commitHash" in packageJson
-                        ? `(${packageJson.commitHash})`
+                        ? `(${escapeHtml(packageJson.commitHash)})`
                         : nothing}
                 </p>
 
@@ -39,11 +48,11 @@ export default class AboutDialog extends BaseDialog {
                     GenomeSpy is developed in
                     <a
                         href="https://www.helsinki.fi/en/researchgroups/systems-biology-of-drug-resistance-in-cancer"
-                        target="_blank"
+                        target="_blank" rel="noopener noreferrer"
                         >The Systems Biology of Drug Resistance in Cancer</a
                     >
                     group at the
-                    <a href="https://www.helsinki.fi/en" target="_blank"
+                    <a href="https://www.helsinki.fi/en" target="_blank" rel="noopener noreferrer"
                         >University of Helsinki</a
                     >.
                 </p>
@@ -52,11 +61,11 @@ export default class AboutDialog extends BaseDialog {
                     This project has received funding from the European Union's
                     Horizon 2020 research and innovation programme under grant
                     agreement No. 965193
-                    <a href="https://www.deciderproject.eu/" target="_blank"
+                    <a href="https://www.deciderproject.eu/" target="_blank" rel="noopener noreferrer"
                         >DECIDER</a
                     >
                     and No. 847912
-                    <a href="https://www.rescuer.uio.no/" target="_blank"
+                    <a href="https://www.rescuer.uio.no/" target="_blank" rel="noopener noreferrer"
                         >RESCUER</a
                     >, as well as from the Biomedicum Helsinki Foundation, the
                     Sigrid Jusélius Foundation, and the Cancer Foundation


### PR DESCRIPTION
## Summary

Security: Unsafe HTML rendering in aboutDialog.js using packageJson values

## Problem

**Severity**: `Medium` | **File**: `packages/app/src/components/dialogs/aboutDialog.js:L1`

The `aboutDialog.js` file uses template literals with `packageJson` values (description, homepage, author.name, license, version, commitHash) directly interpolated into HTML without sanitization. While these are mostly from package.json, if any of these values were to be compromised (e.g., via a malicious dependency or build-time injection), they would be rendered as raw HTML due to lit's `html` tagged template handling. The `target="_blank"` links without `rel="noopener noreferrer"` also present a tabnabbing risk.

## Solution

Sanitize all dynamic values before interpolation, or use lit's `unsafeHTML` explicitly only where intended. Add `rel="noopener noreferrer"` to all `target="_blank"` links to prevent tabnabbing attacks.

## Changes

- `packages/app/src/components/dialogs/aboutDialog.js` (modified)