### PR TITLE
feat(core): support Vega-Lite-style view size defaults

### DIFF
--- a/docs/grammar/config.md
+++ b/docs/grammar/config.md
@@ -143,3 +143,29 @@ See also [Titles](./title.md).
 View background defaults come from `config.view` and from styles referenced by
 `view.style`. GenomeSpy also supports the implicit `"cell"` style model for view
 backgrounds.
+
+## View size defaults
+
+`config.view` can define default sizes for views that do not specify `width` or
+`height` directly. These defaults follow Vega-Lite's continuous/discrete split:
+
+SCHEMA ViewConfig
+
+`discreteWidth` and `discreteHeight` can be fixed pixel values or step objects:
+
+```json
+{
+  "config": {
+    "view": {
+      "continuousWidth": 300,
+      "continuousHeight": 300,
+      "discreteWidth": { "step": 20 },
+      "discreteHeight": { "step": 20 }
+    }
+  }
+}
+```
+
+If these properties are omitted, GenomeSpy keeps its default `"container"`
+sizing behavior. See [child sizing](./composition/concat.md#sizedef) for
+details about `"container"` and other size shorthands.

--- a/examples/core/marks/point/point2d.json
+++ b/examples/core/marks/point/point2d.json
@@ -1,22 +1,18 @@
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+  "$schema": "https://unpkg.com/@genome-spy/core/dist/schema.json",
 
   "description": "A scatterplot showing horsepower and miles per gallons for various cars.",
 
-  "height": 200,
-
-  "width": 200,
-
-  "config": { "legend": { "disable": false, "offset": 18 } },
-
   "data": { "url": "vega-datasets/cars.json" },
 
-  "mark": { "type": "point", "filled": false, "opacity": 0.7, "size": 30 },
+  "mark": { "type": "point", "opacity": 0.7 },
 
   "encoding": {
     "x": { "field": "Horsepower", "type": "quantitative" },
     "y": { "field": "Miles_per_Gallon", "type": "quantitative" },
     "color": { "field": "Origin", "type": "nominal" },
     "shape": { "field": "Origin", "type": "nominal" }
-  }
+  },
+
+  "theme": "vegalite"
 }

