### PR TITLE
feat(app-agent): dock agent chat panel

### DIFF
--- a/packages/app-agent/src/agent/agentState.js
+++ b/packages/app-agent/src/agent/agentState.js
@@ -6,6 +6,13 @@
  *     agentAdapter?: import("./types.js").AgentAdapter;
  *     agentSessionController?: import("./agentSessionController.js").AgentSessionController;
  *     agentChatPanelHost?: HTMLElement;
+ *     agentChatPanelHandle?: {
+ *         show(): void;
+ *         hide(): void;
+ *         toggle(): boolean;
+ *         isVisible(): boolean;
+ *         dispose(): void;
+ *     };
  * }} AgentState
  */
 

--- a/packages/app-agent/src/agent/appAgent.js
+++ b/packages/app-agent/src/agent/appAgent.js
@@ -30,6 +30,8 @@ export function appAgent(options) {
                 state.agentSessionController = undefined;
                 state.agentAdapter = undefined;
                 state.agentBaseUrl = undefined;
+                state.agentChatPanelHandle?.dispose();
+                state.agentChatPanelHandle = undefined;
                 state.agentChatPanelHost?.remove();
                 state.agentChatPanelHost = undefined;
                 disposeUi();

--- a/packages/app-agent/src/agent/appAgent.test.js
+++ b/packages/app-agent/src/agent/appAgent.test.js
@@ -31,7 +31,6 @@ describe("appAgent", () => {
             ui: {
                 registerToolbarButton: vi.fn(),
                 registerToolbarMenuItem: vi.fn(),
-                registerDockedPanel: vi.fn(),
             },
             getAgentApi: vi.fn(async () => ({})),
         };

--- a/packages/app-agent/src/agent/chatMessage.js
+++ b/packages/app-agent/src/agent/chatMessage.js
@@ -97,7 +97,7 @@ export default class ChatMessageElement extends LitElement {
 
             .message.user {
                 border: none;
-                background: #ececec;
+                background: #f0f0f0;
                 border-radius: 14px 14px 2px 14px;
             }
 
@@ -106,6 +106,8 @@ export default class ChatMessageElement extends LitElement {
                 border: none;
                 background: transparent;
                 border-left-width: 0;
+                color: #222;
+                line-height: 1.3;
             }
 
             .assistant-body {

--- a/packages/app-agent/src/agent/chatPanel.js
+++ b/packages/app-agent/src/agent/chatPanel.js
@@ -110,11 +110,6 @@ export default class AgentChatPanel extends LitElement {
                 display: flex;
                 flex-direction: column;
                 height: 100%;
-                min-height: 640px;
-                overflow: hidden;
-                border-top: 3px solid var(--gs-theme-primary, #6c82ab);
-                border-radius: 4px;
-                box-shadow: 0 0 15px rgba(0, 0, 0, 0.3);
             }
 
             header {
@@ -124,7 +119,6 @@ export default class AgentChatPanel extends LitElement {
                 gap: var(--gs-basic-spacing, 10px);
                 padding: var(--gs-basic-spacing, 10px);
                 border-bottom: 1px solid var(--gs-dialog-stroke-color, #d0d0d0);
-                background: white;
             }
 
             .header-main {

--- a/packages/app-agent/src/agent/chatPanel.js
+++ b/packages/app-agent/src/agent/chatPanel.js
@@ -765,7 +765,7 @@ export default class AgentChatPanel extends LitElement {
 customElements.define("gs-agent-chat-panel", AgentChatPanel);
 
 /**
- * Toggle the docked agent chat panel in the app shell.
+ * Toggle the agent chat side panel in the app shell.
  *
  * @param {any} app
  * @returns {Promise<void>}
@@ -781,7 +781,6 @@ export async function toggleAgentChatPanel(app) {
     if (!host) {
         host = document.createElement("div");
         host.dataset.agentChatPanelHost = "true";
-        host.hidden = false;
         host.style.height = "100%";
         host.style.minHeight = "0";
 
@@ -795,23 +794,12 @@ export async function toggleAgentChatPanel(app) {
         panel.devMode = true;
         host.append(panel);
 
-        if (app.ui.registerSidePanel) {
-            agentState.agentChatPanelHandle = app.ui.registerSidePanel({
-                id: "agent-chat",
-                element: host,
-                preferredWidth: "min(36vw, 600px)",
-            });
-            agentState.agentChatPanelHandle.show();
-        } else if (app.ui.registerDockedPanel) {
-            host.style.position = "absolute";
-            host.style.top = "calc(var(--gs-basic-spacing, 10px) + 38px)";
-            host.style.right = "var(--gs-basic-spacing, 10px)";
-            host.style.bottom = "var(--gs-basic-spacing, 10px)";
-            host.style.width = "min(70vw, 600px)";
-            app.ui.registerDockedPanel(host);
-        } else {
-            app.appContainer.append(host);
-        }
+        agentState.agentChatPanelHandle = app.ui.registerSidePanel({
+            id: "agent-chat",
+            element: host,
+            preferredWidth: "min(36vw, 600px)",
+        });
+        agentState.agentChatPanelHandle.show();
         agentState.agentChatPanelHost = host;
         await panel.updateComplete;
         const textarea = panel.renderRoot.querySelector("textarea");
@@ -819,15 +807,7 @@ export async function toggleAgentChatPanel(app) {
         return;
     }
 
-    let isVisible;
-    if (agentState.agentChatPanelHandle) {
-        isVisible = agentState.agentChatPanelHandle.toggle();
-    } else {
-        host.hidden = !host.hidden;
-        isVisible = !host.hidden;
-    }
-
-    if (isVisible) {
+    if (agentState.agentChatPanelHandle.toggle()) {
         const panel = /** @type {AgentChatPanel | null} */ (
             host.querySelector("gs-agent-chat-panel")
         );

--- a/packages/app-agent/src/agent/chatPanel.js
+++ b/packages/app-agent/src/agent/chatPanel.js
@@ -101,7 +101,6 @@ export default class AgentChatPanel extends LitElement {
                 display: block;
                 box-sizing: border-box;
                 height: 100%;
-                min-height: 640px;
                 color: #222;
                 font-family: var(--gs-font-family, sans-serif);
             }
@@ -178,6 +177,17 @@ export default class AgentChatPanel extends LitElement {
                 flex: 1 1 auto;
             }
 
+            .transcript-shell {
+                --fade-size: var(--gs-basic-spacing, 10px);
+
+                mask-image: linear-gradient(
+                    to bottom,
+                    black 0,
+                    black calc(100% - var(--fade-size)),
+                    transparent 100%
+                );
+            }
+
             .transcript {
                 display: flex;
                 flex-direction: column;
@@ -186,7 +196,7 @@ export default class AgentChatPanel extends LitElement {
                 min-height: 0;
                 overflow: auto;
                 padding: var(--gs-basic-spacing, 10px);
-                background: #fafafa;
+                padding-bottom: 0;
             }
 
             .jump-to-latest {
@@ -265,8 +275,7 @@ export default class AgentChatPanel extends LitElement {
                 flex: 0 0 auto;
                 gap: 0.35rem;
                 padding: var(--gs-basic-spacing, 10px);
-                border-top: 1px solid var(--gs-dialog-stroke-color, #d0d0d0);
-                background: white;
+                padding-top: 0;
             }
 
             .composer-input {
@@ -274,6 +283,7 @@ export default class AgentChatPanel extends LitElement {
             }
 
             .composer textarea {
+                display: block;
                 width: 100%;
                 min-height: 2.75rem;
                 max-height: 12rem;
@@ -287,6 +297,7 @@ export default class AgentChatPanel extends LitElement {
                 background: #fff;
                 box-sizing: border-box;
                 resize: none;
+                box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.1);
             }
 
             .composer textarea:focus {
@@ -295,16 +306,15 @@ export default class AgentChatPanel extends LitElement {
 
             .composer-action {
                 position: absolute;
-                right: 0.45rem;
-                bottom: 0.45rem;
-                display: inline-flex;
+                right: calc(0.325rem + 1px);
+                bottom: calc(0.325rem + 1px);
                 align-items: center;
                 justify-content: center;
                 width: 2rem;
                 height: 2rem;
                 padding: 0;
                 border: 1px solid transparent;
-                border-radius: 50%;
+                border-radius: var(--form-control-border-radius);
                 color: white;
                 background: var(--gs-theme-primary, #6c82ab);
                 transition:
@@ -354,7 +364,7 @@ export default class AgentChatPanel extends LitElement {
 
         /** @type {AgentChatController | undefined} */
         this.controller = undefined;
-        this.panelTitle = "Agent Chat";
+        this.panelTitle = "GenomeSpy Agent";
         this.draft = "";
         /** @type {ChatSessionSnapshot} */
         this.snapshot = EMPTY_SNAPSHOT;

--- a/packages/app-agent/src/agent/chatPanel.js
+++ b/packages/app-agent/src/agent/chatPanel.js
@@ -1,5 +1,10 @@
 import { icon } from "@fortawesome/fontawesome-svg-core";
-import { faChevronDown, faRobot } from "@fortawesome/free-solid-svg-icons";
+import {
+    faChevronDown,
+    faPaperPlane,
+    faRobot,
+    faStop,
+} from "@fortawesome/free-solid-svg-icons";
 import { css, html, LitElement, nothing } from "lit";
 import { faStyles, formStyles } from "@genome-spy/app/agentShared";
 import { createAgentSessionController } from "./agentSessionController.js";
@@ -270,58 +275,68 @@ export default class AgentChatPanel extends LitElement {
                 background: white;
             }
 
-            .composer-row {
-                display: flex;
-                align-items: flex-end;
-                gap: 0.65rem;
+            .composer-input {
+                position: relative;
             }
 
             .composer textarea {
-                flex: 1 1 auto;
-                min-height: 4.75rem;
-                resize: vertical;
-                padding: 0.375em 0.75em;
+                width: 100%;
+                min-height: 2.75rem;
+                max-height: 12rem;
+                field-sizing: content;
+                padding: 0.65rem 3rem 0.65rem 0.75rem;
                 border: var(--form-control-border);
-                border-radius: var(--form-control-border-radius);
+                border-radius: calc(var(--form-control-border-radius) * 1.5);
                 font: inherit;
+                line-height: 1.35;
                 color: var(--form-control-color);
                 background: #fff;
                 box-sizing: border-box;
+                resize: none;
             }
 
             .composer textarea:focus {
-                border-color: var(--gs-theme-primary, #6c82ab);
-                box-shadow: 0 0 0 0.2rem rgb(108 130 171 / 25%);
+                outline: none;
             }
 
-            .composer .btn.btn-primary {
-                background-color: var(--gs-theme-primary, #6c82ab);
-                background-image: linear-gradient(
-                    to bottom,
-                    oklch(
-                        from var(--gs-theme-primary, #6c82ab) calc(l + 0.07) c h
-                    ),
-                    oklch(
-                        from var(--gs-theme-primary, #6c82ab) calc(l - 0.07) c h
-                    )
-                );
-                border-color: oklch(
+            .composer-action {
+                position: absolute;
+                right: 0.45rem;
+                bottom: 0.45rem;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 2rem;
+                height: 2rem;
+                padding: 0;
+                border: 1px solid transparent;
+                border-radius: 50%;
+                color: white;
+                background: var(--gs-theme-primary, #6c82ab);
+                transition:
+                    opacity 140ms ease,
+                    background-color 120ms ease,
+                    transform 120ms ease;
+            }
+
+            .composer-action.is-hidden {
+                opacity: 0;
+                pointer-events: none;
+            }
+
+            .composer-action:hover:not(:disabled):not(.is-hidden) {
+                background: oklch(
                     from var(--gs-theme-primary, #6c82ab) calc(l - 0.08) c h
                 );
-                color: var(--gs-theme-on-primary, #ffffff);
-                text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
             }
 
-            .composer .btn.btn-primary:hover:not(:disabled) {
-                background-image: linear-gradient(
-                    to bottom,
-                    oklch(
-                        from var(--gs-theme-primary, #6c82ab) calc(l + 0.1) c h
-                    ),
-                    oklch(
-                        from var(--gs-theme-primary, #6c82ab) calc(l - 0.04) c h
-                    )
-                );
+            .composer-action:active:not(:disabled):not(.is-hidden) {
+                transform: scale(0.96);
+            }
+
+            .composer-action svg {
+                width: 0.9rem;
+                height: 0.9rem;
             }
 
             .composer-footer {
@@ -488,7 +503,7 @@ export default class AgentChatPanel extends LitElement {
                     </div>
 
                     <form class="composer" @submit=${this.#handleSubmit}>
-                        <div class="composer-row">
+                        <div class="composer-input">
                             <textarea
                                 .value=${this.draft}
                                 placeholder="Ask the agent about the current visualization or request an action."
@@ -496,15 +511,42 @@ export default class AgentChatPanel extends LitElement {
                                 @input=${this.#handleDraftInput}
                                 @keydown=${this.#handleComposerKeyDown}
                             ></textarea>
-                            <button
-                                type="submit"
-                                ?disabled=${!this.controller ||
-                                (!this.#hasActiveLoop() &&
-                                    this.draft.trim().length === 0)}
-                                class="btn btn-primary"
-                            >
-                                ${this.#hasActiveLoop() ? "Stop" : "Send"}
-                            </button>
+                            ${this.#hasActiveLoop()
+                                ? html`
+                                      <button
+                                          type="button"
+                                          class="composer-action"
+                                          title="Stop"
+                                          aria-label="Stop"
+                                          @click=${() =>
+                                              this.controller?.stopCurrentTurn?.()}
+                                      >
+                                          ${icon(faStop).node[0]}
+                                      </button>
+                                  `
+                                : html`
+                                      <button
+                                          type="submit"
+                                          class="composer-action ${this.draft.trim()
+                                              .length > 0
+                                              ? ""
+                                              : "is-hidden"}"
+                                          title="Send"
+                                          aria-label="Send"
+                                          aria-hidden=${this.draft.trim()
+                                              .length > 0
+                                              ? "false"
+                                              : "true"}
+                                          tabindex=${this.draft.trim().length >
+                                          0
+                                              ? 0
+                                              : -1}
+                                          ?disabled=${!this.controller ||
+                                          this.draft.trim().length === 0}
+                                      >
+                                          ${icon(faPaperPlane).node[0]}
+                                      </button>
+                                  `}
                         </div>
                     </form>
                 </div>

--- a/packages/app-agent/src/agent/chatPanel.js
+++ b/packages/app-agent/src/agent/chatPanel.js
@@ -782,11 +782,8 @@ export async function toggleAgentChatPanel(app) {
         host = document.createElement("div");
         host.dataset.agentChatPanelHost = "true";
         host.hidden = false;
-        host.style.position = "absolute";
-        host.style.top = "calc(var(--gs-basic-spacing, 10px) + 38px)";
-        host.style.right = "var(--gs-basic-spacing, 10px)";
-        host.style.bottom = "var(--gs-basic-spacing, 10px)";
-        host.style.width = "min(70vw, 600px)";
+        host.style.height = "100%";
+        host.style.minHeight = "0";
 
         const panel = /** @type {AgentChatPanel} */ (
             document.createElement("gs-agent-chat-panel")
@@ -798,7 +795,19 @@ export async function toggleAgentChatPanel(app) {
         panel.devMode = true;
         host.append(panel);
 
-        if (app.ui.registerDockedPanel) {
+        if (app.ui.registerSidePanel) {
+            agentState.agentChatPanelHandle = app.ui.registerSidePanel({
+                id: "agent-chat",
+                element: host,
+                preferredWidth: "min(36vw, 600px)",
+            });
+            agentState.agentChatPanelHandle.show();
+        } else if (app.ui.registerDockedPanel) {
+            host.style.position = "absolute";
+            host.style.top = "calc(var(--gs-basic-spacing, 10px) + 38px)";
+            host.style.right = "var(--gs-basic-spacing, 10px)";
+            host.style.bottom = "var(--gs-basic-spacing, 10px)";
+            host.style.width = "min(70vw, 600px)";
             app.ui.registerDockedPanel(host);
         } else {
             app.appContainer.append(host);
@@ -810,8 +819,15 @@ export async function toggleAgentChatPanel(app) {
         return;
     }
 
-    host.hidden = !host.hidden;
-    if (!host.hidden) {
+    let isVisible;
+    if (agentState.agentChatPanelHandle) {
+        isVisible = agentState.agentChatPanelHandle.toggle();
+    } else {
+        host.hidden = !host.hidden;
+        isVisible = !host.hidden;
+    }
+
+    if (isVisible) {
         const panel = /** @type {AgentChatPanel | null} */ (
             host.querySelector("gs-agent-chat-panel")
         );

--- a/packages/app-agent/src/agent/chatPanel.test.js
+++ b/packages/app-agent/src/agent/chatPanel.test.js
@@ -132,6 +132,48 @@ describe("gs-agent-chat-panel", () => {
         panel.remove();
     });
 
+    it("sends with Enter and shows a contextual send button only for a draft", async () => {
+        const panel = document.createElement("gs-agent-chat-panel");
+        const controller = createController(createSnapshot([]));
+
+        panel.controller = controller;
+        document.body.append(panel);
+        await panel.updateComplete;
+        await Promise.resolve();
+
+        const composer = panel.shadowRoot.querySelector(".composer");
+        const textarea = composer.querySelector("textarea");
+        const initialSendButton = composer.querySelector(
+            "button[type='submit']"
+        );
+
+        expect(initialSendButton?.classList.contains("is-hidden")).toBe(true);
+        expect(initialSendButton?.disabled).toBe(true);
+
+        textarea.value = "Summarize this view";
+        textarea.dispatchEvent(new Event("input"));
+        await panel.updateComplete;
+
+        const sendButton = composer.querySelector("button[type='submit']");
+        expect(sendButton?.getAttribute("aria-label")).toBe("Send");
+        expect(sendButton?.classList.contains("is-hidden")).toBe(false);
+        expect(sendButton?.disabled).toBe(false);
+
+        textarea.dispatchEvent(
+            new KeyboardEvent("keydown", {
+                key: "Enter",
+                bubbles: true,
+            })
+        );
+        await panel.updateComplete;
+
+        expect(controller.sendMessage).toHaveBeenCalledWith(
+            "Summarize this view"
+        );
+
+        panel.remove();
+    });
+
     it("keeps the transcript pinned only while the user is at the bottom", async () => {
         const panel = document.createElement("gs-agent-chat-panel");
         const controller = createController(

--- a/packages/app-agent/src/agent/chatPanel.test.js
+++ b/packages/app-agent/src/agent/chatPanel.test.js
@@ -68,9 +68,7 @@ describe("gs-agent-chat-panel", () => {
                     document.body.append(panel.element);
                     return sidePanelHandle;
                 }),
-                registerDockedPanel: vi.fn(),
             },
-            appContainer: document.body,
         };
 
         getAgentState(app).agentAdapter = {
@@ -89,7 +87,6 @@ describe("gs-agent-chat-panel", () => {
                 element: expect.any(HTMLElement),
             })
         );
-        expect(app.ui.registerDockedPanel).not.toHaveBeenCalled();
         expect(sidePanelHandle.show).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/app-agent/src/agent/chatPanel.test.js
+++ b/packages/app-agent/src/agent/chatPanel.test.js
@@ -3,8 +3,10 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { html } from "lit";
 import { templateResultToString } from "@genome-spy/app/agentShared";
 import { formatSet } from "../../../app/src/sampleView/state/actionInfo.js";
+import { getAgentState } from "./agentState.js";
 import "./chatPanel.js";
 import "./chatStream.js";
+import { toggleAgentChatPanel } from "./chatPanel.js";
 
 const originalScrollTo = HTMLElement.prototype.scrollTo;
 
@@ -53,6 +55,44 @@ function createController(snapshot) {
 }
 
 describe("gs-agent-chat-panel", () => {
+    it("registers the chat panel as an app side panel when available", async () => {
+        const sidePanelHandle = {
+            show: vi.fn(),
+            hide: vi.fn(),
+            toggle: vi.fn(),
+            dispose: vi.fn(),
+        };
+        const app = {
+            ui: {
+                registerSidePanel: vi.fn((panel) => {
+                    document.body.append(panel.element);
+                    return sidePanelHandle;
+                }),
+                registerDockedPanel: vi.fn(),
+            },
+            appContainer: document.body,
+        };
+
+        getAgentState(app).agentAdapter = {
+            requestAgentTurn: vi.fn(),
+            getAgentContext: vi.fn(() => ({})),
+            getAgentVolatileContext: vi.fn(() => ({})),
+            executeActions: vi.fn(),
+        };
+
+        await toggleAgentChatPanel(app);
+
+        expect(app.ui.registerSidePanel).toHaveBeenCalledTimes(1);
+        expect(app.ui.registerSidePanel).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: "agent-chat",
+                element: expect.any(HTMLElement),
+            })
+        );
+        expect(app.ui.registerDockedPanel).not.toHaveBeenCalled();
+        expect(sidePanelHandle.show).toHaveBeenCalledTimes(1);
+    });
+
     it("renders result summary sets as reusable rich content", async () => {
         const content = html`Group by thresholds ${formatSet(["> 0"])} as
         ${formatSet(["Loss", "Gain"])} on stopgain_12q14_3`;

--- a/packages/app/src/app.js
+++ b/packages/app/src/app.js
@@ -91,7 +91,7 @@ export default class App {
                 <genome-spy-toolbar .app=${this}></genome-spy-toolbar>
                 <div class="genome-spy-workspace">
                     <div class="genome-spy-container"></div>
-                    <div class="genome-spy-side-panel-host" hidden></div>
+                    <div class="genome-spy-side-panel-host"></div>
                 </div>
             </div>`,
             this.appContainer

--- a/packages/app/src/app.js
+++ b/packages/app/src/app.js
@@ -89,7 +89,10 @@ export default class App {
         render(
             html`<div class="genome-spy-app">
                 <genome-spy-toolbar .app=${this}></genome-spy-toolbar>
-                <div class="genome-spy-container"></div>
+                <div class="genome-spy-workspace">
+                    <div class="genome-spy-container"></div>
+                    <div class="genome-spy-side-panel-host" hidden></div>
+                </div>
             </div>`,
             this.appContainer
         );

--- a/packages/app/src/appTypes.d.ts
+++ b/packages/app/src/appTypes.d.ts
@@ -21,7 +21,6 @@ export interface AppUiHost {
     registerToolbarMenuItem(
         item: import("./utils/ui/contextMenu.js").MenuItem
     ): () => void;
-    registerDockedPanel?(panel: HTMLElement): () => void;
     registerSidePanel?(panel: SidePanelSpec): SidePanelHandle;
 }
 
@@ -57,7 +56,6 @@ export interface AppUiRegistry extends AppUiHost, EventTarget {
         import("./utils/ui/contextMenu.js").MenuItem
     >;
     attachAppShell(appShell: HTMLElement): void;
-    registerDockedPanel(panel: HTMLElement): () => void;
     registerSidePanel(panel: SidePanelSpec): SidePanelHandle;
 }
 

--- a/packages/app/src/appTypes.d.ts
+++ b/packages/app/src/appTypes.d.ts
@@ -22,6 +22,21 @@ export interface AppUiHost {
         item: import("./utils/ui/contextMenu.js").MenuItem
     ): () => void;
     registerDockedPanel?(panel: HTMLElement): () => void;
+    registerSidePanel?(panel: SidePanelSpec): SidePanelHandle;
+}
+
+export interface SidePanelSpec {
+    id: string;
+    element: HTMLElement;
+    preferredWidth?: string;
+}
+
+export interface SidePanelHandle {
+    show(): void;
+    hide(): void;
+    toggle(): boolean;
+    isVisible(): boolean;
+    dispose(): void;
 }
 
 export interface AppPluginHost {
@@ -43,6 +58,7 @@ export interface AppUiRegistry extends AppUiHost, EventTarget {
     >;
     attachAppShell(appShell: HTMLElement): void;
     registerDockedPanel(panel: HTMLElement): () => void;
+    registerSidePanel(panel: SidePanelSpec): SidePanelHandle;
 }
 
 export type AppEmbedFunction = (

--- a/packages/app/src/appUiRegistry.js
+++ b/packages/app/src/appUiRegistry.js
@@ -12,9 +12,6 @@ export default class AppUiRegistry extends EventTarget {
         this.toolbarMenuItems = new Set();
 
         /** @type {HTMLElement | undefined} */
-        this.#appShell = undefined;
-
-        /** @type {HTMLElement | undefined} */
         this.#sidePanelHost = undefined;
 
         /** @type {ResizeObserver | undefined} */
@@ -32,11 +29,6 @@ export default class AppUiRegistry extends EventTarget {
     toolbarMenuItems;
 
     /**
-     * @type {Set<HTMLElement>}
-     */
-    #dockedPanels = new Set();
-
-    /**
      * @type {Map<string, import("./appTypes.js").SidePanelSpec>}
      */
     #sidePanels = new Map();
@@ -45,11 +37,6 @@ export default class AppUiRegistry extends EventTarget {
      * @type {string | undefined}
      */
     #activeSidePanelId = undefined;
-
-    /**
-     * @type {HTMLElement | undefined}
-     */
-    #appShell;
 
     /**
      * @type {HTMLElement | undefined}
@@ -65,9 +52,6 @@ export default class AppUiRegistry extends EventTarget {
      * @param {HTMLElement} appShell
      */
     attachAppShell(appShell) {
-        // Panels can be registered before the app shell exists, so keep the
-        // shell reference and attach any queued panels here.
-        this.#appShell = appShell;
         this.#sidePanelHost =
             appShell.querySelector(".genome-spy-side-panel-host") ??
             this.#createSidePanelHost(appShell);
@@ -79,9 +63,6 @@ export default class AppUiRegistry extends EventTarget {
                 }
             });
             this.#sidePanelResizeObserver.observe(appShell);
-        }
-        for (const panel of this.#dockedPanels) {
-            appShell.append(panel);
         }
         this.#renderActiveSidePanel();
     }
@@ -111,27 +92,6 @@ export default class AppUiRegistry extends EventTarget {
 
         return () => {
             if (this.toolbarMenuItems.delete(item)) {
-                this.#emitChange();
-            }
-        };
-    }
-
-    /**
-     * @param {HTMLElement} panel
-     * @returns {() => void}
-     */
-    registerDockedPanel(panel) {
-        this.#dockedPanels.add(panel);
-        // If the shell is already attached, mount immediately; otherwise the
-        // panel will be replayed from attachAppShell().
-        if (this.#appShell) {
-            this.#appShell.append(panel);
-        }
-        this.#emitChange();
-
-        return () => {
-            if (this.#dockedPanels.delete(panel)) {
-                panel.remove();
                 this.#emitChange();
             }
         };

--- a/packages/app/src/appUiRegistry.js
+++ b/packages/app/src/appUiRegistry.js
@@ -187,7 +187,6 @@ export default class AppUiRegistry extends EventTarget {
     #createSidePanelHost(appShell) {
         const host = document.createElement("div");
         host.className = "genome-spy-side-panel-host";
-        host.hidden = true;
         appShell.append(host);
         return host;
     }
@@ -209,13 +208,13 @@ export default class AppUiRegistry extends EventTarget {
         }
 
         if (!activePanel) {
-            this.#sidePanelHost.hidden = true;
+            this.#sidePanelHost.classList.remove("is-open");
             this.#sidePanelHost.style.removeProperty("width");
             this.#emitChange();
             return;
         }
 
-        this.#sidePanelHost.hidden = false;
+        this.#sidePanelHost.classList.add("is-open");
         this.#sidePanelHost.style.width =
             activePanel.preferredWidth ?? "min(36vw, 600px)";
         this.#snapSidePanelWidth();

--- a/packages/app/src/appUiRegistry.js
+++ b/packages/app/src/appUiRegistry.js
@@ -13,6 +13,12 @@ export default class AppUiRegistry extends EventTarget {
 
         /** @type {HTMLElement | undefined} */
         this.#appShell = undefined;
+
+        /** @type {HTMLElement | undefined} */
+        this.#sidePanelHost = undefined;
+
+        /** @type {ResizeObserver | undefined} */
+        this.#sidePanelResizeObserver = undefined;
     }
 
     /**
@@ -31,9 +37,29 @@ export default class AppUiRegistry extends EventTarget {
     #dockedPanels = new Set();
 
     /**
+     * @type {Map<string, import("./appTypes.js").SidePanelSpec>}
+     */
+    #sidePanels = new Map();
+
+    /**
+     * @type {string | undefined}
+     */
+    #activeSidePanelId = undefined;
+
+    /**
      * @type {HTMLElement | undefined}
      */
     #appShell;
+
+    /**
+     * @type {HTMLElement | undefined}
+     */
+    #sidePanelHost;
+
+    /**
+     * @type {ResizeObserver | undefined}
+     */
+    #sidePanelResizeObserver;
 
     /**
      * @param {HTMLElement} appShell
@@ -42,9 +68,22 @@ export default class AppUiRegistry extends EventTarget {
         // Panels can be registered before the app shell exists, so keep the
         // shell reference and attach any queued panels here.
         this.#appShell = appShell;
+        this.#sidePanelHost =
+            appShell.querySelector(".genome-spy-side-panel-host") ??
+            this.#createSidePanelHost(appShell);
+        if (typeof ResizeObserver === "function") {
+            this.#sidePanelResizeObserver?.disconnect();
+            this.#sidePanelResizeObserver = new ResizeObserver(() => {
+                if (this.#activeSidePanelId) {
+                    this.#renderActiveSidePanel();
+                }
+            });
+            this.#sidePanelResizeObserver.observe(appShell);
+        }
         for (const panel of this.#dockedPanels) {
             appShell.append(panel);
         }
+        this.#renderActiveSidePanel();
     }
 
     /**
@@ -96,6 +135,102 @@ export default class AppUiRegistry extends EventTarget {
                 this.#emitChange();
             }
         };
+    }
+
+    /**
+     * @param {import("./appTypes.js").SidePanelSpec} panel
+     * @returns {import("./appTypes.js").SidePanelHandle}
+     */
+    registerSidePanel(panel) {
+        this.#sidePanels.set(panel.id, panel);
+        this.#renderActiveSidePanel();
+
+        return {
+            show: () => {
+                this.#activeSidePanelId = panel.id;
+                this.#renderActiveSidePanel();
+            },
+            hide: () => {
+                if (this.#activeSidePanelId === panel.id) {
+                    this.#activeSidePanelId = undefined;
+                    this.#renderActiveSidePanel();
+                }
+            },
+            toggle: () => {
+                if (this.#activeSidePanelId === panel.id) {
+                    this.#activeSidePanelId = undefined;
+                    this.#renderActiveSidePanel();
+                    return false;
+                }
+
+                this.#activeSidePanelId = panel.id;
+                this.#renderActiveSidePanel();
+                return true;
+            },
+            isVisible: () => this.#activeSidePanelId === panel.id,
+            dispose: () => {
+                if (this.#sidePanels.delete(panel.id)) {
+                    if (this.#activeSidePanelId === panel.id) {
+                        this.#activeSidePanelId = undefined;
+                    }
+                    panel.element.remove();
+                    this.#renderActiveSidePanel();
+                }
+            },
+        };
+    }
+
+    /**
+     * @param {HTMLElement} appShell
+     * @returns {HTMLElement}
+     */
+    #createSidePanelHost(appShell) {
+        const host = document.createElement("div");
+        host.className = "genome-spy-side-panel-host";
+        host.hidden = true;
+        appShell.append(host);
+        return host;
+    }
+
+    #renderActiveSidePanel() {
+        if (!this.#sidePanelHost) {
+            return;
+        }
+
+        const activePanel = this.#activeSidePanelId
+            ? this.#sidePanels.get(this.#activeSidePanelId)
+            : undefined;
+
+        for (const panel of this.#sidePanels.values()) {
+            if (panel.element.parentElement !== this.#sidePanelHost) {
+                this.#sidePanelHost.append(panel.element);
+            }
+            panel.element.hidden = panel !== activePanel;
+        }
+
+        if (!activePanel) {
+            this.#sidePanelHost.hidden = true;
+            this.#sidePanelHost.style.removeProperty("width");
+            this.#emitChange();
+            return;
+        }
+
+        this.#sidePanelHost.hidden = false;
+        this.#sidePanelHost.style.width =
+            activePanel.preferredWidth ?? "min(36vw, 600px)";
+        this.#snapSidePanelWidth();
+        this.#emitChange();
+    }
+
+    #snapSidePanelWidth() {
+        if (!this.#sidePanelHost) {
+            return;
+        }
+
+        const width = Math.round(
+            this.#sidePanelHost.getBoundingClientRect().width
+        );
+        this.#sidePanelHost.style.width = width + "px";
     }
 
     #emitChange() {

--- a/packages/app/src/appUiRegistry.test.js
+++ b/packages/app/src/appUiRegistry.test.js
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+
+import AppUiRegistry from "./appUiRegistry.js";
+
+describe("AppUiRegistry", () => {
+    it("shows one side panel at a time in the app shell", () => {
+        const registry = new AppUiRegistry();
+        const appShell = document.createElement("div");
+        const firstPanel = document.createElement("section");
+        const secondPanel = document.createElement("aside");
+
+        registry.attachAppShell(appShell);
+
+        const firstHandle = registry.registerSidePanel({
+            id: "first",
+            element: firstPanel,
+        });
+        const secondHandle = registry.registerSidePanel({
+            id: "second",
+            element: secondPanel,
+        });
+
+        firstHandle.show();
+
+        const sidePanelHost = appShell.querySelector(
+            ".genome-spy-side-panel-host"
+        );
+        expect(sidePanelHost.hidden).toBe(false);
+        expect(sidePanelHost.firstElementChild).toBe(firstPanel);
+
+        secondHandle.show();
+
+        expect(firstPanel.hidden).toBe(true);
+        expect(secondPanel.hidden).toBe(false);
+
+        secondHandle.hide();
+
+        expect(sidePanelHost.hidden).toBe(true);
+        expect(secondPanel.parentElement).toBe(sidePanelHost);
+    });
+
+    it("snaps measured side panel width to integer pixels", () => {
+        const registry = new AppUiRegistry();
+        const appShell = document.createElement("div");
+        const panel = document.createElement("section");
+
+        registry.attachAppShell(appShell);
+
+        const sidePanelHost = appShell.querySelector(
+            ".genome-spy-side-panel-host"
+        );
+        sidePanelHost.getBoundingClientRect = () =>
+            /** @type {DOMRect} */ ({
+                width: 361.359375,
+                height: 100,
+                x: 0,
+                y: 0,
+                top: 0,
+                right: 361.359375,
+                bottom: 100,
+                left: 0,
+                toJSON: () => ({}),
+            });
+
+        registry
+            .registerSidePanel({
+                id: "panel",
+                element: panel,
+                preferredWidth: "min(36vw, 600px)",
+            })
+            .show();
+
+        expect(sidePanelHost.style.width).toBe("361px");
+    });
+});

--- a/packages/app/src/appUiRegistry.test.js
+++ b/packages/app/src/appUiRegistry.test.js
@@ -4,6 +4,12 @@ import { describe, expect, it } from "vitest";
 import AppUiRegistry from "./appUiRegistry.js";
 
 describe("AppUiRegistry", () => {
+    it("does not expose the obsolete docked panel API", () => {
+        const registry = new AppUiRegistry();
+
+        expect("registerDockedPanel" in registry).toBe(false);
+    });
+
     it("shows one side panel at a time in the app shell", () => {
         const registry = new AppUiRegistry();
         const appShell = document.createElement("div");

--- a/packages/app/src/appUiRegistry.test.js
+++ b/packages/app/src/appUiRegistry.test.js
@@ -26,7 +26,7 @@ describe("AppUiRegistry", () => {
         const sidePanelHost = appShell.querySelector(
             ".genome-spy-side-panel-host"
         );
-        expect(sidePanelHost.hidden).toBe(false);
+        expect(sidePanelHost.classList.contains("is-open")).toBe(true);
         expect(sidePanelHost.firstElementChild).toBe(firstPanel);
 
         secondHandle.show();
@@ -36,7 +36,7 @@ describe("AppUiRegistry", () => {
 
         secondHandle.hide();
 
-        expect(sidePanelHost.hidden).toBe(true);
+        expect(sidePanelHost.classList.contains("is-open")).toBe(false);
         expect(secondPanel.parentElement).toBe(sidePanelHost);
     });
 

--- a/packages/app/src/index.d.ts
+++ b/packages/app/src/index.d.ts
@@ -6,6 +6,7 @@ export * from "./agentShared/index.js";
 export { BaseDialog, showDialog, showMessageDialog } from "./dialog/index.js";
 
 export declare const embed: AppEmbedFunction;
+export type * from "./appTypes.d.ts";
 export type * from "./sampleView/types.d.ts";
 export type * from "./sampleView/state/sampleState.d.ts";
 export type * from "./sampleView/state/payloadTypes.d.ts";

--- a/packages/app/src/index.test.js
+++ b/packages/app/src/index.test.js
@@ -10,7 +10,6 @@ const { AppMock } = vi.hoisted(() => ({
             toolbarMenuItems: new Set(),
             registerToolbarButton: vi.fn(),
             registerToolbarMenuItem: vi.fn(),
-            registerDockedPanel: vi.fn(),
             addEventListener: vi.fn(),
             removeEventListener: vi.fn(),
         };

--- a/packages/app/src/styles/genome-spy-app.scss
+++ b/packages/app/src/styles/genome-spy-app.scss
@@ -27,10 +27,30 @@ $basic-spacing: generic.$basic-spacing;
 
     font-size: 14px;
 
+    .genome-spy-workspace {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        flex: 1 1 auto;
+        min-height: 0;
+        min-width: 0;
+    }
+
     .genome-spy-container {
         position: relative;
-        flex-grow: 1;
+        min-width: 0;
+        min-height: 0;
         overflow: hidden;
+    }
+
+    .genome-spy-side-panel-host {
+        min-height: 0;
+        border-left: 1px solid var(--gs-dialog-stroke-color, #d0d0d0);
+        background: white;
+        overflow: hidden;
+    }
+
+    .genome-spy-side-panel-host[hidden] {
+        display: none;
     }
 }
 

--- a/packages/app/src/styles/genome-spy-app.scss
+++ b/packages/app/src/styles/genome-spy-app.scss
@@ -46,7 +46,6 @@ $basic-spacing: generic.$basic-spacing;
         display: none;
         min-height: 0;
         border-left: 1px solid var(--gs-dialog-stroke-color, #d0d0d0);
-        background: white;
         overflow: hidden;
     }
 

--- a/packages/app/src/styles/genome-spy-app.scss
+++ b/packages/app/src/styles/genome-spy-app.scss
@@ -43,14 +43,31 @@ $basic-spacing: generic.$basic-spacing;
     }
 
     .genome-spy-side-panel-host {
+        display: none;
         min-height: 0;
         border-left: 1px solid var(--gs-dialog-stroke-color, #d0d0d0);
         background: white;
         overflow: hidden;
     }
 
-    .genome-spy-side-panel-host[hidden] {
-        display: none;
+    .genome-spy-side-panel-host.is-open {
+        display: block;
+        opacity: 1;
+        transform: translateX(0);
+        transition:
+            opacity 260ms ease,
+            transform 280ms ease;
+
+        @starting-style {
+            opacity: 0;
+            transform: translateX(20px);
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .genome-spy-side-panel-host.is-open {
+            transition: none;
+        }
     }
 }
 

--- a/packages/app/src/styles/genome-spy-app.scss
+++ b/packages/app/src/styles/genome-spy-app.scss
@@ -84,6 +84,8 @@ $basic-spacing: generic.$basic-spacing;
     --gs-toolbar-bg-lo: oklch(from var(--gs-toolbar-bg) calc(l - 0.06) c h);
     --gs-toolbar-bg-dim: oklch(from var(--gs-toolbar-bg) calc(l - 0.05) c h);
 
+    z-index: 1;
+
     height: 38px;
 
     background-color: var(--gs-toolbar-bg);


### PR DESCRIPTION
This PR changes the app agent chat from an overlay into a docked side panel so the visualization canvas can resize instead of being covered. It also tightens the chat panel UI by removing the legacy overlay behavior, animating panel opening, and refining the message composer controls.

Key points:

- Adds an app UI registry mechanism for plugins to contribute side panels.
- Docks the agent chat panel beside the visualization canvas and keeps canvas dimensions stable.
- Removes legacy fixed-position chat panel styling.
- Adds opening animation for the side panel while keeping close behavior simple.
- Refines the chat composer with an auto-sizing textarea and contextual send/stop action.

Validation:

- `npx vitest run packages/app/src/appUiRegistry.test.js packages/app-agent/src/agent/chatPanel.test.js`
- `npm --workspace packages/app-agent run test:tsc`
- Commit hook ran `eslint` and `prettier --write` for staged files.