--- a/packages/app/src/index.js
+++ b/packages/app/src/index.js
@@ -43,7 +43,6 @@ export async function embed(el, spec, options = {}) {
         const specObject = isObject(spec) ? spec : await loadSpec(spec);
 
         specObject.baseUrl ??= "";
-        specObject.width ??= "container";
         specObject.padding ??= 10;
 
         const embedOptions =

--- a/packages/core/__snapshots__/layout.test.js.snap
+++ b/packages/core/__snapshots__/layout.test.js.snap
@@ -2290,69 +2290,85 @@ ViewCoords {
       "children": [
         ViewCoords {
           "children": [],
-          "coords": "Rectangle: x: 32, y: 200, width: 200, height: 32",
+          "coords": "Rectangle: x: 33, y: 0, width: 300, height: 300",
+          "viewName": "grid_lines",
+        },
+      ],
+      "coords": "Rectangle: x: 33, y: 0, width: 300, height: 300",
+      "viewName": "grid_layers",
+    },
+    ViewCoords {
+      "children": [],
+      "coords": "Rectangle: x: 33, y: 0, width: 300, height: 300",
+      "viewName": "backgroundStroke0",
+    },
+    ViewCoords {
+      "children": [
+        ViewCoords {
+          "children": [],
+          "coords": "Rectangle: x: 33, y: 300, width: 300, height: 33",
           "viewName": "domain",
         },
         ViewCoords {
           "children": [
             ViewCoords {
               "children": [],
-              "coords": "Rectangle: x: 32, y: 200, width: 200, height: 32",
+              "coords": "Rectangle: x: 33, y: 300, width: 300, height: 33",
               "viewName": "ticks",
             },
             ViewCoords {
               "children": [],
-              "coords": "Rectangle: x: 32, y: 200, width: 200, height: 32",
+              "coords": "Rectangle: x: 33, y: 300, width: 300, height: 33",
               "viewName": "labels_main",
             },
           ],
-          "coords": "Rectangle: x: 32, y: 200, width: 200, height: 32",
+          "coords": "Rectangle: x: 33, y: 300, width: 300, height: 33",
           "viewName": "ticks_and_labels",
         },
         ViewCoords {
           "children": [],
-          "coords": "Rectangle: x: 32, y: 200, width: 200, height: 32",
+          "coords": "Rectangle: x: 33, y: 300, width: 300, height: 33",
           "viewName": "title",
         },
       ],
-      "coords": "Rectangle: x: 32, y: 200, width: 200, height: 32",
+      "coords": "Rectangle: x: 33, y: 300, width: 300, height: 33",
       "viewName": "axis_bottom",
     },
     ViewCoords {
       "children": [
         ViewCoords {
           "children": [],
-          "coords": "Rectangle: x: 0, y: 0, width: 32, height: 200",
+          "coords": "Rectangle: x: 0, y: 0, width: 33, height: 300",
           "viewName": "domain",
         },
         ViewCoords {
           "children": [
             ViewCoords {
               "children": [],
-              "coords": "Rectangle: x: 0, y: 0, width: 32, height: 200",
+              "coords": "Rectangle: x: 0, y: 0, width: 33, height: 300",
               "viewName": "ticks",
             },
             ViewCoords {
               "children": [],
-              "coords": "Rectangle: x: 0, y: 0, width: 32, height: 200",
+              "coords": "Rectangle: x: 0, y: 0, width: 33, height: 300",
               "viewName": "labels_main",
             },
           ],
-          "coords": "Rectangle: x: 0, y: 0, width: 32, height: 200",
+          "coords": "Rectangle: x: 0, y: 0, width: 33, height: 300",
           "viewName": "ticks_and_labels",
         },
         ViewCoords {
           "children": [],
-          "coords": "Rectangle: x: 0, y: 0, width: 32, height: 200",
+          "coords": "Rectangle: x: 0, y: 0, width: 33, height: 300",
           "viewName": "title",
         },
       ],
-      "coords": "Rectangle: x: 0, y: 0, width: 32, height: 200",
+      "coords": "Rectangle: x: 0, y: 0, width: 33, height: 300",
       "viewName": "axis_left",
     },
     ViewCoords {
       "children": [],
-      "coords": "Rectangle: x: 32, y: 0, width: 200, height: 200",
+      "coords": "Rectangle: x: 33, y: 0, width: 300, height: 300",
       "viewName": "grid0",
     },
     ViewCoords {
@@ -2363,39 +2379,39 @@ ViewCoords {
               "children": [
                 ViewCoords {
                   "children": [],
-                  "coords": "Rectangle: x: 250, y: 0, width: 0, height: 16",
+                  "coords": "Rectangle: x: 351, y: 0, width: 300, height: 16",
                   "viewName": "title",
                 },
                 ViewCoords {
                   "children": [
                     ViewCoords {
                       "children": [],
-                      "coords": "Rectangle: x: 250, y: 16, width: 0, height: 12",
+                      "coords": "Rectangle: x: 351, y: 16, width: 300, height: 12",
                       "viewName": "symbols",
                     },
                     ViewCoords {
                       "children": [],
-                      "coords": "Rectangle: x: 250, y: 16, width: 0, height: 12",
+                      "coords": "Rectangle: x: 351, y: 16, width: 300, height: 12",
                       "viewName": "labels",
                     },
                   ],
-                  "coords": "Rectangle: x: 250, y: 16, width: 0, height: 12",
+                  "coords": "Rectangle: x: 351, y: 16, width: 300, height: 12",
                   "viewName": "legendBody",
                 },
               ],
-              "coords": "Rectangle: x: 250, y: 0, width: 0, height: 28",
+              "coords": "Rectangle: x: 351, y: 0, width: 0, height: 28",
               "viewName": "legend0",
             },
           ],
-          "coords": "Rectangle: x: 250, y: 0, width: 0, height: 28",
+          "coords": "Rectangle: x: 351, y: 0, width: 0, height: 28",
           "viewName": "legend_right",
         },
       ],
-      "coords": "Rectangle: x: 250, y: 0, width: 0, height: 28",
+      "coords": "Rectangle: x: 351, y: 0, width: 0, height: 28",
       "viewName": "legend_region_right",
     },
   ],
-  "coords": "Rectangle: x: 0, y: 0, width: 250, height: 232",
+  "coords": "Rectangle: x: 0, y: 0, width: 351, height: 333",
   "viewName": "implicitRoot",
 }
 `;

--- a/packages/core/layout.test.js
+++ b/packages/core/layout.test.js
@@ -64,8 +64,8 @@ describe("Test layout process", () => {
 
         expect(plot).toBeDefined();
         expect(legend).toBeDefined();
-        expect(readCoord(plot.coords, "width")).toBe(200);
-        expect(readCoord(plot.coords, "height")).toBe(200);
+        expect(readCoord(plot.coords, "width")).toBe(300);
+        expect(readCoord(plot.coords, "height")).toBe(300);
         expect(readCoord(legend.coords, "x")).toBe(
             readCoord(plot.coords, "x") + readCoord(plot.coords, "width") + 18
         );

--- a/packages/core/src/config/resolveConfig.test.js
+++ b/packages/core/src/config/resolveConfig.test.js
@@ -71,6 +71,21 @@ describe("resolveConfig", () => {
         expect(urbanInstitute.view.strokeOpacity).toBe(0);
     });
 
+    test("vegalite and derived themes use Vega-Lite view size defaults", () => {
+        for (const themeName of /** @type {const} */ ([
+            "vegalite",
+            "quartz",
+            "dark",
+            "fivethirtyeight",
+            "urbaninstitute",
+        ])) {
+            const theme = resolveThemeSelection(themeName);
+            expect(theme.view.continuousWidth).toBe(300);
+            expect(theme.view.continuousHeight).toBe(300);
+            expect(theme.view.step).toBe(20);
+        }
+    });
+
     test("exposes built-in theme background for root resolution", () => {
         expect(getBuiltInThemeBackground("vegalite")).toBeUndefined();
         expect(getBuiltInThemeBackground("dark")).toBe("#333");

--- a/packages/core/src/config/themes.js
+++ b/packages/core/src/config/themes.js
@@ -16,6 +16,9 @@ const VEGALITE_THEME = {
         color: "black",
     },
     view: {
+        continuousWidth: 300,
+        continuousHeight: 300,
+        step: 20,
         stroke: "#ddd",
         strokeWidth: 1,
     },

--- a/packages/core/src/embedFactory.js
+++ b/packages/core/src/embedFactory.js
@@ -38,7 +38,6 @@ export function createEmbed(GenomeSpy) {
             const specObject = isObject(spec) ? spec : await loadSpec(spec);
 
             specObject.baseUrl ??= "";
-            specObject.width ??= "container";
             specObject.padding ??= 10;
 
             if (element == document.body) {

--- a/packages/core/src/embedFactory.test.js
+++ b/packages/core/src/embedFactory.test.js
@@ -43,8 +43,12 @@ describe("embed factory", () => {
         };
 
         class ParamGenomeSpy extends MockGenomeSpy {
-            constructor() {
-                super();
+            /**
+             * @param {HTMLElement} element
+             * @param {any} spec
+             */
+            constructor(element, spec) {
+                super(element, spec);
                 this.getParam = vi.fn(() => paramApi);
             }
         }

--- a/packages/core/src/embedFactory.test.js
+++ b/packages/core/src/embedFactory.test.js
@@ -5,6 +5,28 @@ import { describe, expect, test, vi } from "vitest";
 import { createEmbed } from "./embedFactory.js";
 
 describe("embed factory", () => {
+    class MockGenomeSpy {
+        /**
+         * @param {HTMLElement} element
+         * @param {any} spec
+         */
+        constructor(element, spec) {
+            this.element = element;
+            this.spec = spec;
+            this.launch = vi.fn();
+            this.getParam = vi.fn();
+            this.destroy = vi.fn();
+            this.addEventListener = vi.fn();
+            this.removeEventListener = vi.fn();
+            this.getNamedScaleResolutions = vi.fn(() => new Map());
+            this.awaitVisibleLazyData = vi.fn();
+            this.getRenderedBounds = vi.fn();
+            this.updateNamedData = vi.fn();
+            this.getLogicalCanvasSize = vi.fn();
+            this.exportCanvas = vi.fn();
+        }
+    }
+
     test("forwards getParam from the GenomeSpy instance", async () => {
         const paramApi = {
             /** @returns {number} */
@@ -20,26 +42,41 @@ describe("embed factory", () => {
             },
         };
 
-        class MockGenomeSpy {
+        class ParamGenomeSpy extends MockGenomeSpy {
             constructor() {
-                this.launch = vi.fn();
+                super();
                 this.getParam = vi.fn(() => paramApi);
-                this.destroy = vi.fn();
-                this.addEventListener = vi.fn();
-                this.removeEventListener = vi.fn();
-                this.getNamedScaleResolutions = vi.fn(() => new Map());
-                this.awaitVisibleLazyData = vi.fn();
-                this.getRenderedBounds = vi.fn();
-                this.updateNamedData = vi.fn();
-                this.getLogicalCanvasSize = vi.fn();
-                this.exportCanvas = vi.fn();
             }
         }
 
-        const embed = createEmbed(/** @type {any} */ (MockGenomeSpy));
+        const embed = createEmbed(/** @type {any} */ (ParamGenomeSpy));
         const element = document.createElement("div");
         const api = await embed(element, /** @type {any} */ ({}));
 
         expect(api.getParam("threshold")).toBe(paramApi);
+    });
+
+    test("leaves missing width implicit", async () => {
+        /** @type {MockGenomeSpy | undefined} */
+        let instance;
+        class CapturingGenomeSpy extends MockGenomeSpy {
+            /**
+             * @param {HTMLElement} element
+             * @param {any} spec
+             */
+            constructor(element, spec) {
+                super(element, spec);
+                instance = this;
+            }
+        }
+
+        const embed = createEmbed(/** @type {any} */ (CapturingGenomeSpy));
+        const element = document.createElement("div");
+        await embed(element, /** @type {any} */ ({}));
+
+        expect(instance.spec).toEqual({
+            baseUrl: "",
+            padding: 10,
+        });
     });
 });

--- a/packages/core/src/scales/scaleResolution.js
+++ b/packages/core/src/scales/scaleResolution.js
@@ -1279,6 +1279,9 @@ export default class ScaleResolution {
      * Returns the scale instance, creating it if needed.
      *
      * Use this from call sites that may run before explicit initialization.
+     * Creating the scale resolves default domains and may require loaded
+     * assemblies for locus scales. For side-effect-free type checks, use
+     * `getResolvedScaleType()`.
      *
      * @returns {ScaleWithProps}
      */

--- a/packages/core/src/spec/config.d.ts
+++ b/packages/core/src/spec/config.d.ts
@@ -12,6 +12,7 @@ import { Scale, SchemeParams } from "./scale.js";
 import { Title } from "./title.js";
 import { ViewBackgroundProps } from "./decoration.js";
 import { LegendConfig } from "./legend.js";
+import { Step } from "./view.js";
 
 export type BuiltInThemeName =
     | "genomespy"
@@ -21,7 +22,44 @@ export type BuiltInThemeName =
     | "fivethirtyeight"
     | "urbaninstitute";
 
-export type ViewConfig = ViewBackgroundProps;
+export interface ViewConfig extends ViewBackgroundProps {
+    /**
+     * The default width when the view has a continuous x scale.
+     *
+     * __Default value:__ `"container"`
+     */
+    continuousWidth?: number;
+
+    /**
+     * The default width when the view has a discrete x scale or no x scale.
+     * This may be a fixed width or a step size for each discrete domain value.
+     *
+     * __Default value:__ `"container"`
+     */
+    discreteWidth?: number | Step;
+
+    /**
+     * The default height when the view has a continuous y scale.
+     *
+     * __Default value:__ `"container"`
+     */
+    continuousHeight?: number;
+
+    /**
+     * The default height when the view has a discrete y scale or no y scale.
+     * This may be a fixed height or a step size for each discrete domain value.
+     *
+     * __Default value:__ `"container"`
+     */
+    discreteHeight?: number | Step;
+
+    /**
+     * Default step size for discrete view sizes.
+     *
+     * __Default value:__ none
+     */
+    step?: number;
+}
 
 export type MarkConfig = Partial<Omit<MarkPropsBase, "type">>;
 

--- a/packages/core/src/view/renderingContext/bufferedViewRenderingContext.test.js
+++ b/packages/core/src/view/renderingContext/bufferedViewRenderingContext.test.js
@@ -6,16 +6,22 @@ import BufferedViewRenderingContext from "./bufferedViewRenderingContext.js";
 describe("BufferedViewRenderingContext", () => {
     test("reuses viewport setup for value-equal mark clips", () => {
         const coords = Rectangle.create(0, 0, 20, 10);
-        const gl = {
-            COLOR_BUFFER_BIT: 0x4000,
-            SCISSOR_TEST: 0x0c11,
-            drawingBufferWidth: 100,
-            drawingBufferHeight: 100,
-            viewport: () => undefined,
-            disable: () => undefined,
-            clearColor: () => undefined,
-            clear: () => undefined,
-        };
+        const gl = /** @type {WebGL2RenderingContext} */ (
+            /** @type {unknown} */ ({
+                COLOR_BUFFER_BIT: 0x4000,
+                SCISSOR_TEST: 0x0c11,
+                drawingBufferWidth: 100,
+                drawingBufferHeight: 100,
+                /** @returns {void} */
+                viewport: () => undefined,
+                /** @returns {void} */
+                disable: () => undefined,
+                /** @returns {void} */
+                clearColor: () => undefined,
+                /** @returns {void} */
+                clear: () => undefined,
+            })
+        );
         let viewportSetups = 0;
         let draws = 0;
 
@@ -64,7 +70,10 @@ describe("BufferedViewRenderingContext", () => {
         const context = new BufferedViewRenderingContext(
             { picking: false },
             {
-                webGLHelper: { gl },
+                webGLHelper:
+                    /** @type {import("../../gl/webGLHelper.js").default} */ (
+                        /** @type {unknown} */ ({ gl })
+                    ),
                 canvasSize: { width: 100, height: 100 },
                 devicePixelRatio: 1,
             }

--- a/packages/core/src/view/testUtils.js
+++ b/packages/core/src/view/testUtils.js
@@ -31,13 +31,19 @@ import {
     createHeadlessEngine,
     createHeadlessViewContext,
 } from "../genomeSpy/headlessBootstrap.js";
+import { INTERNAL_DEFAULT_CONFIG } from "../config/defaultConfig.js";
+import { mergeConfigScopes } from "../config/mergeConfig.js";
+import { resolveBaseConfig } from "../config/resolveConfig.js";
+import { DEFAULT_THEME_NAME, resolveThemeSelection } from "../config/themes.js";
 
 /**
  * @param {import("./viewFactory.js").ViewFactoryOptions} [viewFactoryOptions]
+ * @param {Parameters<typeof createHeadlessViewContext>[0]} [contextOptions]
  * @returns
  */
-export function createTestViewContext(viewFactoryOptions = {}) {
+export function createTestViewContext(viewFactoryOptions = {}, contextOptions) {
     return createHeadlessViewContext({
+        ...contextOptions,
         viewFactoryOptions,
     });
 }
@@ -82,10 +88,15 @@ export function createBroadcastingTestViewContext(viewFactoryOptions = {}) {
 }
 
 /**
- * @type {<V extends import("./view.js").default>(spec: RootSpec, viewClass: { new(...args: any[]): V }, ViewFactoryOptions?: import("./viewFactory.js").ViewFactoryOptions) => Promise<V>}
+ * @type {<V extends import("./view.js").default>(spec: RootSpec, viewClass: { new(...args: any[]): V }, ViewFactoryOptions?: import("./viewFactory.js").ViewFactoryOptions, contextOptions?: Parameters<typeof createHeadlessViewContext>[0]) => Promise<V>}
  */
-export async function create(spec, viewClass, viewFactoryOptions = {}) {
-    const c = createTestViewContext(viewFactoryOptions);
+export async function create(
+    spec,
+    viewClass,
+    viewFactoryOptions = {},
+    contextOptions
+) {
+    const c = createTestViewContext(viewFactoryOptions, contextOptions);
     const view = await c.createOrImportView(
         /** @type {import("../spec/view.js").ViewSpec} */ (spec),
         null,
@@ -159,10 +170,21 @@ export function renderToLayout(view, coords) {
  * @param {import("./layout/rectangle.js").default} [coords]
  */
 export async function specToLayout(spec, viewFactoryOptions = {}, coords) {
-    const view = await create(/** @type {any} */ (spec), View, {
-        wrapRoot: true,
-        ...viewFactoryOptions,
+    const baseConfig = resolveBaseConfig({
+        defaultConfig: INTERNAL_DEFAULT_CONFIG,
+        builtInTheme: resolveThemeSelection(DEFAULT_THEME_NAME),
+        theme: mergeConfigScopes([resolveThemeSelection(spec.theme)]),
     });
+
+    const view = await create(
+        /** @type {any} */ (spec),
+        View,
+        {
+            wrapRoot: true,
+            ...viewFactoryOptions,
+        },
+        { baseConfig }
+    );
 
     return renderToLayout(view, coords);
 }

--- a/packages/core/src/view/view.js
+++ b/packages/core/src/view/view.js
@@ -405,7 +405,7 @@ export default class View {
      * @return {import("./layout/flexLayout.js").SizeDef}
      */
     #getDimensionSize(dimension) {
-        let value = this.spec[dimension];
+        const { value, implicit } = this.#getDimensionValue(dimension);
         const needsStepInvalidation = isStepSize(value);
 
         const viewport =
@@ -453,6 +453,10 @@ export default class View {
                 );
 
                 return { px: steps * stepSize, grow: 0 };
+            } else if (implicit) {
+                // Vega-Lite treats a missing positional channel as one
+                // discrete step. Keep explicit step sizes strict.
+                return { px: stepSize, grow: 0 };
             } else {
                 throw new ViewError(
                     `Cannot use step-based size with "${dimension}"!`,
@@ -467,6 +471,58 @@ export default class View {
         }
     }
 
+    /**
+     * @param {"width" | "height" | "viewportWidth" | "viewportHeight"} dimension
+     * @returns {{ value: "container" | number | import("../spec/view.js").SizeDef | import("../spec/view.js").Step | undefined, implicit: boolean }}
+     */
+    #getDimensionValue(dimension) {
+        const value = this.spec[dimension];
+        if (value != null) {
+            return { value, implicit: false };
+        }
+
+        const viewport =
+            dimension == "viewportWidth" || dimension == "viewportHeight";
+        if (viewport) {
+            return { value, implicit: false };
+        }
+
+        return {
+            value: this.#getConfiguredDefaultSize(
+                /** @type {"width" | "height"} */ (dimension)
+            ),
+            implicit: true,
+        };
+    }
+
+    /**
+     * @param {"width" | "height"} dimension
+     * @returns {number | import("../spec/view.js").Step | undefined}
+     */
+    #getConfiguredDefaultSize(dimension) {
+        const viewConfig = this.getConfig().view;
+        if (!viewConfig) {
+            return undefined;
+        }
+
+        const channel = dimension == "width" ? "x" : "y";
+        const scale = this.getScaleResolution(channel)?.getScale();
+        if (scale && !isDiscrete(scale.type)) {
+            return dimension == "width"
+                ? viewConfig.continuousWidth
+                : viewConfig.continuousHeight;
+        } else {
+            return (
+                (dimension == "width"
+                    ? viewConfig.discreteWidth
+                    : viewConfig.discreteHeight) ??
+                (viewConfig.step !== undefined
+                    ? { step: viewConfig.step }
+                    : undefined)
+            );
+        }
+    }
+
     registerStepSizeInvalidation() {
         this.#registerStepSizeInvalidationFor("width", "x");
         this.#registerStepSizeInvalidationFor("height", "y");
@@ -477,13 +533,17 @@ export default class View {
      * @param {import("../spec/channel.js").PrimaryPositionalChannel} channel
      */
     #registerStepSizeInvalidationFor(dimension, channel) {
-        const value = this.spec[dimension];
+        const { value, implicit } = this.#getDimensionValue(dimension);
         if (!isStepSize(value)) {
             return;
         }
 
         const resolution = this.getScaleResolution(channel);
         if (!resolution) {
+            if (implicit) {
+                return;
+            }
+
             throw new ViewError(
                 "Cannot use 'step' size without a scale!",
                 this

--- a/packages/core/src/view/view.js
+++ b/packages/core/src/view/view.js
@@ -506,8 +506,9 @@ export default class View {
         }
 
         const channel = dimension == "width" ? "x" : "y";
-        const scale = this.getScaleResolution(channel)?.getScale();
-        if (scale && !isDiscrete(scale.type)) {
+        const scaleType =
+            this.getScaleResolution(channel)?.getResolvedScaleType();
+        if (scaleType && !isDiscrete(scaleType)) {
             return dimension == "width"
                 ? viewConfig.continuousWidth
                 : viewConfig.continuousHeight;

--- a/packages/core/src/view/view.test.js
+++ b/packages/core/src/view/view.test.js
@@ -813,6 +813,125 @@ describe("Test domain handling", () => {
 });
 
 describe("Step sizing and domain updates", () => {
+    test("Implicit width and height use container sizing by default", async () => {
+        /** @type {import("../spec/view.js").UnitSpec} */
+        const spec = {
+            data: { values: [{ x: 1, y: 2 }] },
+            mark: "point",
+            encoding: {
+                x: { field: "x", type: "quantitative" },
+                y: { field: "y", type: "quantitative" },
+            },
+        };
+
+        const { view } = await createHeadlessEngine(spec);
+
+        expect(view.getSize().width).toEqual({ px: 0, grow: 1 });
+        expect(view.getSize().height).toEqual({ px: 0, grow: 1 });
+    });
+
+    test("Implicit continuous view size uses configured continuous defaults", async () => {
+        /** @type {import("../spec/view.js").UnitSpec} */
+        const spec = {
+            config: {
+                view: {
+                    continuousWidth: 123,
+                    continuousHeight: 456,
+                },
+            },
+            data: { values: [{ x: 1, y: 2 }] },
+            mark: "point",
+            encoding: {
+                x: { field: "x", type: "quantitative" },
+                y: { field: "y", type: "quantitative" },
+            },
+        };
+
+        const { view } = await createHeadlessEngine(spec);
+
+        expect(view.getSize().width).toEqual({ px: 123, grow: 0 });
+        expect(view.getSize().height).toEqual({ px: 456, grow: 0 });
+    });
+
+    test("Implicit discrete view size uses configured fixed discrete defaults", async () => {
+        /** @type {import("../spec/view.js").UnitSpec} */
+        const spec = {
+            config: {
+                view: {
+                    discreteWidth: 123,
+                    discreteHeight: 456,
+                },
+            },
+            data: { values: [{ x: "a", y: "b" }] },
+            mark: "point",
+            encoding: {
+                x: { field: "x", type: "nominal" },
+                y: { field: "y", type: "nominal" },
+            },
+        };
+
+        const { view } = await createHeadlessEngine(spec);
+
+        expect(view.getSize().width).toEqual({ px: 123, grow: 0 });
+        expect(view.getSize().height).toEqual({ px: 456, grow: 0 });
+    });
+
+    test("Implicit discrete view size uses configured step defaults", async () => {
+        /** @type {import("../spec/view.js").UnitSpec} */
+        const spec = {
+            config: {
+                view: {
+                    discreteWidth: { step: 10 },
+                    discreteHeight: { step: 20 },
+                },
+            },
+            data: {
+                values: [
+                    { x: "a", y: "d" },
+                    { x: "b", y: "e" },
+                    { x: "c", y: "f" },
+                ],
+            },
+            mark: "point",
+            encoding: {
+                x: { field: "x", type: "nominal" },
+                y: { field: "y", type: "nominal" },
+            },
+        };
+
+        const { view } = await createHeadlessEngine(spec);
+
+        expect(view.getSize().width.px).toBeCloseTo(30);
+        expect(view.getSize().height.px).toBeCloseTo(60);
+        expect(view.getSize().width.grow).toBe(0);
+        expect(view.getSize().height.grow).toBe(0);
+    });
+
+    test("Implicit discrete view size uses configured default step", async () => {
+        /** @type {import("../spec/view.js").UnitSpec} */
+        const spec = {
+            config: {
+                view: {
+                    step: 12,
+                },
+            },
+            data: {
+                values: [{ x: "a" }, { x: "b" }],
+            },
+            mark: "point",
+            encoding: {
+                x: { field: "x", type: "nominal" },
+                y: { value: 0 },
+            },
+        };
+
+        const { view } = await createHeadlessEngine(spec);
+
+        expect(view.getSize().width.px).toBeCloseTo(24);
+        expect(view.getSize().width.grow).toBe(0);
+        expect(view.getSize().height).toEqual({ px: 12, grow: 0 });
+    });
+
     test("Layer view width updates when discrete domain grows", async () => {
         // Non-obvious: step sizing depends on the x-scale domain, which is owned
         // by a child unit view. Ensure the parent layer size updates on data changes.


### PR DESCRIPTION
This PR adds Vega-Lite-style view size defaults while preserving GenomeSpy's existing implicit container sizing unless a theme or config opts into fixed continuous/discrete defaults.

Key points:
- Adds `config.view` sizing defaults for continuous and discrete views, with GenomeSpy's current container behavior retained by default.
- Sets the Vega-Lite-derived themes to use Vega-Lite defaults for continuous width/height and discrete step sizing.
- Keeps embed paths from forcing missing top-level width to `container`, allowing themed implicit sizing to take effect.
- Updates layout tests and helpers so root themes are resolved consistently in layout snapshots.