### PR TITLE
feat(core): add public view mutation API

### DIFF
--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -112,7 +112,7 @@ cover.
     selectors, layout bounds, and mutations under the actual mutable container
     behave predictably.
 
-13. Handle liveness under nested removal
+13. Handle liveness under nested removal - done
 
     Keep handles to a parent and its descendants, remove the parent subtree,
     then verify all descendant handles are dead and cannot be used for
@@ -309,9 +309,10 @@ during an in-flight shared load, async branch insertion/removal cancellation,
 shared guide ownership churn after add/move/remove operations, and inherited
 data insertion/removal, scoped params/subscription cleanup, repeated scoped spec
 insertion, nested container mutation, transaction batching, failed insertion
-rollback, move render freshness, implicit root behavior, duplicate names across
-scopes, and named data updates after mutation. It does not yet cover visibility
-toggles, encoding mutation, or URL/bookmark restore.
+rollback, move render freshness, implicit root behavior, handle liveness under
+nested removal, duplicate names across scopes, and named data updates after
+mutation. It does not yet cover visibility toggles, encoding mutation, or
+URL/bookmark restore.
 
 ## Testability considerations
 

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -74,7 +74,7 @@ cover.
    scopes. Verify independent handles, selectors, titles/data, no shared spec
    mutation, and correct removal of one instance.
 
-7. Nested containers
+7. Nested containers - done
 
    Mutate a named concat inside another concat, grid, or layer. Verify scoped
    selectors resolve through the hierarchy, implicit chrome is preserved, and
@@ -265,11 +265,11 @@ Suggested order:
 
    Commit shape: `test(core): cover repeated scoped spec insertion`.
 
-8. Next: Implement nested container mutation coverage.
+8. Done: Implement nested container mutation coverage.
 
    Commit shape: `test(core): cover nested container view mutations`.
 
-9. Implement transaction batching coverage.
+9. Next: Implement transaction batching coverage.
 
    Commit shape: `test(core): cover batched view mutation lifecycle`.
 
@@ -307,9 +307,9 @@ ownership.
 Current executable coverage includes round-trip cancellation, lazy insertion
 during an in-flight shared load, async branch insertion/removal cancellation,
 shared guide ownership churn after add/move/remove operations, and inherited
-data insertion/removal, scoped params/subscription cleanup, and repeated scoped
-spec insertion. It does not yet cover visibility toggles, encoding mutation, or
-URL/bookmark restore.
+data insertion/removal, scoped params/subscription cleanup, repeated scoped spec
+insertion, and nested container mutation. It does not yet cover visibility
+toggles, encoding mutation, or URL/bookmark restore.
 
 ## Testability considerations
 

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -28,14 +28,136 @@ cover.
 - Use synthetic specs with controlled data to make failures deterministic.
 - Include a slow/async data source to exercise in-flight load timing.
 
-## Mutation scenarios to cover (draft)
+## Mutation scenarios to cover
 
-- Toggle visibility of a hidden subtree with chrom/pos encodings.
-- Add/remove a subtree that shares a data source with an existing branch.
-- Reinsert a previously removed subtree with shared scales/axes.
-- Apply a complex speculative mutation sequence and cancel it immediately.
-- Switch visibility via URL hash/bookmark restore during initial load.
-- Mutate encodings (e.g., add a channel) and confirm mark encoders reinit.
+### Highest value
+
+1. Lazy source insertion during in-flight loading
+
+   Insert a new track that shares or uses a lazy/windowed data source while
+   another source is loading. Verify the inserted view receives data, renders,
+   and can be removed cleanly.
+
+2. Immediate cancel acid sequence with async data
+
+   Capture a baseline snapshot, insert an async/lazy track, reorder it, remove
+   it before or after data resolves, and compare the normalized hierarchy,
+   guides, flow handles, resolutions, and rendered layout with the baseline.
+
+3. Shared guide ownership churn
+
+   Use multiple tracks with a shared x axis and a shared color legend. Add,
+   remove, and reorder tracks so the owner of a shared axis or legend changes.
+   Verify guides remain present, measured, rendered, and free of stale guide
+   views. Also verify scale, axis, and legend resolution members match the
+   current live children and preserve correct domains after mutation.
+
+4. Inherited data insertion and removal
+
+   Use a container with inherited data and transforms, then insert tracks that
+   inherit that data instead of declaring their own source. Verify inserted
+   collectors attach to the correct upstream branch, inherited transforms are
+   applied once, removal leaves no stale observers, and canceling returns the
+   dataflow graph to its baseline shape.
+
+5. Parameter scopes and subscriptions
+
+   Insert and remove views that declare or reference params. Include scoped
+   repeated specs that use the same param names. Verify param scopes,
+   subscriptions, signal values, and expression dependencies are registered and
+   disposed with the view subtree, and that pre-existing param subscriptions
+   survive round-trip cancellation.
+
+6. Repeated same spec object with scopes
+
+   Insert the exact same `ViewSpec` object multiple times using different
+   scopes. Verify independent handles, selectors, titles/data, no shared spec
+   mutation, and correct removal of one instance.
+
+7. Nested containers
+
+   Mutate a named concat inside another concat, grid, or layer. Verify scoped
+   selectors resolve through the hierarchy, implicit chrome is preserved, and
+   sibling branches are unaffected.
+
+8. Transaction batching
+
+   In one transaction, insert several tracks, move one, and remove another.
+   Verify one final layout/render pass, stable final order, and no intermediate
+   stale guide or dataflow state leaks.
+
+9. Failure rollback after partial insertion
+
+   Force a failure after spec insertion but before full initialization, for
+   example with invalid assembly, data, font, or import setup. Verify backing
+   spec, live child list, guide views, dataflow collectors, and handles roll
+   back.
+
+10. Move render freshness
+
+   Reorder tracks where layout bounds change but data does not reload. Verify
+   the canvas changes immediately without resize and overlay controls update
+   from `subscribeToLayout()`.
+
+### Important secondary coverage
+
+11. Layer container semantics
+
+   Insert, remove, and reorder layer children. Verify z-order changes without
+   data reload and without incorrectly creating concat-style chrome.
+
+12. Implicit root behavior
+
+    Start from a root unit spec that is wrapped internally. Verify `root()`,
+    selectors, layout bounds, and mutations under the actual mutable container
+    behave predictably.
+
+13. Handle liveness under nested removal
+
+    Keep handles to a parent and its descendants, remove the parent subtree,
+    then verify all descendant handles are dead and cannot be used for
+    move/remove/layout-bounds operations.
+
+14. Duplicate names across scopes
+
+    Insert views with the same `name` under different scopes. Verify scoped
+    selectors resolve correctly and unscoped ambiguous selectors fail fast or
+    follow the documented behavior.
+
+15. Named data updates after mutation
+
+    Insert a track using `data.name`, call `updateNamedData()`, remove it, and
+    update the named data again. Verify no stale collectors or listeners remain.
+
+16. Visibility toggles
+
+    Insert hidden or conditionally visible views, toggle visibility, then remove
+    and reinsert them. Verify layout, guide ownership, and data initialization
+    remain consistent.
+
+17. Resize after mutation
+
+    Add, reorder, and remove tracks, resize the container, and verify layout
+    bounds, canvas rendering, axes, legends, and overlay controls remain
+    aligned.
+
+18. Import spec scope reuse
+
+    Import the same template multiple times with different scopes, then mutate,
+    remove, and reorder imported instances. Verify imported scope addressing and
+    cleanup.
+
+19. Complex undo round trip
+
+    Apply a realistic sequence: add a signal track, add a variants track, move
+    variants up, remove signal, then immediately undo to the original state.
+    Compare the normalized internal hierarchy with the baseline.
+
+20. Error ordering and serialization
+
+    Queue several mutations quickly, including one invalid operation. Verify
+    operation order, rejection behavior, and final hierarchy state are
+    deterministic.
 
 ## Round-trip cancellation invariant
 
@@ -71,8 +193,20 @@ reloads, or stale references may remain.
 
 - Every visible UnitView has a dataflow branch with a Collector.
 - Collectors for visible views receive data after initialization completes.
+- Views with inherited data attach to the correct upstream flow node and do not
+  duplicate inherited transforms.
+- Removing a subtree removes its dataflow observers, collectors, and named data
+  listeners without disturbing inherited-data users that remain live.
 - ScaleResolution members match the visible view set (no stray members).
+- Shared scale domains reflect the current live members after add/remove/reorder
+  and return to the baseline after round-trip cancellation.
 - Axis/gridline views exist and render for visible scale resolutions.
+- Shared axis and legend definitions match the current resolution owners and do
+  not retain removed views.
+- Param scopes, registered params, expression subscriptions, and signal values
+  match the live view hierarchy.
+- Removing or canceling a mutation disposes params introduced by that subtree
+  while preserving pre-existing param objects and subscriptions.
 - Encoders never see chrom/pos channel defs after linearization.
 - No extra data reloads when not needed; no missed reloads when required.
 - Canceling a speculative mutation restores the normalized internal snapshot.
@@ -87,6 +221,78 @@ reloads, or stale references may remain.
 - A verification layer that compares snapshots and inspects selected object
   identities where cancellation should preserve them.
 - A mocked slow data source to control load timing and partial propagation.
+
+## How to proceed next
+
+Implement the highest-value scenarios first. Each scenario should be its own
+commit so regressions, follow-up fixes, and review feedback can be traced to one
+behavioral concern at a time. If a scenario needs reusable test infrastructure,
+put that infrastructure in a small preparatory commit before the scenario that
+uses it.
+
+Suggested order:
+
+1. Add the minimum reusable acid-test harness needed for the next scenarios.
+   Keep this focused on normalized snapshots, selected identity checks, and
+   lifecycle settling. Do not broaden the harness beyond what the first new
+   scenario needs.
+
+   Commit shape: `test(core): factor view mutation acid test harness`.
+
+2. Implement lazy source insertion during in-flight loading.
+
+   Commit shape: `test(core): cover lazy insertion during in-flight loading`.
+
+3. Implement the immediate cancel sequence with async data.
+
+   Commit shape: `test(core): cover async mutation cancellation`.
+
+4. Implement shared guide ownership churn.
+
+   Commit shape: `test(core): cover shared guide ownership churn`.
+
+5. Implement inherited data insertion and removal.
+
+   Commit shape: `test(core): cover inherited data view mutations`.
+
+6. Implement parameter scopes and subscriptions.
+
+   Commit shape: `test(core): cover params across view mutations`.
+
+7. Implement repeated same-spec insertion with scopes.
+
+   Commit shape: `test(core): cover repeated scoped spec insertion`.
+
+8. Implement nested container mutation coverage.
+
+   Commit shape: `test(core): cover nested container view mutations`.
+
+9. Implement transaction batching coverage.
+
+   Commit shape: `test(core): cover batched view mutation lifecycle`.
+
+10. Implement failure rollback after partial insertion.
+
+    Commit shape: `test(core): cover failed insertion rollback`.
+
+11. Implement move render freshness coverage.
+
+    Commit shape: `test(core): cover render scheduling after view move`.
+
+After this highest-value batch, pause and evaluate the status before starting
+the secondary scenarios. The secondary scenarios may expose new API design or
+testability questions, so they should not be implemented mechanically before
+the first batch has been reviewed.
+
+When implementing the scenarios, fix trivial bugs as they are discovered. If the
+bug is local to the scenario, include the fix and regression coverage in the
+scenario commit. If the bug is incidental or affects existing behavior more
+broadly, make a separate `fix(core): ...` commit before continuing the scenario.
+
+If a scenario exposes a larger lifecycle or architecture issue that needs design
+discussion, document it in this plan, mark the scenario as deferred or blocked,
+and continue with the next independent scenario. One design issue should not
+stall the whole acid-test expansion.
 
 ## Initial executable coverage
 
@@ -103,15 +309,62 @@ restore.
 
 ## Testability considerations
 
-To make acid testing feasible and reliable, some architectural improvements may
-be needed. Areas to revisit:
+To make acid testing feasible and reliable, some testing infrastructure should
+be factored out of the first acid test and strengthened. These changes should
+stay in test utilities unless the production API needs the same capability.
 
-- Provide a minimal, headless test context for view creation and dataflow (see
-  view context responsibilities in `ARCHITECTURE.md`).
-- Expose stable inspection hooks for flow nodes and scale resolutions.
-- Allow deterministic control of async load completion (test hooks/mocks).
-- Make lifecycle boundaries explicit (e.g., "data ready" for subtree).
-- Avoid hidden side effects that require a full render loop to stabilize state.
+- Extract a reusable mutation acid harness.
+
+  The current acid test has local snapshot helpers. Move the stable parts into
+  test utilities so new scenarios can reuse a common setup: create a headless
+  engine, create the view API, render to a stable layout snapshot, apply ordered
+  mutations, await stabilization, and compare normalized snapshots.
+
+- Define a stable normalized hierarchy representation.
+
+  The snapshot should intentionally represent public and lifecycle-relevant
+  facts: view names, types, layout/data parents, child order, visibility, data
+  init state, flow handle presence, generated chrome, and resolution summaries.
+  It should avoid incidental object shapes that make tests brittle.
+
+- Add identity assertions as an explicit helper.
+
+  Round-trip cancellation tests need both structural equality and selected
+  identity preservation for pre-existing views, collectors, data sources, scale
+  resolutions, and guide views. A helper should make these expectations explicit
+  per scenario.
+
+- Provide deterministic async/lazy data test sources.
+
+  In-flight data scenarios need controllable promises or a mock lazy source that
+  can pause, resolve, reject, and report request counts. Without this, tests
+  either become timing-sensitive or miss the real lifecycle risk.
+
+- Add lifecycle settle helpers.
+
+  Tests need a clear way to await mutation completion, data readiness, guide
+  rebuild, layout computation, and render scheduling. Existing mutation promises
+  cover operation-specific work, but async source and visibility tests need a
+  reusable "settle until stable" helper.
+
+- Improve dataflow inspection for tests.
+
+  Acid scenarios should inspect collector/source counts, observer membership,
+  loading status, and branch ownership without traversing private implementation
+  details ad hoc in every test.
+
+- Improve guide/resolution inspection for tests.
+
+  Existing code can inspect scale, axis, and legend resolutions, but the shape
+  should be centralized so tests can compare guide ownership churn and stale
+  members consistently.
+
+- Keep browser-level checks separate from core acid tests.
+
+  Scenarios such as overlay alignment and immediate canvas refresh are useful,
+  but they involve DOM/canvas behavior. Core acid tests should verify layout
+  bounds and render scheduling; browser smoke tests can verify actual overlay
+  positioning.
 
 ## Items that need further analysis
 

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -80,7 +80,7 @@ cover.
    selectors resolve through the hierarchy, implicit chrome is preserved, and
    sibling branches are unaffected.
 
-8. Transaction batching
+8. Transaction batching - done
 
    In one transaction, insert several tracks, move one, and remove another.
    Verify one final layout/render pass, stable final order, and no intermediate
@@ -269,11 +269,11 @@ Suggested order:
 
    Commit shape: `test(core): cover nested container view mutations`.
 
-9. Next: Implement transaction batching coverage.
+9. Done: Implement transaction batching coverage.
 
    Commit shape: `test(core): cover batched view mutation lifecycle`.
 
-10. Implement failure rollback after partial insertion.
+10. Next: Implement failure rollback after partial insertion.
 
     Commit shape: `test(core): cover failed insertion rollback`.
 
@@ -308,8 +308,8 @@ Current executable coverage includes round-trip cancellation, lazy insertion
 during an in-flight shared load, async branch insertion/removal cancellation,
 shared guide ownership churn after add/move/remove operations, and inherited
 data insertion/removal, scoped params/subscription cleanup, repeated scoped spec
-insertion, and nested container mutation. It does not yet cover visibility
-toggles, encoding mutation, or URL/bookmark restore.
+insertion, nested container mutation, and transaction batching. It does not yet
+cover visibility toggles, encoding mutation, or URL/bookmark restore.
 
 ## Testability considerations
 

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -106,7 +106,7 @@ cover.
    Insert, remove, and reorder layer children. Verify z-order changes without
    data reload and without incorrectly creating concat-style chrome.
 
-12. Implicit root behavior
+12. Implicit root behavior - done
 
     Start from a root unit spec that is wrapped internally. Verify `root()`,
     selectors, layout bounds, and mutations under the actual mutable container
@@ -309,8 +309,8 @@ during an in-flight shared load, async branch insertion/removal cancellation,
 shared guide ownership churn after add/move/remove operations, and inherited
 data insertion/removal, scoped params/subscription cleanup, repeated scoped spec
 insertion, nested container mutation, transaction batching, failed insertion
-rollback, and move render freshness. It does not yet cover visibility toggles,
-encoding mutation, or URL/bookmark restore.
+rollback, move render freshness, and implicit root behavior. It does not yet
+cover visibility toggles, encoding mutation, or URL/bookmark restore.
 
 ## Testability considerations
 

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -93,7 +93,7 @@ cover.
    spec, live child list, guide views, dataflow collectors, and handles roll
    back.
 
-10. Move render freshness
+10. Move render freshness - done
 
    Reorder tracks where layout bounds change but data does not reload. Verify
    the canvas changes immediately without resize and overlay controls update
@@ -277,7 +277,7 @@ Suggested order:
 
     Commit shape: `test(core): cover failed insertion rollback`.
 
-11. Next: Implement move render freshness coverage.
+11. Done: Implement move render freshness coverage.
 
     Commit shape: `test(core): cover render scheduling after view move`.
 
@@ -308,9 +308,9 @@ Current executable coverage includes round-trip cancellation, lazy insertion
 during an in-flight shared load, async branch insertion/removal cancellation,
 shared guide ownership churn after add/move/remove operations, and inherited
 data insertion/removal, scoped params/subscription cleanup, repeated scoped spec
-insertion, nested container mutation, transaction batching, and failed insertion
-rollback. It does not yet cover visibility toggles, encoding mutation, or
-URL/bookmark restore.
+insertion, nested container mutation, transaction batching, failed insertion
+rollback, and move render freshness. It does not yet cover visibility toggles,
+encoding mutation, or URL/bookmark restore.
 
 ## Testability considerations
 

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -60,7 +60,7 @@ cover.
    applied once, removal leaves no stale observers, and canceling returns the
    dataflow graph to its baseline shape.
 
-5. Parameter scopes and subscriptions
+5. Parameter scopes and subscriptions - done
 
    Insert and remove views that declare or reference params. Include scoped
    repeated specs that use the same param names. Verify param scopes,
@@ -257,11 +257,11 @@ Suggested order:
 
    Commit shape: `test(core): cover inherited data view mutations`.
 
-6. Next: Implement parameter scopes and subscriptions.
+6. Done: Implement parameter scopes and subscriptions.
 
    Commit shape: `test(core): cover params across view mutations`.
 
-7. Implement repeated same-spec insertion with scopes.
+7. Next: Implement repeated same-spec insertion with scopes.
 
    Commit shape: `test(core): cover repeated scoped spec insertion`.
 
@@ -307,8 +307,8 @@ ownership.
 Current executable coverage includes round-trip cancellation, lazy insertion
 during an in-flight shared load, async branch insertion/removal cancellation,
 shared guide ownership churn after add/move/remove operations, and inherited
-data insertion/removal. It does not yet cover params, visibility toggles,
-encoding mutation, or URL/bookmark restore.
+data insertion/removal, and scoped params/subscription cleanup. It does not yet
+cover visibility toggles, encoding mutation, or URL/bookmark restore.
 
 ## Testability considerations
 
@@ -388,3 +388,8 @@ stay in test utilities unless the production API needs the same capability.
 - Implicit coupling between view creation and dataflow initialization (tracked
   in `ARCHITECTURE.md`).
 - Lack of a formal mutation API that enforces lifecycle ordering.
+- Parameter-driven scale-domain changes can affect axis extents and layout
+  caches even after the parameter value is reset. This is broader than mutation
+  cleanup, so the current params acid scenario audits hierarchy and
+  subscription cleanup but leaves layout-cache invalidation for separate
+  analysis.

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -32,19 +32,19 @@ cover.
 
 ### Highest value
 
-1. Lazy source insertion during in-flight loading
+1. Lazy source insertion during in-flight loading - done
 
    Insert a new track that shares or uses a lazy/windowed data source while
    another source is loading. Verify the inserted view receives data, renders,
    and can be removed cleanly.
 
-2. Immediate cancel acid sequence with async data
+2. Immediate cancel acid sequence with async data - done
 
    Capture a baseline snapshot, insert an async/lazy track, reorder it, remove
    it before or after data resolves, and compare the normalized hierarchy,
    guides, flow handles, resolutions, and rendered layout with the baseline.
 
-3. Shared guide ownership churn
+3. Shared guide ownership churn - done
 
    Use multiple tracks with a shared x axis and a shared color legend. Add,
    remove, and reorder tracks so the owner of a shared axis or legend changes.
@@ -232,26 +232,28 @@ uses it.
 
 Suggested order:
 
-1. Add the minimum reusable acid-test harness needed for the next scenarios.
+1. Done: Add the minimum reusable acid-test harness needed for the next
+   scenarios.
+
    Keep this focused on normalized snapshots, selected identity checks, and
    lifecycle settling. Do not broaden the harness beyond what the first new
    scenario needs.
 
    Commit shape: `test(core): factor view mutation acid test harness`.
 
-2. Implement lazy source insertion during in-flight loading.
+2. Done: Implement lazy source insertion during in-flight loading.
 
    Commit shape: `test(core): cover lazy insertion during in-flight loading`.
 
-3. Implement the immediate cancel sequence with async data.
+3. Done: Implement the immediate cancel sequence with async data.
 
    Commit shape: `test(core): cover async mutation cancellation`.
 
-4. Implement shared guide ownership churn.
+4. Done: Implement shared guide ownership churn.
 
    Commit shape: `test(core): cover shared guide ownership churn`.
 
-5. Implement inherited data insertion and removal.
+5. Next: Implement inherited data insertion and removal.
 
    Commit shape: `test(core): cover inherited data view mutations`.
 
@@ -296,16 +298,17 @@ stall the whole acid-test expansion.
 
 ## Initial executable coverage
 
-`packages/core/src/view/viewMutationApi.acid.test.js` contains the first
-round-trip cancellation scenario. It captures a normalized internal hierarchy
-snapshot, rendered layout snapshot, and selected object identities, then applies
-an add/reorder/remove mutation sequence inside a transaction and verifies that
-the pre-existing hierarchy is restored.
+`packages/core/src/view/viewMutationApi.acid.test.js` contains the reusable
+acid-test harness and the first batch of executable scenarios. The covered
+scenarios capture normalized internal hierarchy snapshots, rendered layout
+snapshots, selected object identities, dataflow object counts, and shared guide
+ownership.
 
-This first scenario covers generated guide/chrome views, flow handles,
-scale/axis/legend resolution summaries, and layout output. It does not yet cover
-slow data sources, visibility toggles, encoding mutation, or URL/bookmark
-restore.
+Current executable coverage includes round-trip cancellation, lazy insertion
+during an in-flight shared load, async branch insertion/removal cancellation,
+and shared guide ownership churn after add/move/remove operations. It does not
+yet cover inherited data, params, visibility toggles, encoding mutation, or
+URL/bookmark restore.
 
 ## Testability considerations
 

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -68,7 +68,7 @@ cover.
    disposed with the view subtree, and that pre-existing param subscriptions
    survive round-trip cancellation.
 
-6. Repeated same spec object with scopes
+6. Repeated same spec object with scopes - done
 
    Insert the exact same `ViewSpec` object multiple times using different
    scopes. Verify independent handles, selectors, titles/data, no shared spec
@@ -261,11 +261,11 @@ Suggested order:
 
    Commit shape: `test(core): cover params across view mutations`.
 
-7. Next: Implement repeated same-spec insertion with scopes.
+7. Done: Implement repeated same-spec insertion with scopes.
 
    Commit shape: `test(core): cover repeated scoped spec insertion`.
 
-8. Implement nested container mutation coverage.
+8. Next: Implement nested container mutation coverage.
 
    Commit shape: `test(core): cover nested container view mutations`.
 
@@ -307,8 +307,9 @@ ownership.
 Current executable coverage includes round-trip cancellation, lazy insertion
 during an in-flight shared load, async branch insertion/removal cancellation,
 shared guide ownership churn after add/move/remove operations, and inherited
-data insertion/removal, and scoped params/subscription cleanup. It does not yet
-cover visibility toggles, encoding mutation, or URL/bookmark restore.
+data insertion/removal, scoped params/subscription cleanup, and repeated scoped
+spec insertion. It does not yet cover visibility toggles, encoding mutation, or
+URL/bookmark restore.
 
 ## Testability considerations
 

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -124,7 +124,7 @@ cover.
     selectors resolve correctly and unscoped ambiguous selectors fail fast or
     follow the documented behavior.
 
-15. Named data updates after mutation
+15. Named data updates after mutation - done
 
     Insert a track using `data.name`, call `updateNamedData()`, remove it, and
     update the named data again. Verify no stale collectors or listeners remain.
@@ -309,9 +309,9 @@ during an in-flight shared load, async branch insertion/removal cancellation,
 shared guide ownership churn after add/move/remove operations, and inherited
 data insertion/removal, scoped params/subscription cleanup, repeated scoped spec
 insertion, nested container mutation, transaction batching, failed insertion
-rollback, move render freshness, implicit root behavior, and duplicate names
-across scopes. It does not yet cover visibility toggles, encoding mutation, or
-URL/bookmark restore.
+rollback, move render freshness, implicit root behavior, duplicate names across
+scopes, and named data updates after mutation. It does not yet cover visibility
+toggles, encoding mutation, or URL/bookmark restore.
 
 ## Testability considerations
 

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -86,7 +86,7 @@ cover.
    Verify one final layout/render pass, stable final order, and no intermediate
    stale guide or dataflow state leaks.
 
-9. Failure rollback after partial insertion
+9. Failure rollback after partial insertion - done
 
    Force a failure after spec insertion but before full initialization, for
    example with invalid assembly, data, font, or import setup. Verify backing
@@ -273,11 +273,11 @@ Suggested order:
 
    Commit shape: `test(core): cover batched view mutation lifecycle`.
 
-10. Next: Implement failure rollback after partial insertion.
+10. Done: Implement failure rollback after partial insertion.
 
     Commit shape: `test(core): cover failed insertion rollback`.
 
-11. Implement move render freshness coverage.
+11. Next: Implement move render freshness coverage.
 
     Commit shape: `test(core): cover render scheduling after view move`.
 
@@ -308,8 +308,9 @@ Current executable coverage includes round-trip cancellation, lazy insertion
 during an in-flight shared load, async branch insertion/removal cancellation,
 shared guide ownership churn after add/move/remove operations, and inherited
 data insertion/removal, scoped params/subscription cleanup, repeated scoped spec
-insertion, nested container mutation, and transaction batching. It does not yet
-cover visibility toggles, encoding mutation, or URL/bookmark restore.
+insertion, nested container mutation, transaction batching, and failed insertion
+rollback. It does not yet cover visibility toggles, encoding mutation, or
+URL/bookmark restore.
 
 ## Testability considerations
 

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -118,7 +118,7 @@ cover.
     then verify all descendant handles are dead and cannot be used for
     move/remove/layout-bounds operations.
 
-14. Duplicate names across scopes
+14. Duplicate names across scopes - done
 
     Insert views with the same `name` under different scopes. Verify scoped
     selectors resolve correctly and unscoped ambiguous selectors fail fast or
@@ -309,8 +309,9 @@ during an in-flight shared load, async branch insertion/removal cancellation,
 shared guide ownership churn after add/move/remove operations, and inherited
 data insertion/removal, scoped params/subscription cleanup, repeated scoped spec
 insertion, nested container mutation, transaction batching, failed insertion
-rollback, move render freshness, and implicit root behavior. It does not yet
-cover visibility toggles, encoding mutation, or URL/bookmark restore.
+rollback, move render freshness, implicit root behavior, and duplicate names
+across scopes. It does not yet cover visibility toggles, encoding mutation, or
+URL/bookmark restore.
 
 ## Testability considerations
 

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -17,6 +17,8 @@ cover.
 - Verify dataflow wiring and propagation when views are initialized lazily.
 - Ensure scale/axis resolution stays consistent across dynamic changes.
 - Detect UI-visible issues such as missing marks, axes, or stale domains.
+- Ensure complex mutations that are canceled immediately leave the internal
+  hierarchy effectively identical to the pre-mutation state.
 
 ## Proposed scope (initial draft)
 
@@ -31,8 +33,39 @@ cover.
 - Toggle visibility of a hidden subtree with chrom/pos encodings.
 - Add/remove a subtree that shares a data source with an existing branch.
 - Reinsert a previously removed subtree with shared scales/axes.
+- Apply a complex speculative mutation sequence and cancel it immediately.
 - Switch visibility via URL hash/bookmark restore during initial load.
 - Mutate encodings (e.g., add a channel) and confirm mark encoders reinit.
+
+## Round-trip cancellation invariant
+
+Acid tests should include "round-trip no-op" scenarios. The test should capture
+a stable internal snapshot, apply a complex mutation sequence, cancel or undo it
+immediately, await lifecycle stabilization, and compare the resulting state with
+the baseline.
+
+The comparison should not require raw object identity everywhere. It should use
+a normalized representation of the relevant internal state, with targeted
+identity checks for objects that are expected to survive cancellation, such as
+pre-existing views, shared data sources, collectors, scale resolutions, and
+parameter scopes.
+
+The snapshot should cover:
+
+- View hierarchy structure, names, import scopes, types, visibility, data init
+  states, and parent relationships.
+- Dataflow sources, collectors, branch shape, observer counts, and loading
+  statuses.
+- Scale, axis, and legend resolution membership and view-level config
+  attachments.
+- Axis, gridline, legend, separator, title, and other generated guide/chrome
+  views.
+- Param scopes, registered params, subscriptions, and lifecycle owner state.
+- Layout-relevant cached state or a stable rendered/layout hierarchy snapshot.
+
+The post-cancel state should be effectively identical to the baseline: no extra
+collectors, listeners, guide views, resolution members, param scopes, data
+reloads, or stale references may remain.
 
 ## Invariants to assert (draft)
 
@@ -42,13 +75,17 @@ cover.
 - Axis/gridline views exist and render for visible scale resolutions.
 - Encoders never see chrom/pos channel defs after linearization.
 - No extra data reloads when not needed; no missed reloads when required.
+- Canceling a speculative mutation restores the normalized internal snapshot.
 
 ## Test harness outline (draft)
 
 - A spec builder that can generate a small, layered layout with shared scales
   (matching the view hierarchy and resolution rules in `ARCHITECTURE.md`).
 - A mutation driver that can apply ordered changes and await completion.
-- A verification layer that inspects views, flow nodes, and scale resolutions.
+- A stable snapshot collector for views, dataflow, resolutions, generated
+  guide/chrome views, params, subscriptions, and layout output.
+- A verification layer that compares snapshots and inspects selected object
+  identities where cancellation should preserve them.
 - A mocked slow data source to control load timing and partial propagation.
 
 ## Testability considerations

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -88,6 +88,19 @@ reloads, or stale references may remain.
   identities where cancellation should preserve them.
 - A mocked slow data source to control load timing and partial propagation.
 
+## Initial executable coverage
+
+`packages/core/src/view/viewMutationApi.acid.test.js` contains the first
+round-trip cancellation scenario. It captures a normalized internal hierarchy
+snapshot, rendered layout snapshot, and selected object identities, then applies
+an add/reorder/remove mutation sequence inside a transaction and verifies that
+the pre-existing hierarchy is restored.
+
+This first scenario covers generated guide/chrome views, flow handles,
+scale/axis/legend resolution summaries, and layout output. It does not yet cover
+slow data sources, visibility toggles, encoding mutation, or URL/bookmark
+restore.
+
 ## Testability considerations
 
 To make acid testing feasible and reliable, some architectural improvements may

--- a/MUTATION_ACID_TEST_PLAN.md
+++ b/MUTATION_ACID_TEST_PLAN.md
@@ -52,7 +52,7 @@ cover.
    views. Also verify scale, axis, and legend resolution members match the
    current live children and preserve correct domains after mutation.
 
-4. Inherited data insertion and removal
+4. Inherited data insertion and removal - done
 
    Use a container with inherited data and transforms, then insert tracks that
    inherit that data instead of declaring their own source. Verify inserted
@@ -253,11 +253,11 @@ Suggested order:
 
    Commit shape: `test(core): cover shared guide ownership churn`.
 
-5. Next: Implement inherited data insertion and removal.
+5. Done: Implement inherited data insertion and removal.
 
    Commit shape: `test(core): cover inherited data view mutations`.
 
-6. Implement parameter scopes and subscriptions.
+6. Next: Implement parameter scopes and subscriptions.
 
    Commit shape: `test(core): cover params across view mutations`.
 
@@ -306,9 +306,9 @@ ownership.
 
 Current executable coverage includes round-trip cancellation, lazy insertion
 during an in-flight shared load, async branch insertion/removal cancellation,
-and shared guide ownership churn after add/move/remove operations. It does not
-yet cover inherited data, params, visibility toggles, encoding mutation, or
-URL/bookmark restore.
+shared guide ownership churn after add/move/remove operations, and inherited
+data insertion/removal. It does not yet cover params, visibility toggles,
+encoding mutation, or URL/bookmark restore.
 
 ## Testability considerations
 

--- a/VIEW_MUTATION_API_PLAN.md
+++ b/VIEW_MUTATION_API_PLAN.md
@@ -440,21 +440,21 @@ harness that can drive ordered mutations and inspect stable invariants.
 
 ## Suggested Implementation Steps
 
-1. Keep the public declaration surface in
+1. **Done.** Keep the public declaration surface in
    `packages/core/src/types/embedApi.d.ts` as the compatibility contract. Changes
    after the first release should be additive unless a breaking change is
    explicitly versioned.
 
-   Tentative commit: `feat(core): declare view mutation API`.
+   Commit: `4c0082b9 feat(core): add view mutation API declarations`.
 
-2. Add a small internal `viewMutationApi` module that owns `ViewHandle`
+2. **Done.** Add a small internal `viewMutationApi` module that owns `ViewHandle`
    creation, handle liveness, address resolution, operation serialization, and
    public error shaping with simple stable error codes. It should wrap internal
    `View` objects without exposing them.
 
-   Tentative commit: `feat(core): add view mutation API facade`.
+   Commit: `af0a632c feat: add view mutation API facade`.
 
-3. Add a new `packages/embed-examples` development example early, for example
+3. **Done.** Add a new `packages/embed-examples` development example early, for example
    `viewMutationApi.html` and `viewMutationApi.js`, and link it from
    `packages/embed-examples/src/index.html`. Start with the smallest working
    flow as soon as `api.views.root()` and address resolution exist, then keep
@@ -464,16 +464,20 @@ harness that can drive ordered mutations and inspect stable invariants.
    view, reordering tracks with `move()`, removing a track, and showing a
    compact UI state derived from handles.
 
-   Tentative commit: `feat(embed-examples): add view mutation API example`.
+   Commits: `af0a632c feat: add view mutation API facade`,
+   `745af1bb feat(core): implement view insertion API`,
+   `5df2420e feat(core): implement view removal API`,
+   `9191bbb4 feat(core): implement view reordering API`, and
+   `6055f733 chore(embed-example): update example`.
 
-4. Attach `views: createViewMutationApi(genomeSpy)` in `embedFactory.js`.
+4. **Done.** Attach `views: createViewMutationApi(genomeSpy)` in `embedFactory.js`.
    `GenomeSpy` already owns `viewRoot`, layout/render hooks, dataflow, and the
    context needed by the mutation coordinator, so the API factory should use
    those existing entry points instead of duplicating lifecycle state.
 
-   Tentative commit: `feat(core): expose view mutation API from embed`.
+   Commit: `af0a632c feat: add view mutation API facade`.
 
-5. Generalize selector scope registration. The existing import-scope machinery
+5. **Done.** Generalize selector scope registration. The existing import-scope machinery
    can already resolve scoped selectors, but `options.scope` must work for
    ordinary `ViewSpec` insertions as well as `ImportSpec` insertions. Consider
    renaming or wrapping `registerImportInstance()` internally so the mutation
@@ -481,72 +485,87 @@ harness that can drive ordered mutations and inspect stable invariants.
    model import-specific. Reject duplicate named scopes in the same enclosing
    selector scope before committing an insertion.
 
-   Tentative commit: `feat(core): support mutation scopes for direct specs`.
+   Commit: `745af1bb feat(core): implement view insertion API`.
 
-6. Harden index handling before exposing it publicly. Validate insert and move
+6. **Done.** Harden index handling before exposing it publicly. Validate insert and move
    indices explicitly instead of relying on `Array.splice()` semantics. Use the
    documented move rule: destination index is interpreted after temporarily
    removing the target from its current parent.
 
-   Tentative commit: `fix(core): validate view mutation indices`.
+   Commits: `745af1bb feat(core): implement view insertion API` and
+   `9191bbb4 feat(core): implement view reordering API`.
 
-7. Refactor container mutation lifecycle so public insert/remove operations call
+7. **Done for the initial API.** Refactor container mutation lifecycle so public insert/remove operations call
    one coordinator. The coordinator should cover create/import, spec cloning,
    backing spec updates, view insertion/removal, config reattachment, assembly
    preflight, opacity setup, subtree dataflow/graphics initialization, guide
    refresh, layout invalidation, and render scheduling.
 
-   Tentative commit: `refactor(core): centralize view mutation lifecycle`.
+   Commits: `745af1bb feat(core): implement view insertion API`,
+   `5df2420e feat(core): implement view removal API`, and
+   `3390f9c4 fix(core): initialize chrome for inserted views`.
+   Remaining reliability work is tracked separately in steps 10 and 11.
 
-8. Add non-disposing same-parent reorder support to `ConcatView`, `LayerView`,
+8. **Done.** Add non-disposing same-parent reorder support to `ConcatView`, `LayerView`,
    and shared helper code. Reorder must update both the backing spec list and
    live child list without rebuilding dataflow, disposing collectors, or
    reloading data.
 
-   Tentative commit: `feat(core): support same-parent view reordering`.
+   Commit: `9191bbb4 feat(core): implement view reordering API`.
 
-9. Add a guide/chrome refresh helper that covers the same artifacts after
+9. **Partial.** Add a guide/chrome refresh helper that covers the same artifacts after
    mutation as initial setup does: shared axes, grid-child axes and gridlines,
    shared legends, local legend regions, and relevant layout decorations. The
    current dynamic path already refreshes shared axes, but public mutation needs
    a single helper that includes legends too.
 
-   Tentative commit: `fix(core): refresh guides consistently after mutations`.
+   Current work initializes newly created chrome for inserted views:
+   `3390f9c4 fix(core): initialize chrome for inserted views`. A single
+   consolidated guide/chrome refresh helper is still pending.
 
-10. Replace the insertion data-loading path with logic compatible with
+10. **Done.** Replace the insertion data-loading path with logic compatible with
    `initializeVisibleViewData`. Inserted branches should repropagate completed
    ancestor collectors when possible, queue reloads for sources already loading,
    and load new subtree-owned sources directly.
 
+    Implemented by extracting a shared selected-view initialization helper from
+    `initializeVisibleViewData` and using it for dynamic insertions. This also
+    makes inserted branches wait for newly requested fonts before loading data.
+
     Tentative commit: `fix(core): populate inserted view data reliably`.
 
-11. Implement operation-level rollback for failed insertions. If an insertion
+11. **Todo.** Implement operation-level rollback for failed insertions. If an insertion
     has touched the backing spec or live hierarchy before a later lifecycle step
     fails, remove the partial view/spec, dispose the subtree, refresh configs and
     guides, then rethrow the original error.
 
     Tentative commit: `fix(core): roll back failed view insertions`.
 
-12. Implement `transaction()` as ordered operation batching. The first version
+12. **Partial.** Implement `transaction()` as ordered operation batching. The first version
     can avoid full transaction rollback, but it should defer layout/render work
     until the callback finishes and then run final lifecycle cleanup once.
     Nested transactions should join the active transaction.
 
+    The facade currently serializes operations and lets nested transactions join
+    the active operation queue, but layout/render deferral and final lifecycle
+    cleanup batching are still pending.
+
     Tentative commit: `feat(core): batch view mutation transactions`.
 
-13. Add focused unit tests close to the lifecycle code for address resolution,
+13. **Done for current behavior.** Add focused unit tests close to the lifecycle code for address resolution,
     handle liveness, scoped ordinary-spec insertion, index validation,
     insert/remove/reorder behavior, and guide/dataflow invariants.
 
-    Tentative commit: `test(core): cover view mutation API behavior`.
+    Covered across `af0a632c`, `745af1bb`, `5df2420e`, `9191bbb4`, and
+    `3390f9c4`. Additional tests should be added with future lifecycle work.
 
-14. Expand the acid-test plan into executable mutation scenarios that compare a
+14. **Todo.** Expand the acid-test plan into executable mutation scenarios that compare a
     normalized internal hierarchy before and after complex mutation sequences
     that are canceled immediately.
 
     Tentative commit: `test(core): add view mutation acid scenarios`.
 
-15. Document the public API in `docs/api.md` once the runtime behavior and
+15. **Todo.** Document the public API in `docs/api.md` once the runtime behavior and
     example have stabilized.
 
     Tentative commit: `docs(core): document view mutation API`.

--- a/VIEW_MUTATION_API_PLAN.md
+++ b/VIEW_MUTATION_API_PLAN.md
@@ -116,12 +116,12 @@ The existing embed API is mostly a set of narrow handles and named resources:
 `getParam(name)` returns a `ParamApi`, `getScaleResolutionByName(name)` returns
 a `ScaleResolutionApi`, `updateNamedData(name, data)` mutates a named data
 source, and `awaitVisibleLazyData()` provides a lifecycle barrier. The view
-mutation API should align with the better parts of that model by exposing a
+hierarchy API should align with the better parts of that model by exposing a
 small handle-based surface rather than internal view objects.
 
 The main improvement should be addressing. Some existing APIs are name-only,
 which can become ambiguous as specifications grow or as templates are reused.
-`ViewMutationApi` should establish the cleaner pattern for new public APIs:
+`ViewApi` should establish the cleaner pattern for new public APIs:
 scoped selectors for durable addresses, opaque live handles for runtime
 operations, and additive evolution for compatibility.
 
@@ -139,12 +139,15 @@ This creates useful synergies with the current API:
 The API should not copy the weaker parts of the existing surface. In
 particular, avoid a primary mutation form like `addView("tracks", spec)` where
 `"tracks"` is a global view name. Keep the old API stable, but let
-`ViewMutationApi` use scoped selectors and handles as the conservative public
+`ViewApi` use scoped selectors and handles as the conservative public
 contract going forward.
+The public namespace can also expose read-only layout observation, such as
+view bounds and layout subscriptions, because those operations use the same
+addresses and handles without exposing internal `View` objects.
 
 ## Recommended Public API
 
-Expose a namespaced mutation API on `EmbedResult`:
+Expose a namespaced view hierarchy API on `EmbedResult`:
 
 ```ts
 const api = await embed(container, spec);
@@ -163,15 +166,17 @@ Type sketch:
 
 ```ts
 interface EmbedResult {
-  views: ViewMutationApi;
+  views: ViewApi;
 }
 
 type ViewAddress = ViewHandle | ViewSelector | "root";
 
-interface ViewMutationApi {
+interface ViewApi {
   root(): ViewHandle;
   resolve(address: ViewAddress): ViewHandle | undefined;
   get(address: ViewAddress): ViewHandle;
+  getLayoutBounds(address: ViewAddress): ViewLayoutBounds | undefined;
+  subscribeToLayout(listener: () => void): () => void;
   insert(
     parent: ViewAddress,
     spec: ViewSpec | ImportSpec,
@@ -180,8 +185,15 @@ interface ViewMutationApi {
   remove(target: ViewAddress): Promise<void>;
   move(target: ViewAddress, options: { index: number }): Promise<ViewHandle>;
   transaction<T>(
-    callback: (views: ViewMutationApi) => T | Promise<T>
+    callback: (views: ViewApi) => T | Promise<T>
   ): Promise<T>;
+}
+
+interface ViewLayoutBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 }
 
 interface InsertOptions {
@@ -590,8 +602,21 @@ harness that can drive ordered mutations and inspect stable invariants.
 15. **Done.** Document the public API in `docs/api.md` once the runtime behavior and
     example have stabilized.
 
-    The API docs now include a concise view mutation section covering the live
-    layout hierarchy, root handles, selectors, scopes, async mutation promises,
-    child reordering, and transactions.
+    The API docs now include a concise view hierarchy section covering the live
+    layout hierarchy, root handles, selectors, scopes, layout bounds,
+    layout subscriptions, async mutation promises, child reordering, and
+    transactions.
 
     Commit: `5d77e630 docs(core): document view mutation API`.
+
+16. **Done.** Add read-only layout observation to `api.views` so embedding
+    applications can position external UI next to live views without accessing
+    internal `View` objects. The first version should expose last rendered view
+    bounds and a completed-layout subscription hook.
+
+    Implemented as `getLayoutBounds(address)` and
+    `subscribeToLayout(listener)`. The embed example now overlays per-track
+    move/remove controls using the reported bounds and updates them after
+    layout changes.
+
+    Tentative commit: `feat(core): expose view layout observation API`.

--- a/VIEW_MUTATION_API_PLAN.md
+++ b/VIEW_MUTATION_API_PLAN.md
@@ -545,14 +545,15 @@ harness that can drive ordered mutations and inspect stable invariants.
 
     Tentative commit: `fix(core): roll back failed view insertions`.
 
-12. **Partial.** Implement `transaction()` as ordered operation batching. The first version
+12. **Done.** Implement `transaction()` as ordered operation batching. The first version
     can avoid full transaction rollback, but it should defer layout/render work
     until the callback finishes and then run final lifecycle cleanup once.
     Nested transactions should join the active transaction.
 
-    The facade currently serializes operations and lets nested transactions join
-    the active operation queue, but layout/render deferral and final lifecycle
-    cleanup batching are still pending.
+    The facade serializes operations, lets nested transactions join the active
+    operation queue, and defers layout reflow requests until the outer
+    transaction finishes. Full rollback for a multi-operation transaction remains
+    out of scope for the first public API version.
 
     Tentative commit: `feat(core): batch view mutation transactions`.
 

--- a/VIEW_MUTATION_API_PLAN.md
+++ b/VIEW_MUTATION_API_PLAN.md
@@ -110,6 +110,38 @@ only address explicitly named views that satisfy selector uniqueness
 constraints. They are not enough for anonymous containers or for follow-up
 operations on newly inserted views.
 
+## Alignment With Existing API
+
+The existing embed API is mostly a set of narrow handles and named resources:
+`getParam(name)` returns a `ParamApi`, `getScaleResolutionByName(name)` returns
+a `ScaleResolutionApi`, `updateNamedData(name, data)` mutates a named data
+source, and `awaitVisibleLazyData()` provides a lifecycle barrier. The view
+mutation API should align with the better parts of that model by exposing a
+small handle-based surface rather than internal view objects.
+
+The main improvement should be addressing. Some existing APIs are name-only,
+which can become ambiguous as specifications grow or as templates are reused.
+`ViewMutationApi` should establish the cleaner pattern for new public APIs:
+scoped selectors for durable addresses, opaque live handles for runtime
+operations, and additive evolution for compatibility.
+
+This creates useful synergies with the current API:
+
+- Inserted views can use named data sources and continue to work with
+  `updateNamedData()`.
+- Scoped inserted views can provide a future path for scoped parameter access,
+  avoiding more global name-only APIs.
+- Named scale resolutions remain useful after mutations when their names and
+  resolution ownership are kept stable.
+- Mutation promises and transactions can compose with lifecycle barriers such as
+  `awaitVisibleLazyData()`.
+
+The API should not copy the weaker parts of the existing surface. In
+particular, avoid a primary mutation form like `addView("tracks", spec)` where
+`"tracks"` is a global view name. Keep the old API stable, but let
+`ViewMutationApi` use scoped selectors and handles as the conservative public
+contract going forward.
+
 ## Recommended Public API
 
 Expose a namespaced mutation API on `EmbedResult`:
@@ -188,6 +220,10 @@ Do not make index paths a primary public address in the initial API. Structural
 paths are convenient for diagnostics but unstable under insertion and reorder.
 Handles cover anonymous views without pretending structural paths are durable.
 
+Keep `ViewHandle` minimal initially. Convenience fields such as a current child
+index or explicit scope can be reconsidered after the embed example has been
+used for manual iteration.
+
 ## Scope Support
 
 Scopes should be available for both ordinary `ViewSpec` objects and
@@ -250,6 +286,12 @@ the same object multiple times. `options.scope` should register the created
 subtree root as a scope root after creation. It should not overwrite
 `spec.name`; the scope is an address namespace, while `name` remains the view's
 explicit name.
+
+Named scope collisions should fail fast. If `options.scope` or `ImportSpec.name`
+would create a duplicate non-null scope name in the same enclosing selector
+scope, the insertion should fail before committing the new subtree. This keeps
+selector behavior deterministic and avoids making callers discover ambiguity
+later through `resolve()`.
 
 ## Container Support
 
@@ -352,6 +394,8 @@ view/spec, disposing the subtree, refreshing configs/guides, and rethrowing.
 `transaction()` should batch several operations and defer layout/render requests
 until the end. It does not need full rollback in the first version, but it
 should preserve operation ordering and ensure final lifecycle cleanup runs once.
+Nested transactions should join the current transaction rather than creating an
+independent batch.
 
 All public errors should include enough context to debug:
 
@@ -361,6 +405,10 @@ All public errors should include enough context to debug:
 - stale/dead handle
 - root removal attempt
 - move across parents, if attempted
+
+Keep the public error model simple. A single mutation error shape with a stable
+string `code` and a clear message should be enough for v1; avoid a large error
+class hierarchy unless implementation experience proves it useful.
 
 ## Acid Test Coverage
 
@@ -392,19 +440,113 @@ harness that can drive ordered mutations and inspect stable invariants.
 
 ## Suggested Implementation Steps
 
-1. Add public types to `packages/core/src/types/embedApi.d.ts`.
-2. Add `packages/core/src/view/viewMutationApi.js` with handle creation,
-   address resolution, operation serialization, and public error shaping.
-3. Attach `views: createViewMutationApi(genomeSpy)` in `embedFactory.js`.
-4. Generalize import scope registration so inserted ordinary specs can also
-   become scope roots through `options.scope`.
-5. Refactor container mutation lifecycle so public operations call one
-   coordinator.
-6. Add same-parent reorder support to `ConcatView`, `LayerView`, and shared
-   helper code.
-7. Add guide/chrome refresh helper that covers axes and legends consistently.
-8. Replace naive insertion loading with reload/repropagation logic compatible
-   with `initializeVisibleViewData`.
-9. Add focused unit tests for API behavior and lifecycle invariants.
-10. Expand the acid-test plan into executable mutation scenarios.
-11. Document the public API in `docs/api.md` once the behavior is stable.
+1. Keep the public declaration surface in
+   `packages/core/src/types/embedApi.d.ts` as the compatibility contract. Changes
+   after the first release should be additive unless a breaking change is
+   explicitly versioned.
+
+   Tentative commit: `feat(core): declare view mutation API`.
+
+2. Add a small internal `viewMutationApi` module that owns `ViewHandle`
+   creation, handle liveness, address resolution, operation serialization, and
+   public error shaping with simple stable error codes. It should wrap internal
+   `View` objects without exposing them.
+
+   Tentative commit: `feat(core): add view mutation API facade`.
+
+3. Add a new `packages/embed-examples` development example early, for example
+   `viewMutationApi.html` and `viewMutationApi.js`, and link it from
+   `packages/embed-examples/src/index.html`. Start with the smallest working
+   flow as soon as `api.views.root()` and address resolution exist, then keep
+   the example updated throughout implementation. It should serve as a manual
+   testing and iteration fixture for resolving a named container, inserting two
+   scoped tracks from a reusable spec/template, resolving one inserted scoped
+   view, reordering tracks with `move()`, removing a track, and showing a
+   compact UI state derived from handles.
+
+   Tentative commit: `feat(embed-examples): add view mutation API example`.
+
+4. Attach `views: createViewMutationApi(genomeSpy)` in `embedFactory.js`.
+   `GenomeSpy` already owns `viewRoot`, layout/render hooks, dataflow, and the
+   context needed by the mutation coordinator, so the API factory should use
+   those existing entry points instead of duplicating lifecycle state.
+
+   Tentative commit: `feat(core): expose view mutation API from embed`.
+
+5. Generalize selector scope registration. The existing import-scope machinery
+   can already resolve scoped selectors, but `options.scope` must work for
+   ordinary `ViewSpec` insertions as well as `ImportSpec` insertions. Consider
+   renaming or wrapping `registerImportInstance()` internally so the mutation
+   path can register a generic inserted subtree scope without making the public
+   model import-specific. Reject duplicate named scopes in the same enclosing
+   selector scope before committing an insertion.
+
+   Tentative commit: `feat(core): support mutation scopes for direct specs`.
+
+6. Harden index handling before exposing it publicly. Validate insert and move
+   indices explicitly instead of relying on `Array.splice()` semantics. Use the
+   documented move rule: destination index is interpreted after temporarily
+   removing the target from its current parent.
+
+   Tentative commit: `fix(core): validate view mutation indices`.
+
+7. Refactor container mutation lifecycle so public insert/remove operations call
+   one coordinator. The coordinator should cover create/import, spec cloning,
+   backing spec updates, view insertion/removal, config reattachment, assembly
+   preflight, opacity setup, subtree dataflow/graphics initialization, guide
+   refresh, layout invalidation, and render scheduling.
+
+   Tentative commit: `refactor(core): centralize view mutation lifecycle`.
+
+8. Add non-disposing same-parent reorder support to `ConcatView`, `LayerView`,
+   and shared helper code. Reorder must update both the backing spec list and
+   live child list without rebuilding dataflow, disposing collectors, or
+   reloading data.
+
+   Tentative commit: `feat(core): support same-parent view reordering`.
+
+9. Add a guide/chrome refresh helper that covers the same artifacts after
+   mutation as initial setup does: shared axes, grid-child axes and gridlines,
+   shared legends, local legend regions, and relevant layout decorations. The
+   current dynamic path already refreshes shared axes, but public mutation needs
+   a single helper that includes legends too.
+
+   Tentative commit: `fix(core): refresh guides consistently after mutations`.
+
+10. Replace the insertion data-loading path with logic compatible with
+   `initializeVisibleViewData`. Inserted branches should repropagate completed
+   ancestor collectors when possible, queue reloads for sources already loading,
+   and load new subtree-owned sources directly.
+
+    Tentative commit: `fix(core): populate inserted view data reliably`.
+
+11. Implement operation-level rollback for failed insertions. If an insertion
+    has touched the backing spec or live hierarchy before a later lifecycle step
+    fails, remove the partial view/spec, dispose the subtree, refresh configs and
+    guides, then rethrow the original error.
+
+    Tentative commit: `fix(core): roll back failed view insertions`.
+
+12. Implement `transaction()` as ordered operation batching. The first version
+    can avoid full transaction rollback, but it should defer layout/render work
+    until the callback finishes and then run final lifecycle cleanup once.
+    Nested transactions should join the active transaction.
+
+    Tentative commit: `feat(core): batch view mutation transactions`.
+
+13. Add focused unit tests close to the lifecycle code for address resolution,
+    handle liveness, scoped ordinary-spec insertion, index validation,
+    insert/remove/reorder behavior, and guide/dataflow invariants.
+
+    Tentative commit: `test(core): cover view mutation API behavior`.
+
+14. Expand the acid-test plan into executable mutation scenarios that compare a
+    normalized internal hierarchy before and after complex mutation sequences
+    that are canceled immediately.
+
+    Tentative commit: `test(core): add view mutation acid scenarios`.
+
+15. Document the public API in `docs/api.md` once the runtime behavior and
+    example have stabilized.
+
+    Tentative commit: `docs(core): document view mutation API`.

--- a/VIEW_MUTATION_API_PLAN.md
+++ b/VIEW_MUTATION_API_PLAN.md
@@ -577,7 +577,11 @@ harness that can drive ordered mutations and inspect stable invariants.
 
     Tentative commit: `test(core): add view mutation acid scenarios`.
 
-15. **Todo.** Document the public API in `docs/api.md` once the runtime behavior and
+15. **Done.** Document the public API in `docs/api.md` once the runtime behavior and
     example have stabilized.
+
+    The API docs now include a concise view mutation section covering the live
+    layout hierarchy, root handles, selectors, scopes, async mutation promises,
+    child reordering, and transactions.
 
     Tentative commit: `docs(core): document view mutation API`.

--- a/VIEW_MUTATION_API_PLAN.md
+++ b/VIEW_MUTATION_API_PLAN.md
@@ -1,0 +1,410 @@
+# Public View Mutation API Plan
+
+## Context
+
+Issue [#419](https://github.com/genome-spy/genome-spy/issues/419) asks for the
+existing internal view hierarchy mutation APIs to be stabilized and exposed
+through the `embed()` result. The API should support adding unit views and full
+subtrees, removing subtrees, and eventually reordering children without leaving
+stale dataflow, scale, guide, legend, parameter, or graphics references.
+
+`MUTATION_ACID_TEST_PLAN.md` frames the risk: dynamic hierarchy mutation,
+visibility-aware lazy initialization, scale resolution updates, and in-flight
+data loading interact in timing-sensitive ways. The public API should therefore
+be a small lifecycle-enforcing surface rather than direct exposure of internal
+view classes.
+
+## Use Case Examples
+
+### Genome browser custom tracks
+
+A genome browser embeds a base specification with a named track container, such
+as `{ scope: [], view: "tracks" }`. The host application provides templates for
+common genomic file types and visual representations, such as BED annotation
+tracks, BigWig signal tracks, VCF variant tracks, segment tracks, and paired-end
+link tracks.
+
+When the user adds a local or remote dataset, the application chooses the
+matching template, supplies the dataset URL or named data source through params,
+and inserts a new track into the track container:
+
+```ts
+const tracks = api.views.get({ scope: [], view: "tracks" });
+
+const track = await api.views.insert(
+  tracks,
+  {
+    import: { template: "bigwigSignalTrack" },
+    params: {
+      url: "https://example.org/sample.bw",
+      title: "Sample signal",
+    },
+  },
+  { scope: "sampleSignal" }
+);
+```
+
+The user can then remove the track or rearrange it relative to other tracks:
+
+```ts
+await api.views.move(track, { index: 1 });
+await api.views.remove(track);
+```
+
+The inserted scope makes repeated template instances independently addressable.
+For example, inner views named `signal` can be addressed as
+`{ scope: ["sampleSignal"], view: "signal" }` even when the same template has
+been inserted many times. The same pattern should work when the host
+application already has an ordinary `ViewSpec` object instead of an import
+template.
+
+### Temporary analysis overlays
+
+An application may add a transient overlay track for a selection, search result,
+or quality-control calculation, then remove it immediately when the user
+cancels the action. This requires insertion and cancellation to leave no stale
+dataflow branches, resolution members, guide views, params, or event listeners.
+
+### Saved layouts and user workspaces
+
+A host application may restore a user-specific workspace by replaying a set of
+track insertions and reorder operations after embedding. The same operations
+should be usable later for interactive editing, so the API should keep backing
+spec order, live hierarchy order, and selector scopes consistent.
+
+## Current Findings
+
+The internal mutation path already exists:
+
+- `ConcatView.addChildSpec()` and `ConcatView.removeChildAt()` route through
+  `ContainerMutationHelper`.
+- `LayerView.addChildSpec()` and `LayerView.removeChildAt()` use the same
+  helper.
+- `GridView` owns the low-level child insertion/removal primitives and shared
+  guide views.
+- `ContainerMutationHelper` handles create/import, spec list updates,
+  view-level scale/axis/legend config reattachment, assembly preflight,
+  opacity configuration, subtree dataflow initialization, data loading,
+  graphics finalization, size invalidation, and layout reflow.
+
+The public `embed()` result currently exposes params, named data, named scale
+resolutions, lazy-data waiting, canvas helpers, event listeners, and finalizing.
+It has no view hierarchy mutation surface.
+
+Selectors already support import scopes with the shape:
+
+```ts
+interface ViewSelector {
+  scope: string[];
+  view: string;
+}
+```
+
+Named import instances are registered as selector scopes. For example, adding
+the same imported template twice as `panelA` and `panelB` lets callers address
+inner views as `{ scope: ["panelA"], view: "coverage" }` and
+`{ scope: ["panelB"], view: "coverage" }`.
+
+Selectors are durable and useful for bookmarkable/provenance state, but they
+only address explicitly named views that satisfy selector uniqueness
+constraints. They are not enough for anonymous containers or for follow-up
+operations on newly inserted views.
+
+## Recommended Public API
+
+Expose a namespaced mutation API on `EmbedResult`:
+
+```ts
+const api = await embed(container, spec);
+
+const tracks = api.views.get({ scope: [], view: "tracks" });
+
+const inserted = await api.views.insert(tracks, coverageTrackSpec, {
+  scope: "sampleA",
+});
+
+await api.views.move(inserted, { index: 0 });
+await api.views.remove(inserted);
+```
+
+Type sketch:
+
+```ts
+interface EmbedResult {
+  views: ViewMutationApi;
+}
+
+type ViewAddress = ViewHandle | ViewSelector | "root";
+
+interface ViewMutationApi {
+  root(): ViewHandle;
+  resolve(address: ViewAddress): ViewHandle | undefined;
+  get(address: ViewAddress): ViewHandle;
+  insert(
+    parent: ViewAddress,
+    spec: ViewSpec | ImportSpec,
+    options?: InsertOptions
+  ): Promise<ViewHandle>;
+  remove(target: ViewAddress): Promise<void>;
+  move(target: ViewAddress, options: { index: number }): Promise<ViewHandle>;
+  transaction<T>(
+    callback: (views: ViewMutationApi) => T | Promise<T>
+  ): Promise<T>;
+}
+
+interface InsertOptions {
+  index?: number;
+  scope?: string | null;
+}
+
+interface ViewHandle {
+  readonly id: string;
+  readonly name: string | undefined;
+  readonly selector: ViewSelector | undefined;
+  readonly type: "unit" | "layer" | "concat" | "grid" | "unknown";
+  isAlive(): boolean;
+  parent(): ViewHandle | undefined;
+  children(): ViewHandle[];
+}
+```
+
+The API should return handles instead of internal `View` instances. A handle is
+a live reference with a stable runtime id and explicit liveness checks. It can
+expose selector metadata when available, but it must not expose mutable internal
+view objects.
+
+## Addressing Model
+
+Use three address forms, each with a distinct purpose:
+
+- `ViewSelector`: durable address for named views inside import scopes. This is
+  the right shape for bookmarks, provenance, saved UI state, and app-agent
+  references.
+- `ViewHandle`: live runtime address returned by `root()`, `get()`, `resolve()`,
+  and `insert()`. This is the right shape for newly inserted or anonymous views.
+- `"root"`: explicit shortcut for the current root view.
+
+Do not make index paths a primary public address in the initial API. Structural
+paths are convenient for diagnostics but unstable under insertion and reorder.
+Handles cover anonymous views without pretending structural paths are durable.
+
+## Scope Support
+
+Scopes should be available for both ordinary `ViewSpec` objects and
+`ImportSpec` objects. The public mutation API should treat a scope as
+mutation-time instance metadata, not as something that only exists because the
+spec came through the import grammar.
+
+This lets API users keep a reusable spec object and add it multiple times with
+different scopes:
+
+```ts
+await api.views.insert(tracks, coverageTrackSpec, {
+  scope: "tumorA",
+});
+
+await api.views.insert(tracks, coverageTrackSpec, {
+  scope: "tumorB",
+});
+```
+
+If `coverageTrackSpec` contains a named inner view such as `coverage`, callers
+can address the inserted instances as `{ scope: ["tumorA"], view: "coverage" }`
+and `{ scope: ["tumorB"], view: "coverage" }`.
+
+The same option should work for imported specs:
+
+```ts
+await api.views.insert(
+  tracks,
+  {
+    import: { template: "track" },
+    params: { sample: "A" },
+  },
+  { scope: "tumorA" }
+);
+
+await api.views.insert(
+  tracks,
+  {
+    import: { template: "track" },
+    params: { sample: "B" },
+  },
+  { scope: "tumorB" }
+);
+```
+
+`ImportSpec.name` should remain supported because the grammar already defines it
+as both the imported root view name and selector scope name. For the public
+mutation API, `options.scope` should be the preferred way to create an instance
+scope because it also works for ordinary specs and does not require changing the
+root view name embedded in a reusable spec.
+
+If both `ImportSpec.name` and `options.scope` are provided, the API should
+either require them to match or throw. Silent precedence would make selector
+addresses hard to reason about.
+
+For direct `ViewSpec` inputs, the mutation API should clone the spec before
+insertion. This prevents accidental shared mutable spec state when callers add
+the same object multiple times. `options.scope` should register the created
+subtree root as a scope root after creation. It should not overwrite
+`spec.name`; the scope is an address namespace, while `name` remains the view's
+explicit name.
+
+## Container Support
+
+Initial support should cover the existing dynamic containers:
+
+- `ConcatView`: insertion, removal, same-parent reorder.
+- `LayerView`: insertion, removal, same-parent reorder.
+
+Unsupported containers should fail fast with a clear error such as:
+
+```text
+View "foo" does not support child mutation.
+```
+
+Moving a view to another branch should not be part of the initial API. It needs
+new decisions around data parent changes, param scope changes, scale resolution
+membership, and inherited config/data/encoding semantics.
+
+## Lifecycle Requirements
+
+All public mutations should go through one lifecycle coordinator instead of
+calling container methods directly from the API wrapper.
+
+Insertion should:
+
+1. Resolve the parent address to a mutable container.
+2. Clone direct specs and pass import specs through `createOrImportView`.
+3. Register `options.scope` on the created subtree root when provided.
+4. Insert the backing spec and view in the same relative order.
+5. Attach view-level scale, axis, and legend configs.
+6. Ensure assemblies before scale/encoder-dependent initialization.
+7. Configure view opacity.
+8. Initialize visible subtree dataflow and graphics.
+9. Populate new collectors by reload or repropagation.
+10. Refresh guide/chrome artifacts.
+11. Invalidate size/layout, compute layout, and request render.
+12. Return a live `ViewHandle`.
+
+Removal should:
+
+1. Resolve the target address to a live child view.
+2. Reject root removal.
+3. Clear affected view-level configs before disposal.
+4. Remove the view and backing spec from its parent.
+5. Dispose the subtree in post-order.
+6. Prune dataflow branches and unused data sources.
+7. Reattach view-level configs.
+8. Refresh guide/chrome artifacts.
+9. Invalidate size/layout, compute layout, and request render.
+10. Mark the removed handle dead.
+
+Reorder should:
+
+1. Resolve the target to a live child view.
+2. Require same-parent reorder only.
+3. Update the parent container child list and backing spec list without disposal.
+4. Refresh guide/chrome artifacts and affected cached resolution-derived values.
+5. Invalidate size/layout, compute layout, and request render.
+
+Reorder must not rebuild dataflow, dispose collectors, or reload data. However,
+it can affect layout, axis placement, legend order, and deterministic resolution
+member ordering because resolution merges are based on view path strings.
+
+## Data Loading Strategy
+
+The current dynamic insert helper loads the subtree sources directly. Before
+making this public, reuse the smarter visibility path from
+`initializeVisibleViewData`:
+
+- If the inserted visible view inherits from a completed ancestor collector,
+  repropagate the collector instead of reloading the source.
+- If a needed source is currently loading, queue a reload so new branches receive
+  complete data propagation.
+- If the inserted subtree owns a data source, load that source.
+
+This avoids both extra reloads and missed rows during in-flight loading.
+
+## Guide And Legend Refresh
+
+The internal dynamic path should treat guide/chrome refresh as one lifecycle
+step. `ConcatView` currently refreshes shared axes after add/remove, while
+`GridView.createAxes()` refreshes both shared axes and shared legends during
+initial setup. Public mutation should not require callers to know those details.
+
+Add a container-level method or helper such as `refreshGuideViews()` that covers:
+
+- shared axes
+- gridline/axis views owned by grid children
+- shared legends
+- local legend regions
+- separator/layout decorations where relevant
+
+## Error Handling And Transactions
+
+The public API should be fail-fast and transactional at the operation level.
+
+If insertion fails after partial commit, roll back by removing the inserted
+view/spec, disposing the subtree, refreshing configs/guides, and rethrowing.
+
+`transaction()` should batch several operations and defer layout/render requests
+until the end. It does not need full rollback in the first version, but it
+should preserve operation ordering and ensure final lifecycle cleanup runs once.
+
+All public errors should include enough context to debug:
+
+- unresolved selector
+- unsupported parent/container type
+- out-of-range index
+- stale/dead handle
+- root removal attempt
+- move across parents, if attempted
+
+## Acid Test Coverage
+
+The acid tests should cover the draft scenarios in
+`MUTATION_ACID_TEST_PLAN.md` and add API-level cases:
+
+- Insert the same template import twice with different names and resolve both
+  import scopes.
+- Insert the same direct `ViewSpec` twice with different `options.scope` values
+  and resolve both scoped instances.
+- Insert the same direct `ViewSpec` object twice and verify no shared spec
+  mutation.
+- Remove an inserted subtree and verify old handles are dead.
+- Reorder inside concat and layer containers without collector disposal or data
+  reload.
+- Insert during an in-flight shared source load and verify the new collector
+  receives data.
+- Remove a subtree and verify no stale scale, axis, or legend members remain.
+- Apply a complex mutation sequence, cancel it immediately, await
+  stabilization, and verify the normalized internal hierarchy snapshot matches
+  the pre-mutation baseline.
+- Reinsert a removed subtree with shared scales and axes.
+- Toggle visibility of a hidden inserted subtree with chrom/pos encodings.
+- Verify axis/gridline/legend views render after add/remove/reorder.
+- Verify encoders never see chrom/pos channel defs after linearization.
+
+Prefer focused Vitest suites close to the lifecycle code, plus a small acid-test
+harness that can drive ordered mutations and inspect stable invariants.
+
+## Suggested Implementation Steps
+
+1. Add public types to `packages/core/src/types/embedApi.d.ts`.
+2. Add `packages/core/src/view/viewMutationApi.js` with handle creation,
+   address resolution, operation serialization, and public error shaping.
+3. Attach `views: createViewMutationApi(genomeSpy)` in `embedFactory.js`.
+4. Generalize import scope registration so inserted ordinary specs can also
+   become scope roots through `options.scope`.
+5. Refactor container mutation lifecycle so public operations call one
+   coordinator.
+6. Add same-parent reorder support to `ConcatView`, `LayerView`, and shared
+   helper code.
+7. Add guide/chrome refresh helper that covers axes and legends consistently.
+8. Replace naive insertion loading with reload/repropagation logic compatible
+   with `initializeVisibleViewData`.
+9. Add focused unit tests for API behavior and lifecycle invariants.
+10. Expand the acid-test plan into executable mutation scenarios.
+11. Document the public API in `docs/api.md` once the behavior is stable.

--- a/VIEW_MUTATION_API_PLAN.md
+++ b/VIEW_MUTATION_API_PLAN.md
@@ -534,10 +534,14 @@ harness that can drive ordered mutations and inspect stable invariants.
 
     Tentative commit: `fix(core): populate inserted view data reliably`.
 
-11. **Todo.** Implement operation-level rollback for failed insertions. If an insertion
+11. **Done.** Implement operation-level rollback for failed insertions. If an insertion
     has touched the backing spec or live hierarchy before a later lifecycle step
     fails, remove the partial view/spec, dispose the subtree, refresh configs and
     guides, then rethrow the original error.
+
+    Implemented in the shared container mutation helper. Failed post-insertion
+    lifecycle work removes the partial live child and backing spec entry, then
+    rethrows the original error.
 
     Tentative commit: `fix(core): roll back failed view insertions`.
 

--- a/VIEW_MUTATION_API_PLAN.md
+++ b/VIEW_MUTATION_API_PLAN.md
@@ -564,9 +564,16 @@ harness that can drive ordered mutations and inspect stable invariants.
     Covered across `af0a632c`, `745af1bb`, `5df2420e`, `9191bbb4`, and
     `3390f9c4`. Additional tests should be added with future lifecycle work.
 
-14. **Todo.** Expand the acid-test plan into executable mutation scenarios that compare a
+14. **Partial.** Expand the acid-test plan into executable mutation scenarios that compare a
     normalized internal hierarchy before and after complex mutation sequences
     that are canceled immediately.
+
+    Initial executable coverage lives in
+    `packages/core/src/view/viewMutationApi.acid.test.js`. It snapshots the
+    normalized live hierarchy, generated chrome, flow handles, scale/axis/legend
+    resolution summaries, and rendered layout before an add/reorder/remove
+    sequence that is immediately undone. Additional scenarios should cover async
+    sources, visibility toggles, encoding mutation, and URL/bookmark restore.
 
     Tentative commit: `test(core): add view mutation acid scenarios`.
 

--- a/VIEW_MUTATION_API_PLAN.md
+++ b/VIEW_MUTATION_API_PLAN.md
@@ -376,7 +376,7 @@ step. `ConcatView` currently refreshes shared axes after add/remove, while
 `GridView.createAxes()` refreshes both shared axes and shared legends during
 initial setup. Public mutation should not require callers to know those details.
 
-Add a container-level method or helper such as `refreshGuideViews()` that covers:
+Add a container-level method or helper such as `syncGuideViews()` that covers:
 
 - shared axes
 - gridline/axis views owned by grid children
@@ -445,14 +445,14 @@ harness that can drive ordered mutations and inspect stable invariants.
    after the first release should be additive unless a breaking change is
    explicitly versioned.
 
-   Commit: `4c0082b9 feat(core): add view mutation API declarations`.
+   Commit: `655e5aff feat(core): add view mutation API declarations`.
 
 2. **Done.** Add a small internal `viewMutationApi` module that owns `ViewHandle`
    creation, handle liveness, address resolution, operation serialization, and
    public error shaping with simple stable error codes. It should wrap internal
    `View` objects without exposing them.
 
-   Commit: `af0a632c feat: add view mutation API facade`.
+   Commit: `2cb7b30e feat: add view mutation API facade`.
 
 3. **Done.** Add a new `packages/embed-examples` development example early, for example
    `viewMutationApi.html` and `viewMutationApi.js`, and link it from
@@ -464,18 +464,20 @@ harness that can drive ordered mutations and inspect stable invariants.
    view, reordering tracks with `move()`, removing a track, and showing a
    compact UI state derived from handles.
 
-   Commits: `af0a632c feat: add view mutation API facade`,
-   `745af1bb feat(core): implement view insertion API`,
-   `5df2420e feat(core): implement view removal API`,
-   `9191bbb4 feat(core): implement view reordering API`, and
-   `6055f733 chore(embed-example): update example`.
+   Commits: `2cb7b30e feat: add view mutation API facade`,
+   `fb66f500 feat(core): implement view insertion API`,
+   `da2fa515 feat(core): implement view removal API`,
+   `8acfb0c8 feat(core): implement view reordering API`,
+   `222e96ce chore(embed-example): update example`,
+   `ee59b23f docs(embed-examples): simplify view mutation example`, and
+   `d33c9be8 chore(embed-examples): adjust example`.
 
 4. **Done.** Attach `views: createViewMutationApi(genomeSpy)` in `embedFactory.js`.
    `GenomeSpy` already owns `viewRoot`, layout/render hooks, dataflow, and the
    context needed by the mutation coordinator, so the API factory should use
    those existing entry points instead of duplicating lifecycle state.
 
-   Commit: `af0a632c feat: add view mutation API facade`.
+   Commit: `2cb7b30e feat: add view mutation API facade`.
 
 5. **Done.** Generalize selector scope registration. The existing import-scope machinery
    can already resolve scoped selectors, but `options.scope` must work for
@@ -485,15 +487,15 @@ harness that can drive ordered mutations and inspect stable invariants.
    model import-specific. Reject duplicate named scopes in the same enclosing
    selector scope before committing an insertion.
 
-   Commit: `745af1bb feat(core): implement view insertion API`.
+   Commit: `fb66f500 feat(core): implement view insertion API`.
 
 6. **Done.** Harden index handling before exposing it publicly. Validate insert and move
    indices explicitly instead of relying on `Array.splice()` semantics. Use the
    documented move rule: destination index is interpreted after temporarily
    removing the target from its current parent.
 
-   Commits: `745af1bb feat(core): implement view insertion API` and
-   `9191bbb4 feat(core): implement view reordering API`.
+   Commits: `fb66f500 feat(core): implement view insertion API` and
+   `8acfb0c8 feat(core): implement view reordering API`.
 
 7. **Done for the initial API.** Refactor container mutation lifecycle so public insert/remove operations call
    one coordinator. The coordinator should cover create/import, spec cloning,
@@ -501,9 +503,9 @@ harness that can drive ordered mutations and inspect stable invariants.
    preflight, opacity setup, subtree dataflow/graphics initialization, guide
    refresh, layout invalidation, and render scheduling.
 
-   Commits: `745af1bb feat(core): implement view insertion API`,
-   `5df2420e feat(core): implement view removal API`, and
-   `3390f9c4 fix(core): initialize chrome for inserted views`.
+   Commits: `fb66f500 feat(core): implement view insertion API`,
+   `da2fa515 feat(core): implement view removal API`, and
+   `8da33040 fix(core): initialize chrome for inserted views`.
    Remaining reliability work is tracked separately in steps 10 and 11.
 
 8. **Done.** Add non-disposing same-parent reorder support to `ConcatView`, `LayerView`,
@@ -511,17 +513,24 @@ harness that can drive ordered mutations and inspect stable invariants.
    live child list without rebuilding dataflow, disposing collectors, or
    reloading data.
 
-   Commit: `9191bbb4 feat(core): implement view reordering API`.
+   Commit: `8acfb0c8 feat(core): implement view reordering API`.
 
-9. **Partial.** Add a guide/chrome refresh helper that covers the same artifacts after
+9. **Done.** Add a guide/chrome refresh helper that covers the same artifacts after
    mutation as initial setup does: shared axes, grid-child axes and gridlines,
    shared legends, local legend regions, and relevant layout decorations. The
    current dynamic path already refreshes shared axes, but public mutation needs
    a single helper that includes legends too.
 
-   Current work initializes newly created chrome for inserted views:
-   `3390f9c4 fix(core): initialize chrome for inserted views`. A single
-   consolidated guide/chrome refresh helper is still pending.
+   `GridView.syncGuideViews()` now recreates shared axes, shared legends,
+   and grid-child guides through the same path used by initial setup.
+   `ConcatView` routes insert, remove, and same-parent reorder through this
+   helper, and mutation data initialization picks up newly generated chrome
+   before returning to callers.
+
+   Commits: `8da33040 fix(core): initialize chrome for inserted views`,
+   `c237fbd2 fix(core): initialize shared axes after view removal`,
+   `098614ae fix(core): measure legends after view mutation`, and
+   tentative commit `fix(core): refresh guides after view mutations`.
 
 10. **Done.** Replace the insertion data-loading path with logic compatible with
    `initializeVisibleViewData`. Inserted branches should repropagate completed
@@ -532,7 +541,7 @@ harness that can drive ordered mutations and inspect stable invariants.
     `initializeVisibleViewData` and using it for dynamic insertions. This also
     makes inserted branches wait for newly requested fonts before loading data.
 
-    Tentative commit: `fix(core): populate inserted view data reliably`.
+    Commit: `7afa3000 fix(core): populate inserted view data reliably`.
 
 11. **Done.** Implement operation-level rollback for failed insertions. If an insertion
     has touched the backing spec or live hierarchy before a later lifecycle step
@@ -543,7 +552,7 @@ harness that can drive ordered mutations and inspect stable invariants.
     lifecycle work removes the partial live child and backing spec entry, then
     rethrows the original error.
 
-    Tentative commit: `fix(core): roll back failed view insertions`.
+    Commit: `18040c94 fix(core): roll back failed view insertions`.
 
 12. **Done.** Implement `transaction()` as ordered operation batching. The first version
     can avoid full transaction rollback, but it should defer layout/render work
@@ -555,14 +564,15 @@ harness that can drive ordered mutations and inspect stable invariants.
     transaction finishes. Full rollback for a multi-operation transaction remains
     out of scope for the first public API version.
 
-    Tentative commit: `feat(core): batch view mutation transactions`.
+    Commit: `862fad28 feat(core): batch view mutation transactions`.
 
 13. **Done for current behavior.** Add focused unit tests close to the lifecycle code for address resolution,
     handle liveness, scoped ordinary-spec insertion, index validation,
     insert/remove/reorder behavior, and guide/dataflow invariants.
 
-    Covered across `af0a632c`, `745af1bb`, `5df2420e`, `9191bbb4`, and
-    `3390f9c4`. Additional tests should be added with future lifecycle work.
+    Covered across `2cb7b30e`, `fb66f500`, `da2fa515`, `8acfb0c8`,
+    `8da33040`, `c237fbd2`, `098614ae`, and the current guide refresh work.
+    Additional tests should be added with future lifecycle work.
 
 14. **Partial.** Expand the acid-test plan into executable mutation scenarios that compare a
     normalized internal hierarchy before and after complex mutation sequences
@@ -575,7 +585,7 @@ harness that can drive ordered mutations and inspect stable invariants.
     sequence that is immediately undone. Additional scenarios should cover async
     sources, visibility toggles, encoding mutation, and URL/bookmark restore.
 
-    Tentative commit: `test(core): add view mutation acid scenarios`.
+    Commit: `bde2874f test(core): add view mutation acid scenarios`.
 
 15. **Done.** Document the public API in `docs/api.md` once the runtime behavior and
     example have stabilized.
@@ -584,4 +594,4 @@ harness that can drive ordered mutations and inspect stable invariants.
     layout hierarchy, root handles, selectors, scopes, async mutation promises,
     child reordering, and transactions.
 
-    Tentative commit: `docs(core): document view mutation API`.
+    Commit: `5d77e630 docs(core): document view mutation API`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,6 +33,66 @@ For practical examples of using the API, check the
 [embed-examples](https://github.com/genome-spy/genome-spy/tree/master/packages/embed-examples)
 package.
 
+## View mutation
+
+The `views` API controls the live layout hierarchy of an embedded GenomeSpy
+instance. It supports adding, removing, and reordering child views in mutable
+container views such as concat and layer views.
+
+The hierarchy exposed by the API matches the layout tree derived from the
+visualization spec. The root may be an implicit layout container, for example
+when a root unit view is wrapped to provide axes, titles, or other guides. Use
+`api.views.root()` to inspect the actual runtime root.
+
+Views can be addressed with:
+
+- `"root"` for the runtime root layout view
+- a `ViewHandle` returned by the API
+- a selector such as `{ scope: [], view: "tracks" }`
+
+When inserting the same spec multiple times, pass `scope` to make each instance
+independently addressable:
+
+```js
+const tracks = api.views.get({ scope: [], view: "tracks" });
+
+const summary = await api.views.insert(tracks, summaryTrackSpec, {
+  scope: "sample-1-summary",
+});
+
+const summaryView = api.views.get({
+  scope: ["sample-1-summary"],
+  view: "summary",
+});
+```
+
+Mutation methods are asynchronous. Await the returned promise before using the
+new hierarchy. Handles remain stable while their views are live; after removing
+a subtree, `handle.isAlive()` returns `false`.
+
+Use `move()` to reorder a view within its current parent. The destination
+`index` is evaluated after temporarily removing the target from its parent:
+
+```js
+await api.views.move(summary, { index: 0 });
+```
+
+Use `transaction()` to apply ordered mutations while deferring layout work until
+the outer transaction finishes:
+
+```js
+await api.views.transaction(async (views) => {
+  const inserted = await views.insert(tracks, summaryTrackSpec, {
+    scope: "sample-2-summary",
+  });
+
+  await views.move(inserted, { index: 0 });
+});
+```
+
+The initial mutation API does not move views between different parent
+containers.
+
 ## Embed options
 
 The `embed` function accepts an optional options object.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,8 @@
 # JavaScript API
 
-The public JavaScript API is currently quite minimal.
+This page documents the public API of the GenomeSpy JavaScript library. The API
+enables dynamic control of embedded GenomeSpy visualizations, including view
+hierarchy inspection and mutation, and parameterized data updates.
 
 ## Embedding
 
@@ -21,9 +23,15 @@ loaders. Import the data source and format modules you need explicitly:
 import { embed } from "@genome-spy/core/minimal";
 import "@genome-spy/core/data/formats/parquet.js";
 import "@genome-spy/core/data/sources/lazy/bigBedSource.js";
+
+const spec = {
+  // view specification that uses the lazy bigBed source
+};
+
+const api = await embed(document.body, spec);
 ```
 
-## The API
+## API object
 
 The `embed` function returns a promise that resolves into an object that
 provides the current public API. The API is documented in the [interface
@@ -55,18 +63,31 @@ Views can be addressed with:
 - a selector such as `{ scope: [], view: "tracks" }`
 
 When inserting the same spec multiple times, pass `scope` to make each instance
-independently addressable:
+independently addressable. The inserted value is a view spec, the same kind of
+object that appears inside `vconcat`, `hconcat`, or `layer` in a visualization
+specification:
 
 ```js
+const signalTrackSpec = {
+  name: "signalTrack",
+  data: {
+    // ...
+  },
+  mark: "point",
+  encoding: {
+    // ...
+  },
+};
+
 const tracks = api.views.get({ scope: [], view: "tracks" });
 
-const summary = await api.views.insert(tracks, summaryTrackSpec, {
-  scope: "sample-1-summary",
+const signalTrack = await api.views.insert(tracks, signalTrackSpec, {
+  scope: "sample-1-signal",
 });
 
-const summaryView = api.views.get({
-  scope: ["sample-1-summary"],
-  view: "summary",
+const sameSignalTrack = api.views.get({
+  scope: ["sample-1-signal"],
+  view: "signalTrack",
 });
 ```
 
@@ -74,51 +95,47 @@ Mutation methods are asynchronous. Await the returned promise before using the
 new hierarchy. Handles remain stable while their views are live; after removing
 a subtree, `handle.isAlive()` returns `false`.
 
-Use `getLayoutBounds()` to position external UI relative to a view. Bounds are
-reported in CSS pixels in the embedded GenomeSpy canvas coordinate space.
-Convert them to DOM coordinates when the external UI does not share the same
-positioning origin. The method returns `undefined` until the view has been
-rendered or when the address cannot be resolved:
+`getLayoutBounds()` returns the rendered bounds of a view for positioning
+external UI. Bounds are reported in CSS pixels in the embedded GenomeSpy canvas
+coordinate space. Convert them to DOM coordinates when the external UI does not
+share the same positioning origin. The method returns `undefined` until the view
+has been rendered or when the address cannot be resolved:
 
 ```js
-const bounds = api.views.getLayoutBounds(summary);
+const bounds = api.views.getLayoutBounds(signalTrack);
 ```
 
-Use `subscribeToLayout()` to update external UI after GenomeSpy has recomputed
-view bounds. The method returns an unsubscribe function:
+`subscribeToLayout()` runs a callback after GenomeSpy has recomputed view
+bounds, which is useful for updating external UI. The method returns an
+unsubscribe function:
 
 ```js
 const unsubscribe = api.views.subscribeToLayout(() => {
-  const bounds = api.views.getLayoutBounds(summary);
+  const bounds = api.views.getLayoutBounds(signalTrack);
 });
 ```
 
-Use `move()` to reorder a view within its current parent. The destination
-`index` is evaluated after temporarily removing the target from its parent:
+`move()` reorders a view within its current parent. The destination `index` is
+evaluated after temporarily removing the target from its parent:
 
 ```js
-await api.views.move(summary, { index: 0 });
+await api.views.move(signalTrack, { index: 0 });
 ```
 
-Use `transaction()` to apply ordered mutations while deferring layout work until
-the outer transaction finishes:
+`transaction()` applies ordered mutations while deferring layout work until the
+outer transaction finishes:
 
 ```js
 await api.views.transaction(async (views) => {
-  const inserted = await views.insert(tracks, summaryTrackSpec, {
-    scope: "sample-2-summary",
+  const inserted = await views.insert(tracks, signalTrackSpec, {
+    scope: "sample-2-signal",
   });
 
   await views.move(inserted, { index: 0 });
 });
 ```
 
-The initial mutation API does not move views between different parent
-containers.
-
-## Embed options
-
-The `embed` function accepts an optional options object.
+The mutation API does not move views between different parent containers.
 
 ## Named data
 
@@ -139,7 +156,7 @@ There are two ways to provide the data:
 
 ### `updateNamedData()`
 
-Use `updateNamedData(name, data)` when your application provides updated data
+Call `updateNamedData(name, data)` when your application provides updated data
 explicitly.
 
 ```js
@@ -153,8 +170,7 @@ api.updateNamedData("myResults", [
 
 ### `namedDataProvider`
 
-Use the `namedDataProvider` embed option when GenomeSpy should load named data
-on demand.
+The `namedDataProvider` embed option lets GenomeSpy load named data on demand.
 
 ```js
 const api = await embed("#container", spec, {
@@ -177,36 +193,12 @@ user interactions. For practical examples, see the
 [embed-examples](https://github.com/genome-spy/genome-spy/tree/master/packages/embed-examples)
 package.
 
-### Named data provider
-
-See [Named data](#named-data).
-
-### Theme config
-
-Use the `theme` embed option to provide global defaults without modifying the
-specification itself:
-
-```js
-embed(container, spec, {
-  theme: {
-    mark: { color: "#1f77b4" },
-    point: { size: 80 },
-    scale: { nominalColorScheme: "set2" },
-  },
-});
-```
-
-Theme config is merged before `spec.config`, so spec-local config and explicit
-properties still take precedence.
-
-See also [Config, Themes, and Styles](./grammar/config.md).
-
-### Named scales
+## Named scales
 
 Named scales can be accessed through `getScaleResolutionByName()`. To define a
 named scale in a spec, set `scale.name`. See [Scale](./grammar/scale.md).
 
-### Parameters
+## Parameters
 
 Named parameters can be accessed through `getParam()`. The returned handle can
 read and write the parameter value and subscribe to changes:
@@ -223,8 +215,8 @@ const unsubscribe = threshold.subscribe((value) => {
 });
 ```
 
-Variable parameters and interval selections can be read and written. Use
-`intervalSelection()` to construct interval selection values:
+Variable parameters and interval selections can be read and written.
+`intervalSelection()` constructs interval selection values:
 
 ```js
 import { embed, intervalSelection } from "@genome-spy/core";
@@ -245,6 +237,30 @@ Current limitations:
 For examples, see the `paramApi` and `brushLinkingApi` pages in the
 [embed-examples](https://github.com/genome-spy/genome-spy/tree/master/packages/embed-examples)
 package.
+
+## Embed options
+
+The `embed` function accepts an optional options object.
+
+### Theme config
+
+The `theme` embed option provides global defaults without modifying the
+specification itself:
+
+```js
+embed(container, spec, {
+  theme: {
+    mark: { color: "#1f77b4" },
+    point: { size: 80 },
+    scale: { nominalColorScheme: "set2" },
+  },
+});
+```
+
+Theme config is merged before `spec.config`, so spec-local config and explicit
+properties still take precedence.
+
+See also [Config, Themes, and Styles](./grammar/config.md).
 
 ### Custom tooltip handlers
 
@@ -320,8 +336,8 @@ Supported `mode` values:
 - `"endpoints"`
 - `"disabled"`
 
-Use the `tooltipHandlers` option to register custom handlers or override the
-default. See the example below.
+The `tooltipHandlers` option registers custom handlers or overrides the default.
+See the example below.
 
 #### Examples
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,7 +31,10 @@ definition](https://github.com/genome-spy/genome-spy/blob/master/packages/core/s
 
 For practical examples of using the API, check the
 [embed-examples](https://github.com/genome-spy/genome-spy/tree/master/packages/embed-examples)
-package.
+package. The
+[view mutation example](https://github.com/genome-spy/genome-spy/blob/master/packages/embed-examples/src/viewMutationApi.js)
+demonstrates adding, removing, reordering, and positioning external controls
+next to live views.
 
 ## View hierarchy
 
@@ -72,14 +75,17 @@ new hierarchy. Handles remain stable while their views are live; after removing
 a subtree, `handle.isAlive()` returns `false`.
 
 Use `getLayoutBounds()` to position external UI relative to a view. Bounds are
-reported in CSS pixels in the embedded GenomeSpy canvas coordinate space:
+reported in CSS pixels in the embedded GenomeSpy canvas coordinate space.
+Convert them to DOM coordinates when the external UI does not share the same
+positioning origin. The method returns `undefined` until the view has been
+rendered or when the address cannot be resolved:
 
 ```js
 const bounds = api.views.getLayoutBounds(summary);
 ```
 
 Use `subscribeToLayout()` to update external UI after GenomeSpy has recomputed
-view bounds:
+view bounds. The method returns an unsubscribe function:
 
 ```js
 const unsubscribe = api.views.subscribeToLayout(() => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,11 +33,12 @@ For practical examples of using the API, check the
 [embed-examples](https://github.com/genome-spy/genome-spy/tree/master/packages/embed-examples)
 package.
 
-## View mutation
+## View hierarchy
 
-The `views` API controls the live layout hierarchy of an embedded GenomeSpy
-instance. It supports adding, removing, and reordering child views in mutable
-container views such as concat and layer views.
+The `views` API inspects and controls the live layout hierarchy of an embedded
+GenomeSpy instance. It supports addressing views, reading their rendered layout
+bounds, listening for layout updates, and adding, removing, or reordering child
+views in mutable container views such as concat and layer views.
 
 The hierarchy exposed by the API matches the layout tree derived from the
 visualization spec. The root may be an implicit layout container, for example
@@ -69,6 +70,22 @@ const summaryView = api.views.get({
 Mutation methods are asynchronous. Await the returned promise before using the
 new hierarchy. Handles remain stable while their views are live; after removing
 a subtree, `handle.isAlive()` returns `false`.
+
+Use `getLayoutBounds()` to position external UI relative to a view. Bounds are
+reported in CSS pixels in the embedded GenomeSpy canvas coordinate space:
+
+```js
+const bounds = api.views.getLayoutBounds(summary);
+```
+
+Use `subscribeToLayout()` to update external UI after GenomeSpy has recomputed
+view bounds:
+
+```js
+const unsubscribe = api.views.subscribeToLayout(() => {
+  const bounds = api.views.getLayoutBounds(summary);
+});
+```
 
 Use `move()` to reorder a view within its current parent. The destination
 `index` is evaluated after temporarily removing the target from its parent:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,7 +61,7 @@ not yet 100% stable, it is recommended to use a specific version.
 The `embed` function initializes a visualization into the HTML element given as
 the first parameter using the specification given as the second parameter. The
 function returns a promise that resolves into an object that provides the
-current public API. For details, see the [API Documentation](./api.md).
+current public API. For details, see the [JavaScript API](./api.md).
 
 #### Load the spec from a file
 

--- a/docs/snippets-src/getting-started/core-module-inline-spec.html
+++ b/docs/snippets-src/getting-started/core-module-inline-spec.html
@@ -19,7 +19,7 @@
         },
       };
 
-      await embed(document.body, spec, {});
+      const api = await embed(document.body, spec, {});
     </script>
   </body>
 </html>

--- a/docs/snippets-src/getting-started/core-module-spec-file.html
+++ b/docs/snippets-src/getting-started/core-module-spec-file.html
@@ -7,7 +7,7 @@
     <script type="module">
       import { embed } from "https://cdn.jsdelivr.net/npm/@genome-spy/core@{{CORE_VERSION}}/dist/bundle/index.es.js";
 
-      await embed(document.body, "spec.json", {});
+      const api = await embed(document.body, "spec.json", {});
     </script>
   </body>
 </html>

--- a/docs/snippets-src/getting-started/core-plain-spec-file.html
+++ b/docs/snippets-src/getting-started/core-plain-spec-file.html
@@ -10,7 +10,9 @@
     ></script>
 
     <script>
-      genomeSpyEmbed.embed(document.body, "spec.json", {});
+      genomeSpyEmbed.embed(document.body, "spec.json", {}).then((api) => {
+        // Call API methods here.
+      });
     </script>
   </body>
 </html>

--- a/packages/app/src/index.js
+++ b/packages/app/src/index.js
@@ -2,6 +2,7 @@ import { isObject, isString } from "vega-util";
 
 import GenomeSpy from "@genome-spy/core/genomeSpy.js";
 import { loadSpec } from "@genome-spy/core/index.js";
+import { createViewMutationApi } from "@genome-spy/core/view/viewMutationApi.js";
 import App from "./app.js";
 import icon from "@genome-spy/core/img/bowtie.svg";
 import { html } from "lit";
@@ -67,6 +68,8 @@ export async function embed(el, spec, options = {}) {
     }
 
     return {
+        views: createViewMutationApi(genomeSpy),
+
         finalize() {
             const disposers = pluginDisposers;
             pluginDisposers = [];

--- a/packages/core/__snapshots__/examples.test.js.snap
+++ b/packages/core/__snapshots__/examples.test.js.snap
@@ -6320,6 +6320,110 @@ exports[`shared examples > initializes examples/docs/genomic-data/genomic-coordi
 }
 `;
 
+exports[`shared examples > initializes examples/docs/grammar/axis/genome-axis.json 1`] = `
+{
+  "assemblies": [
+    "hg38",
+  ],
+  "dataSources": [
+    {
+      "identifier": null,
+      "type": "AxisGenomeSource",
+    },
+    {
+      "identifier": null,
+      "type": "AxisGenomeSource",
+    },
+    {
+      "identifier": null,
+      "type": "AxisGenomeSource",
+    },
+    {
+      "identifier": null,
+      "type": "AxisTickSource",
+    },
+    {
+      "identifier": null,
+      "type": "AxisTickSource",
+    },
+    {
+      "identifier": null,
+      "type": "InlineSource",
+    },
+    {
+      "identifier": null,
+      "type": "InlineSource",
+    },
+  ],
+  "hierarchy": {
+    "baseUrl": null,
+    "children": [
+      {
+        "baseUrl": "examples/",
+        "children": [],
+        "name": "grid0",
+        "type": "UnitView",
+      },
+    ],
+    "name": "implicitRoot",
+    "type": "ConcatView",
+  },
+}
+`;
+
+exports[`shared examples > initializes examples/docs/grammar/axis/inside-axis.json 1`] = `
+{
+  "assemblies": [],
+  "dataSources": [
+    {
+      "identifier": null,
+      "type": "AxisTickSource",
+    },
+    {
+      "identifier": null,
+      "type": "AxisTickSource",
+    },
+    {
+      "identifier": null,
+      "type": "AxisTickSource",
+    },
+    {
+      "identifier": null,
+      "type": "InlineSource",
+    },
+    {
+      "identifier": null,
+      "type": "InlineSource",
+    },
+    {
+      "identifier": null,
+      "type": "InlineSource",
+    },
+    {
+      "identifier": null,
+      "type": "InlineSource",
+    },
+    {
+      "identifier": null,
+      "type": "SequenceSource",
+    },
+  ],
+  "hierarchy": {
+    "baseUrl": null,
+    "children": [
+      {
+        "baseUrl": "examples/",
+        "children": [],
+        "name": "grid0",
+        "type": "UnitView",
+      },
+    ],
+    "name": "implicitRoot",
+    "type": "ConcatView",
+  },
+}
+`;
+
 exports[`shared examples > initializes examples/docs/grammar/composition/concat/child-sizing.json 1`] = `
 {
   "assemblies": [],
@@ -9888,57 +9992,6 @@ exports[`shared examples > initializes examples/docs/grammar/parameters/two-way-
       },
     ],
     "name": "viewRoot",
-    "type": "ConcatView",
-  },
-}
-`;
-
-exports[`shared examples > initializes examples/docs/grammar/scale/genome-axis.json 1`] = `
-{
-  "assemblies": [
-    "hg38",
-  ],
-  "dataSources": [
-    {
-      "identifier": null,
-      "type": "AxisGenomeSource",
-    },
-    {
-      "identifier": null,
-      "type": "AxisGenomeSource",
-    },
-    {
-      "identifier": null,
-      "type": "AxisGenomeSource",
-    },
-    {
-      "identifier": null,
-      "type": "AxisTickSource",
-    },
-    {
-      "identifier": null,
-      "type": "AxisTickSource",
-    },
-    {
-      "identifier": null,
-      "type": "InlineSource",
-    },
-    {
-      "identifier": null,
-      "type": "InlineSource",
-    },
-  ],
-  "hierarchy": {
-    "baseUrl": null,
-    "children": [
-      {
-        "baseUrl": "examples/",
-        "children": [],
-        "name": "grid0",
-        "type": "UnitView",
-      },
-    ],
-    "name": "implicitRoot",
     "type": "ConcatView",
   },
 }

--- a/packages/core/__snapshots__/layout.test.js.snap
+++ b/packages/core/__snapshots__/layout.test.js.snap
@@ -804,7 +804,7 @@ ViewCoords {
           "viewName": "title1",
         },
       ],
-      "coords": "Rectangle: x: 0, y: 0, width: 627, height: 310",
+      "coords": "Rectangle: x: 0, y: 0, width: 595, height: 255",
       "viewName": "grid0",
     },
     ViewCoords {
@@ -986,7 +986,7 @@ ViewCoords {
           "viewName": "title1",
         },
       ],
-      "coords": "Rectangle: x: 0, y: 279, width: 627, height: 310",
+      "coords": "Rectangle: x: 0, y: 279, width: 595, height: 255",
       "viewName": "grid1",
     },
   ],

--- a/packages/core/src/data/flowInit.js
+++ b/packages/core/src/data/flowInit.js
@@ -324,7 +324,7 @@ function collectSubtreeViews(subtreeRoot, viewFilter) {
  *
  * @param {import("../view/view.js").default} subtreeRoot
  */
-function broadcastSubtreeDataReady(subtreeRoot) {
+export function broadcastSubtreeDataReady(subtreeRoot) {
     /** @type {import("../view/view.js").BroadcastMessage} */
     const message = {
         type: /** @type {import("../genomeSpy.js").BroadcastEventType} */ (

--- a/packages/core/src/embedFactory.js
+++ b/packages/core/src/embedFactory.js
@@ -1,5 +1,6 @@
 import { isObject, isString } from "vega-util";
 
+import { createViewMutationApi } from "./view/viewMutationApi.js";
 import { fetchJson } from "./utils/fetchUtils.js";
 import inferSpecBaseUrl from "./utils/inferSpecBaseUrl.js";
 
@@ -59,6 +60,8 @@ export function createEmbed(GenomeSpy) {
         }
 
         return {
+            views: createViewMutationApi(genomeSpy),
+
             finalize() {
                 genomeSpy.destroy();
                 while (element.firstChild) {

--- a/packages/core/src/embedFactory.test.js
+++ b/packages/core/src/embedFactory.test.js
@@ -60,6 +60,34 @@ describe("embed factory", () => {
         expect(api.getParam("threshold")).toBe(paramApi);
     });
 
+    test("exposes the view mutation API", async () => {
+        /** @type {any} */
+        const viewRoot = {
+            explicitName: "root",
+            name: "root",
+            layoutParent: undefined,
+            getDescendants: () => [viewRoot],
+            children: [],
+        };
+
+        class ViewGenomeSpy extends MockGenomeSpy {
+            /**
+             * @param {HTMLElement} element
+             * @param {any} spec
+             */
+            constructor(element, spec) {
+                super(element, spec);
+                this.viewRoot = viewRoot;
+            }
+        }
+
+        const embed = createEmbed(/** @type {any} */ (ViewGenomeSpy));
+        const element = document.createElement("div");
+        const api = await embed(element, /** @type {any} */ ({}));
+
+        expect(api.views.root().name).toBe("root");
+    });
+
     test("leaves missing width implicit", async () => {
         /** @type {MockGenomeSpy | undefined} */
         let instance;

--- a/packages/core/src/genomeSpy/viewDataInit.js
+++ b/packages/core/src/genomeSpy/viewDataInit.js
@@ -1,4 +1,5 @@
 import {
+    broadcastSubtreeDataReady,
     initializeViewSubtree,
     loadViewSubtreeData,
 } from "../data/flowInit.js";
@@ -168,6 +169,7 @@ export async function initializeViewDataForViews(
             )
         );
     }
+    broadcastSubtreeDataReady(viewRoot);
 
     return builtDataFlow;
 }

--- a/packages/core/src/genomeSpy/viewDataInit.js
+++ b/packages/core/src/genomeSpy/viewDataInit.js
@@ -65,16 +65,51 @@ export async function initializeVisibleViewData(
     dataFlow,
     fontManager
 ) {
-    // Initialize dataflow/graphics for views that have become visible since the
-    // initial load, while avoiding unnecessary data source reloads. If a view
-    // attaches downstream of an already completed collector, repropagate that
-    // collector instead of reloading the source.
     const visibilityPredicate = (
         /** @type {import("../view/view.js").default} */ view
     ) => view.isConfiguredVisible();
     const visibleViews = collectVisibleViews(viewRoot, visibilityPredicate);
     const viewsToInitialize = visibleViews.filter(
         (view) => view.getDataInitializationState() === "none"
+    );
+
+    return initializeViewDataForViews(
+        viewRoot,
+        dataFlow,
+        fontManager,
+        viewsToInitialize
+    );
+}
+
+/**
+ * Initializes dataflow/graphics for selected views while avoiding unnecessary
+ * data source reloads.
+ *
+ * If a selected view attaches downstream of an already completed collector,
+ * the collector is repropagated instead of reloading the source.
+ *
+ * @param {import("../view/view.js").default} viewRoot
+ * @param {import("../data/dataFlow.js").default} dataFlow
+ * @param {import("../fonts/bmFontManager.js").default} fontManager
+ * @param {Iterable<import("../view/view.js").default>} candidateViews
+ * @returns {Promise<import("../data/dataFlow.js").default>}
+ */
+export async function initializeViewDataForViews(
+    viewRoot,
+    dataFlow,
+    fontManager,
+    candidateViews
+) {
+    const candidates = new Set(candidateViews);
+    const visibilityPredicate = (
+        /** @type {import("../view/view.js").default} */ view
+    ) => view.isConfiguredVisible();
+    const viewsToInitialize = collectVisibleViews(
+        viewRoot,
+        visibilityPredicate
+    ).filter(
+        (view) =>
+            candidates.has(view) && view.getDataInitializationState() === "none"
     );
 
     if (viewsToInitialize.length === 0) {

--- a/packages/core/src/genomeSpyBase.js
+++ b/packages/core/src/genomeSpyBase.js
@@ -492,7 +492,7 @@ export default class GenomeSpy {
 
         // Allow early layout requests from view subscriptions created during initialization.
         // Layout will be recomputed anyway once launch completes.
-        context.requestLayoutReflow = this.computeLayout.bind(this);
+        context.requestLayoutReflow = this.requestLayoutReflow.bind(this);
 
         this.#setupDpr();
     }
@@ -513,7 +513,7 @@ export default class GenomeSpy {
      */
     #finalizeViewInitialization(context) {
         // Allow layout computation (in case a custom context overrode the early assignment).
-        context.requestLayoutReflow = this.computeLayout.bind(this);
+        context.requestLayoutReflow = this.requestLayoutReflow.bind(this);
 
         // Invalidate cached sizes to ensure that step-based sizes are current.
         // TODO: This should be done automatically when the domains of band/point scales are updated.
@@ -686,6 +686,14 @@ export default class GenomeSpy {
     computeLayout() {
         this.#renderCoordinator.computeLayout();
         this.#glHelper.invalidateSize();
+    }
+
+    /**
+     * Recomputes layout and schedules the buffered render commands to be drawn.
+     */
+    requestLayoutReflow() {
+        this.computeLayout();
+        this.animator.requestRender();
     }
 
     renderAll() {

--- a/packages/core/src/genomeSpyBase.test.js
+++ b/packages/core/src/genomeSpyBase.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, test, vi } from "vitest";
+
+import GenomeSpy from "./genomeSpyBase.js";
+
+describe("GenomeSpy layout reflow", () => {
+    test("requestLayoutReflow recomputes layout and schedules rendering", () => {
+        const computeLayout = vi.fn();
+        const requestRender = vi.fn();
+
+        /** @type {any} */ (GenomeSpy.prototype.requestLayoutReflow).call({
+            computeLayout,
+            animator: {
+                requestRender,
+            },
+        });
+
+        expect(computeLayout).toHaveBeenCalledTimes(1);
+        expect(requestRender).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/core/src/types/embedApi.d.ts
+++ b/packages/core/src/types/embedApi.d.ts
@@ -4,6 +4,8 @@ import { RootSpec } from "../spec/root.js";
 import { GenomeSpyConfig } from "../spec/config.js";
 import { Scalar } from "../spec/channel.js";
 import { IntervalSelection } from "./selectionTypes.js";
+import { ImportSpec, ViewSpec } from "../spec/view.js";
+import { ViewSelector } from "../view/viewUtilTypes.js";
 
 /**
  * Embeds GenomeSpy into the DOM
@@ -98,9 +100,202 @@ export interface ParamApi<T = ParamValue> {
 }
 
 /**
+ * Address of a view in the live layout hierarchy.
+ *
+ * Use a `ViewSelector` for durable references to named views within import or
+ * insertion scopes. Use a `ViewHandle` for views returned by this API,
+ * including anonymous views. Use `"root"` to address the root view.
+ */
+export type ViewAddress = ViewHandle | ViewSelector | "root";
+
+/**
+ * Options for inserting a new child view or subtree.
+ */
+export interface InsertViewOptions {
+    /**
+     * Child index where the view is inserted. If omitted, the view is appended.
+     */
+    index?: number;
+
+    /**
+     * Optional scope name for the inserted subtree.
+     *
+     * The scope makes repeated instances of the same spec independently
+     * addressable by selectors. It does not replace the inserted root view's
+     * own `name`.
+     */
+    scope?: string | null;
+}
+
+/**
+ * Public view kind reported by `ViewHandle`.
+ */
+export type ViewHandleType = "unit" | "layer" | "concat" | "grid" | "unknown";
+
+/**
+ * Options for reordering a view within its current parent container.
+ */
+export interface MoveViewOptions {
+    /**
+     * Destination child index within the target's current parent.
+     *
+     * The index is zero-based and is interpreted after temporarily removing
+     * the target from its parent. Values from `0` through the remaining child
+     * count are valid. A value equal to the remaining child count places the
+     * target last. Negative values and larger values throw.
+     *
+     * For children `[A, B, C, D]`, moving `B` with `index: 3` results in
+     * `[A, C, D, B]`.
+     */
+    index: number;
+}
+
+/**
+ * Live handle to a view in the embedded GenomeSpy instance.
+ *
+ * The exposed hierarchy matches the layout tree derived from the
+ * visualization spec: unit views and container views are represented as view
+ * handles, and child order is the layout order declared by the spec.
+ * GenomeSpy may add an implicit root layout container, for example when a
+ * root unit view needs space for axes, titles, or other guides.
+ *
+ * Handles are opaque public references. They do not expose internal `View`
+ * objects, and callers should check `isAlive()` before reusing a handle after
+ * mutations that may have removed its subtree.
+ */
+export interface ViewHandle {
+    /**
+     * Runtime-stable id for this handle.
+     *
+     * The id is stable only for the current embedded instance. It is not a
+     * bookmark or serialization format.
+     */
+    readonly id: string;
+
+    /**
+     * Explicit view name, if the view has one.
+     */
+    readonly name: string | undefined;
+
+    /**
+     * Selector for this view, if the view is addressable by selector.
+     */
+    readonly selector: ViewSelector | undefined;
+
+    /**
+     * Public view kind.
+     */
+    readonly type: ViewHandleType;
+
+    /**
+     * Returns whether the referenced view is still part of the live hierarchy.
+     */
+    isAlive: () => boolean;
+
+    /**
+     * Returns a handle to the layout parent, if the view has one.
+     */
+    parent: () => ViewHandle | undefined;
+
+    /**
+     * Returns handles for the current layout child views in spec order.
+     */
+    children: () => ViewHandle[];
+}
+
+/**
+ * API for mutating the live layout hierarchy.
+ *
+ * The hierarchy model matches the layout tree derived from the visualization
+ * spec. The API addresses view nodes such as unit, layer, concat, and grid
+ * views, plus implicit layout containers that GenomeSpy may add at the root.
+ * It does not address rendered marks, guide primitives, DOM nodes, or other
+ * internal implementation objects.
+ *
+ * Mutations are asynchronous because view creation, imports, dataflow
+ * initialization, data loading, guide rebuilding, and layout updates may all be
+ * involved. Mutation promises resolve when the operation-specific lifecycle has
+ * completed.
+ */
+export interface ViewMutationApi {
+    /**
+     * Returns a handle to the root layout view.
+     *
+     * The root may be an implicit layout container rather than the top-level
+     * view declared by the input spec.
+     */
+    root: () => ViewHandle;
+
+    /**
+     * Resolves an address to a live view handle.
+     *
+     * Returns `undefined` when the address cannot be resolved or when a handle
+     * no longer refers to a live view.
+     */
+    resolve: (address: ViewAddress) => ViewHandle | undefined;
+
+    /**
+     * Resolves an address to a live view handle.
+     *
+     * Throws if the address cannot be resolved or if a handle no longer refers
+     * to a live view.
+     */
+    get: (address: ViewAddress) => ViewHandle;
+
+    /**
+     * Inserts a new child view or subtree under a mutable container view.
+     *
+     * The `spec` can be an ordinary view spec or an import spec. Use
+     * `options.scope` to give the inserted instance a selector scope, allowing
+     * the same spec to be inserted multiple times and addressed independently.
+     */
+    insert: (
+        parent: ViewAddress,
+        spec: ViewSpec | ImportSpec,
+        options?: InsertViewOptions
+    ) => Promise<ViewHandle>;
+
+    /**
+     * Removes a view and disposes its subtree.
+     *
+     * Removing the root view is not supported.
+     */
+    remove: (target: ViewAddress) => Promise<void>;
+
+    /**
+     * Reorders a view within its current parent container.
+     *
+     * `options.index` is the destination index after temporarily removing the
+     * target from its current position.
+     *
+     * Moving a view to another branch of the hierarchy is not supported by the
+     * initial API.
+     */
+    move: (
+        target: ViewAddress,
+        options: MoveViewOptions
+    ) => Promise<ViewHandle>;
+
+    /**
+     * Runs multiple mutations as one ordered transaction.
+     *
+     * Implementations may defer layout and rendering work until the callback
+     * has completed.
+     */
+    transaction: <T>(
+        callback: (views: ViewMutationApi) => T | Promise<T>
+    ) => Promise<T>;
+}
+
+/**
  * An API for controlling the embedded GenomeSpy instance.
  */
 export interface EmbedResult {
+    /**
+     * Controls the live view hierarchy.
+     */
+    views: ViewMutationApi;
+
     /**
      * Releases all resources and unregisters event listeners, etc.
      */

--- a/packages/core/src/types/embedApi.d.ts
+++ b/packages/core/src/types/embedApi.d.ts
@@ -133,6 +133,35 @@ export interface InsertViewOptions {
 export type ViewHandleType = "unit" | "layer" | "concat" | "grid" | "unknown";
 
 /**
+ * Last rendered layout bounds for a view, in CSS pixels.
+ *
+ * The coordinate space is the embedded GenomeSpy canvas. Convert these bounds
+ * to DOM coordinates in the embedding application when positioning external
+ * controls.
+ */
+export interface ViewLayoutBounds {
+    /**
+     * Horizontal position of the view's left edge.
+     */
+    x: number;
+
+    /**
+     * Vertical position of the view's top edge.
+     */
+    y: number;
+
+    /**
+     * View width.
+     */
+    width: number;
+
+    /**
+     * View height.
+     */
+    height: number;
+}
+
+/**
  * Options for reordering a view within its current parent container.
  */
 export interface MoveViewOptions {
@@ -204,7 +233,7 @@ export interface ViewHandle {
 }
 
 /**
- * API for mutating the live layout hierarchy.
+ * API for inspecting and mutating the live layout hierarchy.
  *
  * The hierarchy model matches the layout tree derived from the visualization
  * spec. The API addresses view nodes such as unit, layer, concat, and grid
@@ -217,7 +246,7 @@ export interface ViewHandle {
  * involved. Mutation promises resolve when the operation-specific lifecycle has
  * completed.
  */
-export interface ViewMutationApi {
+export interface ViewApi {
     /**
      * Returns a handle to the root layout view.
      *
@@ -241,6 +270,23 @@ export interface ViewMutationApi {
      * to a live view.
      */
     get: (address: ViewAddress) => ViewHandle;
+
+    /**
+     * Returns the last rendered layout bounds for a view.
+     *
+     * Bounds are returned in CSS pixels in the embedded GenomeSpy canvas
+     * coordinate space. Returns `undefined` if the address is unresolved, the
+     * view is no longer live, or the view has not been rendered yet.
+     */
+    getLayoutBounds: (address: ViewAddress) => ViewLayoutBounds | undefined;
+
+    /**
+     * Subscribes to completed layout updates.
+     *
+     * The listener is called after a layout/render pass has updated view
+     * bounds. Returns an unsubscribe function.
+     */
+    subscribeToLayout: (listener: () => void) => () => void;
 
     /**
      * Inserts a new child view or subtree under a mutable container view.
@@ -283,18 +329,24 @@ export interface ViewMutationApi {
      * has completed.
      */
     transaction: <T>(
-        callback: (views: ViewMutationApi) => T | Promise<T>
+        callback: (views: ViewApi) => T | Promise<T>
     ) => Promise<T>;
 }
+
+/**
+ * @deprecated Use `ViewApi`. The `api.views` namespace now includes both
+ * mutation and layout observation methods.
+ */
+export type ViewMutationApi = ViewApi;
 
 /**
  * An API for controlling the embedded GenomeSpy instance.
  */
 export interface EmbedResult {
     /**
-     * Controls the live view hierarchy.
+     * Inspects and controls the live view hierarchy.
      */
-    views: ViewMutationApi;
+    views: ViewApi;
 
     /**
      * Releases all resources and unregisters event listeners, etc.

--- a/packages/core/src/utils/arrayUtils.js
+++ b/packages/core/src/utils/arrayUtils.js
@@ -59,3 +59,26 @@ export function asArray(obj) {
 export function peek(arr) {
     return arr[arr.length - 1];
 }
+
+/**
+ * Moves an item within an array.
+ *
+ * The destination index is interpreted after temporarily removing the item.
+ *
+ * @param {T[]} arr
+ * @param {number} fromIndex
+ * @param {number} index
+ * @template T
+ */
+export function moveArrayItem(arr, fromIndex, index) {
+    if (fromIndex < 0 || fromIndex >= arr.length) {
+        throw new Error("Source index out of range.");
+    }
+
+    if (index < 0 || index > arr.length - 1) {
+        throw new Error("Destination index out of range.");
+    }
+
+    const [item] = arr.splice(fromIndex, 1);
+    arr.splice(index, 0, item);
+}

--- a/packages/core/src/view/concatView.js
+++ b/packages/core/src/view/concatView.js
@@ -104,11 +104,15 @@ export default class ConcatView extends GridView {
      *
      * @param {number} fromIndex
      * @param {number} index Destination index after temporarily removing the child.
+     * @returns {Promise<void>}
      */
-    moveChildAt(fromIndex, index) {
+    async moveChildAt(fromIndex, index) {
         const { specs } = this.#getChildSpecs();
         moveArrayItem(specs, fromIndex, index);
         super.moveChildAt(fromIndex, index);
+        // Reordering can move shared guide ownership without changing existing
+        // child-local guides.
+        await this.syncGuideViews({ gridChildren: [] });
         this.context.requestLayoutReflow();
     }
 
@@ -175,13 +179,12 @@ export default class ConcatView extends GridView {
             getChildSpecs: this.#getChildSpecs.bind(this),
             insertView: (view, index) => this.insertChildViewAt(view, index),
             removeView: (index) => super.removeChildAt(index),
-            prepareView: async (view, _index, gridChild) => {
-                await gridChild.createAxes();
-                await this.syncSharedAxes();
-            },
-            afterRemove: async () => {
-                await this.syncSharedAxes();
-            },
+            syncMutationGuideViews: (_view, _index, gridChild) =>
+                this.syncGuideViews({
+                    // Only inserted grid children need new local guides. Shared
+                    // guides are synced by GridView regardless of this filter.
+                    gridChildren: gridChild ? [gridChild] : [],
+                }),
             defaultName: () => this.getNextAutoName("grid"),
         });
     }

--- a/packages/core/src/view/concatView.js
+++ b/packages/core/src/view/concatView.js
@@ -107,12 +107,14 @@ export default class ConcatView extends GridView {
      * @returns {Promise<void>}
      */
     async moveChildAt(fromIndex, index) {
+        const mutationHelper = this.#getMutationHelper();
         const { specs } = this.#getChildSpecs();
         moveArrayItem(specs, fromIndex, index);
         super.moveChildAt(fromIndex, index);
         // Reordering can move shared guide ownership without changing existing
         // child-local guides.
         await this.syncGuideViews({ gridChildren: [] });
+        await mutationHelper.initializeUninitializedChromeViews();
         this.context.requestLayoutReflow();
     }
 

--- a/packages/core/src/view/concatView.js
+++ b/packages/core/src/view/concatView.js
@@ -5,6 +5,7 @@ import {
 } from "./viewSpecGuards.js";
 import GridView from "./gridView/gridView.js";
 import ContainerMutationHelper from "./containerMutationHelper.js";
+import { moveArrayItem } from "../utils/arrayUtils.js";
 
 /**
  * Creates a vertically or horizontally concatenated layout for children.
@@ -96,6 +97,19 @@ export default class ConcatView extends GridView {
      */
     async removeChildAt(index) {
         await this.#getMutationHelper().removeChildAt(index);
+    }
+
+    /**
+     * Moves a child within the concat container without recreating it.
+     *
+     * @param {number} fromIndex
+     * @param {number} index Destination index after temporarily removing the child.
+     */
+    moveChildAt(fromIndex, index) {
+        const { specs } = this.#getChildSpecs();
+        moveArrayItem(specs, fromIndex, index);
+        super.moveChildAt(fromIndex, index);
+        this.context.requestLayoutReflow();
     }
 
     /**

--- a/packages/core/src/view/concatView.js
+++ b/packages/core/src/view/concatView.js
@@ -81,7 +81,7 @@ export default class ConcatView extends GridView {
      * Callers should prefer this over direct GridView insertion to ensure
      * dataflow initialization, axis wiring, and layout reflow are handled.
      *
-     * @param {import("../spec/view.js").ViewSpec} childSpec
+     * @param {import("../spec/view.js").ViewSpec | import("../spec/view.js").ImportSpec} childSpec
      * @param {number} [index]
      * @returns {Promise<import("./view.js").default>}
      */

--- a/packages/core/src/view/containerMutationHelper.js
+++ b/packages/core/src/view/containerMutationHelper.js
@@ -169,7 +169,7 @@ export default class ContainerMutationHelper {
      */
     async #rollbackInsertedChild(index, originalError) {
         try {
-            await this.removeChildAt(index);
+            await this.removeChildAt(index, { requestLayout: false });
         } catch (rollbackError) {
             /** @type {any} */ (originalError).rollbackError = rollbackError;
         }
@@ -179,8 +179,9 @@ export default class ContainerMutationHelper {
      * Removes a child by index and updates the backing spec list.
      *
      * @param {number} index
+     * @param {{ requestLayout?: boolean }} [options]
      */
-    async removeChildAt(index) {
+    async removeChildAt(index, options = {}) {
         const { removeAt } = this.options.getChildSpecs();
         clearViewLevelScaleConfigs(this.container);
         clearViewLevelGuideConfigs(this.container);
@@ -219,7 +220,10 @@ export default class ContainerMutationHelper {
             );
         }
 
-        if (this.options.requestLayout !== false) {
+        if (
+            this.options.requestLayout !== false &&
+            options.requestLayout !== false
+        ) {
             this.container.invalidateSizeCache();
             this.container.context.requestLayoutReflow();
         }

--- a/packages/core/src/view/containerMutationHelper.js
+++ b/packages/core/src/view/containerMutationHelper.js
@@ -47,6 +47,11 @@ export default class ContainerMutationHelper {
      *   removeView: (index: number) => void,
      *   prepareView?: (view: View, index: number, insertionResult: any) => Promise<void>,
      *   afterRemove?: (index: number) => Promise<void>,
+     *   syncMutationGuideViews?: (
+     *     view: View | undefined,
+     *     index: number | undefined,
+     *     insertionResult: any
+     *   ) => Promise<void>,
      *   defaultName?: (index: number, spec: ViewSpec | ImportSpec) => string,
      *   createViewOptions?: import("../types/viewContext.js").CreateViewOptions,
      *   requestLayout?: boolean
@@ -109,6 +114,16 @@ export default class ContainerMutationHelper {
 
             if (this.options.prepareView) {
                 await this.options.prepareView(
+                    childView,
+                    insertIndex,
+                    insertionResult
+                );
+            }
+
+            // Guide views are container-specific. Sync them after configs and
+            // assemblies are ready so generated guide marks can initialize.
+            if (this.options.syncMutationGuideViews) {
+                await this.options.syncMutationGuideViews(
                     childView,
                     insertIndex,
                     insertionResult
@@ -178,6 +193,15 @@ export default class ContainerMutationHelper {
         attachViewLevelScaleConfigs(this.container);
         attachViewLevelAxisConfigs(this.container);
         attachViewLevelLegendConfigs(this.container);
+
+        // Removed children may change shared guide ownership and visibility.
+        if (this.options.syncMutationGuideViews) {
+            await this.options.syncMutationGuideViews(
+                undefined,
+                undefined,
+                undefined
+            );
+        }
 
         if (this.container.getDataInitializationState() !== "none") {
             const viewsToInitialize = collectUninitializedChromeViews(

--- a/packages/core/src/view/containerMutationHelper.js
+++ b/packages/core/src/view/containerMutationHelper.js
@@ -179,6 +179,22 @@ export default class ContainerMutationHelper {
         attachViewLevelAxisConfigs(this.container);
         attachViewLevelLegendConfigs(this.container);
 
+        if (this.container.getDataInitializationState() !== "none") {
+            const viewsToInitialize = collectUninitializedChromeViews(
+                this.container
+            );
+            for (const view of viewsToInitialize) {
+                view.configureViewOpacity();
+            }
+
+            await initializeViewDataForViews(
+                this.container,
+                this.container.context.dataFlow,
+                this.container.context.fontManager,
+                viewsToInitialize
+            );
+        }
+
         if (this.options.requestLayout !== false) {
             this.container.invalidateSizeCache();
             this.container.context.requestLayoutReflow();
@@ -198,7 +214,17 @@ function collectMutationInitializedViews(
     insertionResult
 ) {
     const views = collectInsertedViews(childView, insertionResult);
+    collectUninitializedChromeViews(container, views);
 
+    return views;
+}
+
+/**
+ * @param {import("./containerView.js").default} container
+ * @param {Set<import("./view.js").default>} [views]
+ * @returns {Set<import("./view.js").default>}
+ */
+function collectUninitializedChromeViews(container, views = new Set()) {
     for (const view of container.getDescendants()) {
         if (
             isChromeView(view) &&

--- a/packages/core/src/view/containerMutationHelper.js
+++ b/packages/core/src/view/containerMutationHelper.js
@@ -204,21 +204,7 @@ export default class ContainerMutationHelper {
             );
         }
 
-        if (this.container.getDataInitializationState() !== "none") {
-            const viewsToInitialize = collectUninitializedChromeViews(
-                this.container
-            );
-            for (const view of viewsToInitialize) {
-                view.configureViewOpacity();
-            }
-
-            await initializeViewDataForViews(
-                this.container,
-                this.container.context.dataFlow,
-                this.container.context.fontManager,
-                viewsToInitialize
-            );
-        }
+        await this.initializeUninitializedChromeViews();
 
         if (
             this.options.requestLayout !== false &&
@@ -227,6 +213,33 @@ export default class ContainerMutationHelper {
             this.container.invalidateSizeCache();
             this.container.context.requestLayoutReflow();
         }
+    }
+
+    /**
+     * Initializes generated guide/chrome views created by a dynamic mutation.
+     *
+     * Reorder operations can recreate shared axes or legends without touching
+     * normal child dataflow. This keeps those regenerated chrome views renderable
+     * without reloading or rebuilding existing track data.
+     */
+    async initializeUninitializedChromeViews() {
+        if (this.container.getDataInitializationState() === "none") {
+            return;
+        }
+
+        const viewsToInitialize = collectUninitializedChromeViews(
+            this.container
+        );
+        for (const view of viewsToInitialize) {
+            view.configureViewOpacity();
+        }
+
+        await initializeViewDataForViews(
+            this.container,
+            this.container.context.dataFlow,
+            this.container.context.fontManager,
+            viewsToInitialize
+        );
     }
 }
 

--- a/packages/core/src/view/containerMutationHelper.js
+++ b/packages/core/src/view/containerMutationHelper.js
@@ -70,12 +70,14 @@ export default class ContainerMutationHelper {
      * @returns {Promise<View>}
      */
     async addChildSpec(childSpec, index) {
-        const { specs, insertAt } = this.options.getChildSpecs();
+        const { specs, insertAt, removeAt } = this.options.getChildSpecs();
         const insertIndex = index ?? specs.length;
         const name =
             this.options.defaultName?.(insertIndex, childSpec) ??
             this.container.getNextAutoName("child");
 
+        let specInserted = false;
+        let viewInserted = false;
         const childView = await this.container.context.createOrImportView(
             childSpec,
             this.container,
@@ -85,43 +87,58 @@ export default class ContainerMutationHelper {
             this.options.createViewOptions
         );
 
-        insertAt(insertIndex, childSpec);
-        const insertionResult = this.options.insertView(childView, insertIndex);
-
-        attachViewLevelScaleConfigs(this.container);
-        attachViewLevelAxisConfigs(this.container);
-        attachViewLevelLegendConfigs(this.container);
-
-        // Reminder: ensure assemblies from the real child hierarchy before any
-        // downstream work that may initialize scales (axis prep / encoders).
-        await ensureAssembliesForView(
-            childView,
-            this.container.context.genomeStore
-        );
-
-        if (this.options.prepareView) {
-            await this.options.prepareView(
+        try {
+            insertAt(insertIndex, childSpec);
+            specInserted = true;
+            const insertionResult = this.options.insertView(
                 childView,
-                insertIndex,
+                insertIndex
+            );
+            viewInserted = true;
+
+            attachViewLevelScaleConfigs(this.container);
+            attachViewLevelAxisConfigs(this.container);
+            attachViewLevelLegendConfigs(this.container);
+
+            // Reminder: ensure assemblies from the real child hierarchy before any
+            // downstream work that may initialize scales (axis prep / encoders).
+            await ensureAssembliesForView(
+                childView,
+                this.container.context.genomeStore
+            );
+
+            if (this.options.prepareView) {
+                await this.options.prepareView(
+                    childView,
+                    insertIndex,
+                    insertionResult
+                );
+            }
+
+            const viewsToInitialize = collectMutationInitializedViews(
+                this.container,
+                childView,
                 insertionResult
             );
-        }
+            for (const view of viewsToInitialize) {
+                view.configureViewOpacity();
+            }
 
-        const viewsToInitialize = collectMutationInitializedViews(
-            this.container,
-            childView,
-            insertionResult
-        );
-        for (const view of viewsToInitialize) {
-            view.configureViewOpacity();
-        }
+            await initializeViewDataForViews(
+                this.container,
+                this.container.context.dataFlow,
+                this.container.context.fontManager,
+                viewsToInitialize
+            );
+        } catch (error) {
+            if (viewInserted) {
+                await this.#rollbackInsertedChild(insertIndex, error);
+            } else if (specInserted) {
+                removeAt(insertIndex);
+            }
 
-        await initializeViewDataForViews(
-            this.container,
-            this.container.context.dataFlow,
-            this.container.context.fontManager,
-            viewsToInitialize
-        );
+            throw error;
+        }
 
         if (this.options.requestLayout !== false) {
             this.container.invalidateSizeCache();
@@ -129,6 +146,18 @@ export default class ContainerMutationHelper {
         }
 
         return childView;
+    }
+
+    /**
+     * @param {number} index
+     * @param {unknown} originalError
+     */
+    async #rollbackInsertedChild(index, originalError) {
+        try {
+            await this.removeChildAt(index);
+        } catch (rollbackError) {
+            /** @type {any} */ (originalError).rollbackError = rollbackError;
+        }
     }
 
     /**

--- a/packages/core/src/view/containerMutationHelper.js
+++ b/packages/core/src/view/containerMutationHelper.js
@@ -1,8 +1,5 @@
-import {
-    initializeViewSubtree,
-    loadViewSubtreeData,
-} from "../data/flowInit.js";
 import { ensureAssembliesForView } from "../genome/assemblyPreflight.js";
+import { initializeViewDataForViews } from "../genomeSpy/viewDataInit.js";
 import {
     attachViewLevelScaleConfigs,
     clearViewLevelScaleConfigs,
@@ -13,7 +10,6 @@ import {
     clearViewLevelGuideConfigs,
 } from "../scales/viewLevelGuideConfig.js";
 import { isChromeView } from "./viewSelectors.js";
-import { finalizeSubtreeGraphics } from "./viewUtils.js";
 
 /**
  * @param {unknown} value
@@ -120,17 +116,12 @@ export default class ContainerMutationHelper {
             view.configureViewOpacity();
         }
 
-        const visibilityPredicate = (
-            /** @type {import("./view.js").default} */ view
-        ) => view.isConfiguredVisible();
-        const { dataSources, graphicsPromises } = initializeViewSubtree(
+        await initializeViewDataForViews(
             this.container,
             this.container.context.dataFlow,
-            visibilityPredicate,
-            (view) => viewsToInitialize.has(view)
+            this.container.context.fontManager,
+            viewsToInitialize
         );
-        await loadViewSubtreeData(childView, dataSources);
-        await finalizeSubtreeGraphics(graphicsPromises);
 
         if (this.options.requestLayout !== false) {
             this.container.invalidateSizeCache();

--- a/packages/core/src/view/containerMutationHelper.js
+++ b/packages/core/src/view/containerMutationHelper.js
@@ -2,7 +2,6 @@ import {
     initializeViewSubtree,
     loadViewSubtreeData,
 } from "../data/flowInit.js";
-import { configureViewOpacity } from "../genomeSpy/viewHierarchyConfig.js";
 import { ensureAssembliesForView } from "../genome/assemblyPreflight.js";
 import {
     attachViewLevelScaleConfigs,
@@ -13,7 +12,20 @@ import {
     attachViewLevelLegendConfigs,
     clearViewLevelGuideConfigs,
 } from "../scales/viewLevelGuideConfig.js";
+import { isChromeView } from "./viewSelectors.js";
 import { finalizeSubtreeGraphics } from "./viewUtils.js";
+
+/**
+ * @param {unknown} value
+ * @returns {value is { getChildren: () => Iterable<import("./view.js").default> }}
+ */
+function hasGridChildChildren(value) {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof (/** @type {any} */ (value).getChildren) === "function"
+    );
+}
 
 /**
  * Shared helper for dynamic container mutations.
@@ -99,15 +111,23 @@ export default class ContainerMutationHelper {
             );
         }
 
-        configureViewOpacity(childView);
+        const viewsToInitialize = collectMutationInitializedViews(
+            this.container,
+            childView,
+            insertionResult
+        );
+        for (const view of viewsToInitialize) {
+            view.configureViewOpacity();
+        }
 
         const visibilityPredicate = (
             /** @type {import("./view.js").default} */ view
         ) => view.isConfiguredVisible();
         const { dataSources, graphicsPromises } = initializeViewSubtree(
-            childView,
+            this.container,
             this.container.context.dataFlow,
-            visibilityPredicate
+            visibilityPredicate,
+            (view) => viewsToInitialize.has(view)
         );
         await loadViewSubtreeData(childView, dataSources);
         await finalizeSubtreeGraphics(graphicsPromises);
@@ -144,4 +164,50 @@ export default class ContainerMutationHelper {
             this.container.context.requestLayoutReflow();
         }
     }
+}
+
+/**
+ * @param {import("./containerView.js").default} container
+ * @param {import("./view.js").default} childView
+ * @param {unknown} insertionResult
+ * @returns {Set<import("./view.js").default>}
+ */
+function collectMutationInitializedViews(
+    container,
+    childView,
+    insertionResult
+) {
+    const views = collectInsertedViews(childView, insertionResult);
+
+    for (const view of container.getDescendants()) {
+        if (
+            isChromeView(view) &&
+            view.getDataInitializationState() === "none"
+        ) {
+            for (const chromeView of view.getDescendants()) {
+                if (chromeView.getDataInitializationState() === "none") {
+                    views.add(chromeView);
+                }
+            }
+        }
+    }
+
+    return views;
+}
+
+/**
+ * @param {import("./view.js").default} childView
+ * @param {unknown} insertionResult
+ * @returns {Set<import("./view.js").default>}
+ */
+function collectInsertedViews(childView, insertionResult) {
+    if (hasGridChildChildren(insertionResult)) {
+        return new Set(
+            Array.from(insertionResult.getChildren()).flatMap((view) =>
+                view.getDescendants()
+            )
+        );
+    }
+
+    return new Set(childView.getDescendants());
 }

--- a/packages/core/src/view/gridView/gridView.js
+++ b/packages/core/src/view/gridView/gridView.js
@@ -636,9 +636,7 @@ export default class GridView extends ContainerView {
      * @return {Padding}
      */
     getOverhang() {
-        return this.#getGridOverhang()
-            .union(this.#getSharedAxisOverhang())
-            .union(this.#getSharedLegendOverhang());
+        return this.#getGridOverhang().add(this.#getSharedGuideOverhang());
     }
 
     #getGridOverhang() {
@@ -692,6 +690,12 @@ export default class GridView extends ContainerView {
         );
     }
 
+    #getSharedGuideOverhang() {
+        return this.#getSharedAxisOverhang().add(
+            this.#getSharedLegendOverhang()
+        );
+    }
+
     #getSharedAxesByOrient() {
         /** @type {Partial<Record<import("../../spec/axis.js").AxisOrient, AxisView>>} */
         const axes = {};
@@ -723,11 +727,7 @@ export default class GridView extends ContainerView {
                     this.#getFlexSize("row"),
                     parallelLegendSize.height,
                 ])
-            ).addPadding(
-                this.#getSharedAxisOverhang().union(
-                    this.#getSharedLegendOverhang()
-                )
-            );
+            ).addPadding(this.#getSharedGuideOverhang());
         });
     }
 
@@ -747,9 +747,7 @@ export default class GridView extends ContainerView {
             // Usually padding is applied by the parent GridView, but if this is the root view, we need to apply it here
             coords = coords.shrink(this.getPadding());
         }
-        const sharedGuideOverhang = this.#getSharedAxisOverhang().union(
-            this.#getSharedLegendOverhang()
-        );
+        const sharedGuideOverhang = this.#getSharedGuideOverhang();
         coords = coords.shrink(sharedGuideOverhang);
 
         context.pushView(this, coords);
@@ -843,10 +841,12 @@ export default class GridView extends ContainerView {
              * @param {boolean} explicitViewport
              */
             const getLen = (size, dimension, explicitViewport = false) =>
-                (size[dimension].grow
-                    ? (dimension == "width" ? colLocSize : rowLocSize).size
-                    : size[dimension].px) +
-                (explicitViewport ? 0 : overhang[dimension]);
+                explicitViewport
+                    ? size[dimension].grow
+                        ? (dimension == "width" ? colLocSize : rowLocSize).size
+                        : size[dimension].px
+                    : (dimension == "width" ? colLocSize : rowLocSize).size +
+                      overhang[dimension];
 
             const viewportWidth = getLen(
                 viewportSize,

--- a/packages/core/src/view/gridView/gridView.js
+++ b/packages/core/src/view/gridView/gridView.js
@@ -343,11 +343,25 @@ export default class GridView extends ContainerView {
      * @protected
      */
     async createAxes() {
+        await this.syncGuideViews();
+    }
+
+    /**
+     * Recreates guide and chrome views that depend on the child hierarchy.
+     * Shared guides always depend on the whole container. Grid-child guides can
+     * be limited to newly inserted children during mutations.
+     *
+     * @param {{ gridChildren?: GridChild[] }} [options]
+     */
+    async syncGuideViews(options = {}) {
+        const gridChildren = options.gridChildren ?? this.#children;
+
         await this.syncSharedAxes();
         await this.syncSharedLegends();
         await Promise.all(
-            this.#children.map((gridChild) => gridChild.createAxes())
+            gridChildren.map((gridChild) => gridChild.createAxes())
         );
+        this.invalidateSizeCache();
     }
 
     /**

--- a/packages/core/src/view/gridView/gridView.js
+++ b/packages/core/src/view/gridView/gridView.js
@@ -38,6 +38,7 @@ import {
 } from "./gridChildLegends.js";
 import SeparatorView, { resolveSeparatorProps } from "./separatorView.js";
 import { getZoomableResolutions } from "./zoomNavigationUtils.js";
+import { moveArrayItem } from "../../utils/arrayUtils.js";
 import { isHConcatSpec, isVConcatSpec } from "../viewSpecGuards.js";
 import {
     clipCoords,
@@ -276,6 +277,17 @@ export default class GridView extends ContainerView {
         }
         this.#disposeGridChild(gridChild);
         this.#children.splice(index, 1);
+        this.invalidateSizeCache();
+    }
+
+    /**
+     * Moves a child within the grid without disposing it.
+     *
+     * @param {number} fromIndex
+     * @param {number} index Destination index after temporarily removing the child.
+     */
+    moveChildAt(fromIndex, index) {
+        moveArrayItem(this.#children, fromIndex, index);
         this.invalidateSizeCache();
     }
 

--- a/packages/core/src/view/layerView.js
+++ b/packages/core/src/view/layerView.js
@@ -73,7 +73,7 @@ export default class LayerView extends ContainerView {
     /**
      * Adds a child spec dynamically. Intended for post-initialization updates.
      *
-     * @param {import("../spec/view.js").LayerSpec | import("../spec/view.js").UnitSpec | import("../spec/view.js").ImportSpec} childSpec
+     * @param {import("../spec/view.js").LayerSpec | import("../spec/view.js").UnitSpec | import("../spec/view.js").MultiscaleSpec | import("../spec/view.js").ImportSpec} childSpec
      * @param {number} [index]
      * @returns {Promise<LayerView | import("./unitView.js").default>}
      */

--- a/packages/core/src/view/layerView.js
+++ b/packages/core/src/view/layerView.js
@@ -3,6 +3,7 @@ import ViewError from "./viewError.js";
 import ContainerMutationHelper from "./containerMutationHelper.js";
 import { isMultiscaleSpec } from "./multiscale.js";
 import { isLayerSpec, isUnitSpec } from "./viewSpecGuards.js";
+import { moveArrayItem } from "../utils/arrayUtils.js";
 
 /**
  * @template {import("../spec/view.js").LayerSpec} [TSpec=import("../spec/view.js").LayerSpec]
@@ -90,6 +91,18 @@ export default class LayerView extends ContainerView {
      */
     async removeChildAt(index) {
         await this.#getMutationHelper().removeChildAt(index);
+    }
+
+    /**
+     * Moves a child within the layer container without recreating it.
+     *
+     * @param {number} fromIndex
+     * @param {number} index Destination index after temporarily removing the child.
+     */
+    moveChildAt(fromIndex, index) {
+        moveArrayItem(this.spec.layer, fromIndex, index);
+        moveArrayItem(this.#children, fromIndex, index);
+        this.context.requestLayoutReflow();
     }
 
     /**

--- a/packages/core/src/view/legendExtent.test.js
+++ b/packages/core/src/view/legendExtent.test.js
@@ -5,8 +5,12 @@ import Rectangle from "./layout/rectangle.js";
 import ViewRenderingContext from "./renderingContext/viewRenderingContext.js";
 import { createBroadcastingTestViewContext } from "./testUtils.js";
 import { VIEW_ROOT_NAME } from "./viewFactory.js";
-import { checkForDuplicateScaleNames } from "./viewUtils.js";
+import {
+    calculateCanvasSize,
+    checkForDuplicateScaleNames,
+} from "./viewUtils.js";
 import { initializeViewData } from "../genomeSpy/viewDataInit.js";
+import { createHeadlessEngine } from "../genomeSpy/headlessBootstrap.js";
 
 /**
  * @typedef {import("./testUtils.js").BroadcastingViewContext} BroadcastingViewContext
@@ -94,6 +98,21 @@ function reflow(root, context) {
     context.emitBroadcast(root, "layoutComputed");
 }
 
+/**
+ * @param {import("./view.js").default} root
+ */
+function getRenderedBounds(root) {
+    /** @type {{ width: number, height: number }} */
+    const bounds = { width: 0, height: 0 };
+    root.visit((view) => {
+        for (const coords of view.facetCoords.values()) {
+            bounds.width = Math.max(bounds.width, coords.x2);
+            bounds.height = Math.max(bounds.height, coords.y2);
+        }
+    });
+    return bounds;
+}
+
 async function flushMicrotasks() {
     await Promise.resolve();
     await Promise.resolve();
@@ -157,6 +176,82 @@ describe("Legend extent measurement", () => {
         await settleLayout(root, context);
 
         expect(legend.getPerpendicularSize()).toBeGreaterThan(80);
+    });
+
+    test("canvas size includes measured shared track legend extent", async () => {
+        const { view } = await createHeadlessEngine({
+            vconcat: [
+                {
+                    name: "tracks",
+                    spacing: 5,
+                    resolve: {
+                        axis: { x: "shared" },
+                        scale: { color: "shared" },
+                        legend: { color: "shared" },
+                    },
+                    vconcat: [
+                        {
+                            name: "signal",
+                            height: 80,
+                            data: {
+                                values: [
+                                    { pos: 0, value: 0.2 },
+                                    { pos: 1, value: 0.8 },
+                                ],
+                            },
+                            mark: "rect",
+                            encoding: {
+                                x: { field: "pos", type: "index" },
+                                y: {
+                                    field: "value",
+                                    type: "quantitative",
+                                },
+                                color: { value: "steelblue" },
+                            },
+                        },
+                        {
+                            name: "variants",
+                            height: 36,
+                            data: {
+                                values: [
+                                    { pos: 0.5, type: "SNV" },
+                                    { pos: 1.5, type: "DEL" },
+                                ],
+                            },
+                            mark: { type: "point", size: 120 },
+                            encoding: {
+                                x: { field: "pos", type: "index" },
+                                color: {
+                                    field: "type",
+                                    type: "nominal",
+                                },
+                            },
+                        },
+                    ],
+                },
+            ],
+            config: {
+                view: { stroke: "lightgray" },
+            },
+            padding: 10,
+        });
+        await flushMicrotasks();
+        const canvasSize = calculateCanvasSize(view);
+        view.render(
+            new NoOpRenderingContext({ picking: false }),
+            Rectangle.create(
+                0,
+                0,
+                canvasSize.width ?? 700,
+                canvasSize.height ?? 300
+            ),
+            { firstFacet: true }
+        );
+
+        // Shared legends and axes on the same side reserve additive overhang.
+        expect(canvasSize.height).toBeGreaterThanOrEqual(
+            getRenderedBounds(view).height
+        );
     });
 
     test("compact gradient legends do not reserve symbol legend extent", async () => {

--- a/packages/core/src/view/viewMutationAcidTestUtils.js
+++ b/packages/core/src/view/viewMutationAcidTestUtils.js
@@ -12,10 +12,11 @@ import { renderToLayout } from "./testUtils.js";
 
 /**
  * @param {import("../spec/root.js").RootSpec} spec
+ * @param {Parameters<typeof createHeadlessEngine>[1]} [options]
  * @returns {Promise<ViewMutationAcidHarness>}
  */
-export async function createViewMutationAcidHarness(spec) {
-    const { view, context } = await createHeadlessEngine(spec);
+export async function createViewMutationAcidHarness(spec, options) {
+    const { view, context } = await createHeadlessEngine(spec, options);
 
     return {
         view,

--- a/packages/core/src/view/viewMutationAcidTestUtils.js
+++ b/packages/core/src/view/viewMutationAcidTestUtils.js
@@ -5,7 +5,8 @@ import { renderToLayout } from "./testUtils.js";
 /**
  * @typedef {{
  *   view: import("./view.js").default,
- *   api: import("../types/embedApi.js").ViewApi
+ *   api: import("../types/embedApi.js").ViewApi,
+ *   context: import("../types/viewContext.js").default
  * }} ViewMutationAcidHarness
  */
 
@@ -14,11 +15,12 @@ import { renderToLayout } from "./testUtils.js";
  * @returns {Promise<ViewMutationAcidHarness>}
  */
 export async function createViewMutationAcidHarness(spec) {
-    const { view } = await createHeadlessEngine(spec);
+    const { view, context } = await createHeadlessEngine(spec);
 
     return {
         view,
         api: createViewMutationApi({ viewRoot: view }),
+        context,
     };
 }
 

--- a/packages/core/src/view/viewMutationAcidTestUtils.js
+++ b/packages/core/src/view/viewMutationAcidTestUtils.js
@@ -1,0 +1,163 @@
+import { createViewMutationApi } from "./viewMutationApi.js";
+import { createHeadlessEngine } from "../genomeSpy/headlessBootstrap.js";
+import { renderToLayout } from "./testUtils.js";
+
+/**
+ * @typedef {{
+ *   view: import("./view.js").default,
+ *   api: import("../types/embedApi.js").ViewApi
+ * }} ViewMutationAcidHarness
+ */
+
+/**
+ * @param {import("../spec/root.js").RootSpec} spec
+ * @returns {Promise<ViewMutationAcidHarness>}
+ */
+export async function createViewMutationAcidHarness(spec) {
+    const { view } = await createHeadlessEngine(spec);
+
+    return {
+        view,
+        api: createViewMutationApi({ viewRoot: view }),
+    };
+}
+
+/**
+ * Captures normalized lifecycle state that should remain stable after a
+ * round-trip mutation.
+ *
+ * @param {import("./view.js").default} viewRoot
+ */
+export function createMutationAcidSnapshot(viewRoot) {
+    return {
+        hierarchy: createHierarchySnapshot(viewRoot),
+        layout: renderToLayout(viewRoot),
+    };
+}
+
+/**
+ * Captures object identities that should survive a round-trip mutation.
+ *
+ * @param {import("./view.js").default} viewRoot
+ */
+export function captureMutationAcidIdentities(viewRoot) {
+    const views = viewRoot.getDescendants();
+
+    return {
+        views,
+        collectors: views.map((view) => view.flowHandle?.collector),
+    };
+}
+
+/**
+ * @param {import("./view.js").default} viewRoot
+ */
+function createHierarchySnapshot(viewRoot) {
+    const views = viewRoot.getDescendants();
+    const viewIndexes = new Map(views.map((view, index) => [view, index]));
+
+    return views.map((view) => ({
+        name: view.name,
+        explicitName: view.explicitName,
+        defaultName: view.defaultName,
+        type: view.constructor.name,
+        dataState: view.getDataInitializationState(),
+        visibleInSpec: view.isVisibleInSpec(),
+        configuredVisible: view.isConfiguredVisible(),
+        layoutParent: getViewIndex(viewIndexes, view.layoutParent),
+        dataParent: getViewIndex(viewIndexes, view.dataParent),
+        children: getLayoutChildren(view).map((child) =>
+            getRequiredViewIndex(viewIndexes, child)
+        ),
+        flowHandle: {
+            dataSource: Boolean(view.flowHandle?.dataSource),
+            collector: Boolean(view.flowHandle?.collector),
+        },
+        resolutions: createResolutionSnapshot(view, viewIndexes),
+    }));
+}
+
+/**
+ * @param {Map<import("./view.js").default, number>} viewIndexes
+ * @param {import("./view.js").default | null | undefined} view
+ */
+function getViewIndex(viewIndexes, view) {
+    return view ? getRequiredViewIndex(viewIndexes, view) : undefined;
+}
+
+/**
+ * @param {Map<import("./view.js").default, number>} viewIndexes
+ * @param {import("./view.js").default} view
+ */
+function getRequiredViewIndex(viewIndexes, view) {
+    const index = viewIndexes.get(view);
+    if (index === undefined) {
+        throw new Error("Expected view to be included in the hierarchy.");
+    }
+
+    return index;
+}
+
+/**
+ * @param {import("./view.js").default} view
+ * @returns {import("./view.js").default[]}
+ */
+function getLayoutChildren(view) {
+    const children = /** @type {{ children?: unknown }} */ (view).children;
+    return Array.isArray(children)
+        ? /** @type {import("./view.js").default[]} */ (children)
+        : [];
+}
+
+/**
+ * @param {import("./view.js").default} view
+ * @param {Map<import("./view.js").default, number>} viewIndexes
+ */
+function createResolutionSnapshot(view, viewIndexes) {
+    return {
+        scale: Object.fromEntries(
+            Object.entries(view.resolutions.scale)
+                .filter((entry) => entry[1])
+                .map(([channel, resolution]) => [
+                    channel,
+                    resolution.getOrderedMembers().map((member) => ({
+                        view: getRequiredViewIndex(viewIndexes, member.view),
+                        channel: member.channel,
+                        contributesToDomain: member.contributesToDomain,
+                    })),
+                ])
+        ),
+        axis: Object.fromEntries(
+            Object.entries(view.resolutions.axis)
+                .filter((entry) => entry[1])
+                .map(([channel, resolution]) => [
+                    channel,
+                    {
+                        visible: resolution.hasVisibleNonChromeMember(),
+                        title: resolution.getTitle(),
+                    },
+                ])
+        ),
+        legend: Object.fromEntries(
+            Object.entries(view.resolutions.legend)
+                .filter((entry) => entry[1])
+                .map(([channel, resolution]) => [
+                    channel,
+                    {
+                        visible: resolution.hasVisibleNonChromeMember(),
+                        definitions: resolution
+                            .getLegendDefs()
+                            .map((definition) => ({
+                                view: getRequiredViewIndex(
+                                    viewIndexes,
+                                    definition.view
+                                ),
+                                channel: definition.channel,
+                                type: definition.type,
+                                field: definition.field,
+                            })),
+                    },
+                ])
+        ),
+    };
+}

--- a/packages/core/src/view/viewMutationAcidTestUtils.js
+++ b/packages/core/src/view/viewMutationAcidTestUtils.js
@@ -50,6 +50,74 @@ export function captureMutationAcidIdentities(viewRoot) {
 }
 
 /**
+ * @template T
+ * @returns {{
+ *   promise: Promise<T>,
+ *   resolve: (value: T) => void,
+ *   reject: (reason?: unknown) => void
+ * }}
+ */
+export function createDeferred() {
+    /** @type {(value: any) => void} */
+    let resolve;
+    /** @type {(reason?: unknown) => void} */
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+
+    return { promise, resolve, reject };
+}
+
+/**
+ * @param {() => boolean} predicate
+ * @returns {Promise<void>}
+ */
+export async function waitUntil(predicate) {
+    for (let i = 0; i < 50; i++) {
+        if (predicate()) {
+            return;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    throw new Error("Condition was not met.");
+}
+
+/**
+ * @param {import("./view.js").default} viewRoot
+ * @param {string} name
+ */
+export function getRequiredView(viewRoot, name) {
+    const view = viewRoot.getDescendants().find((view) => view.name === name);
+    if (!view) {
+        throw new Error("Expected view: " + name);
+    }
+
+    return view;
+}
+
+/**
+ * @param {import("./view.js").default} view
+ */
+export function countCollectorRows(view) {
+    const collector = view.flowHandle?.collector;
+    if (!collector) {
+        throw new Error("Expected view to have a collector.");
+    }
+
+    let count = 0;
+    for (const datum of collector.getData()) {
+        void datum;
+        count++;
+    }
+
+    return count;
+}
+
+/**
  * @param {import("./view.js").default} viewRoot
  */
 function createHierarchySnapshot(viewRoot) {

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -1,10 +1,21 @@
 import { describe, expect, test } from "vitest";
 
+import DataSource from "../data/sources/dataSource.js";
+import { loadViewSubtreeData } from "../data/flowInit.js";
+import { registerLazyDataSource } from "../data/sources/lazy/lazyDataSourceRegistry.js";
 import {
     captureMutationAcidIdentities,
+    countCollectorRows,
+    createDeferred,
     createMutationAcidSnapshot,
     createViewMutationAcidHarness,
+    getRequiredView,
+    waitUntil,
 } from "./viewMutationAcidTestUtils.js";
+
+/**
+ * @typedef {{ pos: number, value: number, group: string }} TrackDatum
+ */
 
 /**
  * @param {string} name
@@ -21,6 +32,31 @@ function makeTrackSpec(name, title) {
                 { pos: 2, value: 4, group: "b" },
             ],
         },
+        mark: "point",
+        encoding: {
+            x: { field: "pos", type: "quantitative" },
+            y: { field: "value", type: "quantitative" },
+            color: { field: "group", type: "nominal" },
+        },
+    };
+}
+
+/**
+ * @param {string} name
+ * @param {string} title
+ * @param {string} sourceId
+ * @returns {import("../spec/view.js").UnitSpec}
+ */
+function makeAsyncTrackSpec(name, title, sourceId) {
+    return {
+        name,
+        title,
+        data: /** @type {any} */ ({
+            lazy: {
+                type: "acidAsync",
+                sourceId,
+            },
+        }),
         mark: "point",
         encoding: {
             x: { field: "pos", type: "quantitative" },
@@ -48,6 +84,21 @@ function makeAcidSpec() {
         config: {
             view: {
                 stroke: "lightgray",
+            },
+        },
+    };
+}
+
+/**
+ * @returns {import("../spec/view.js").VConcatSpec}
+ */
+function makeAsyncAcidSpec() {
+    return {
+        name: "tracks",
+        vconcat: [makeAsyncTrackSpec("trackA", "Track A", "shared")],
+        resolve: {
+            scale: {
+                x: "shared",
             },
         },
     };
@@ -84,6 +135,84 @@ describe("View mutation acid scenarios", () => {
             expect(restoredIdentity.collectors[index]).toBe(
                 baselineIdentity.collectors[index]
             );
+        }
+    });
+
+    test("feeds an inserted lazy branch while a shared source is loading", async () => {
+        /** @type {{ promise: Promise<TrackDatum[]>, resolve: (value: TrackDatum[]) => void, reject: (reason?: unknown) => void }} */
+        const secondLoad = createDeferred();
+        /** @type {Promise<TrackDatum[]>[]} */
+        const loadPlans = [
+            Promise.resolve([{ pos: 1, value: 2, group: "a" }]),
+            secondLoad.promise,
+            Promise.resolve([{ pos: 3, value: 4, group: "b" }]),
+        ];
+        /** @type {DataSource[]} */
+        const loadCalls = [];
+
+        class ControlledAsyncSource extends DataSource {
+            /**
+             * @param {{ sourceId: string }} params
+             * @param {import("./view.js").default} view
+             */
+            constructor(params, view) {
+                super(view);
+                this.params = params;
+            }
+
+            get identifier() {
+                return this.params.sourceId;
+            }
+
+            async load() {
+                loadCalls.push(this);
+                const data = await loadPlans.shift();
+                this.reset();
+                this.beginBatch({ type: "file" });
+
+                for (const datum of data ?? []) {
+                    this._propagate(datum);
+                }
+
+                this.complete();
+            }
+        }
+
+        const unregister = registerLazyDataSource(
+            (params) => /** @type {any} */ (params).type === "acidAsync",
+            ControlledAsyncSource
+        );
+
+        try {
+            const { view, api } =
+                await createViewMutationAcidHarness(makeAsyncAcidSpec());
+            const source = getRequiredView(view, "trackA").flowHandle
+                ?.dataSource;
+            if (!source) {
+                throw new Error("Expected trackA to have a data source.");
+            }
+
+            const inFlightLoad = loadViewSubtreeData(view, new Set([source]));
+            const insertPromise = api.insert(
+                "root",
+                makeAsyncTrackSpec("trackB", "Track B", "shared"),
+                { scope: "trackB" }
+            );
+
+            await waitUntil(() =>
+                view.getDescendants().some((child) => child.name === "trackB")
+            );
+            secondLoad.resolve([{ pos: 2, value: 3, group: "a" }]);
+
+            await insertPromise;
+            await inFlightLoad;
+
+            const insertedView = getRequiredView(view, "trackB");
+            expect(loadCalls).toHaveLength(3);
+            expect(insertedView.flowHandle?.dataSource).toBe(source);
+            expect(countCollectorRows(insertedView)).toBeGreaterThan(0);
+        } finally {
+            unregister();
         }
     });
 });

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "vitest";
+
+import { createViewMutationApi } from "./viewMutationApi.js";
+import { createHeadlessEngine } from "../genomeSpy/headlessBootstrap.js";
+import { renderToLayout } from "./testUtils.js";
+
+/**
+ * @param {string} name
+ * @param {string} title
+ * @returns {import("../spec/view.js").UnitSpec}
+ */
+function makeTrackSpec(name, title) {
+    return {
+        name,
+        title,
+        data: {
+            values: [
+                { pos: 1, value: 2, group: "a" },
+                { pos: 2, value: 4, group: "b" },
+            ],
+        },
+        mark: "point",
+        encoding: {
+            x: { field: "pos", type: "quantitative" },
+            y: { field: "value", type: "quantitative" },
+            color: { field: "group", type: "nominal" },
+        },
+    };
+}
+
+/**
+ * @returns {import("../spec/view.js").VConcatSpec}
+ */
+function makeAcidSpec() {
+    return {
+        name: "tracks",
+        vconcat: [
+            makeTrackSpec("trackA", "Track A"),
+            makeTrackSpec("trackB", "Track B"),
+        ],
+        resolve: {
+            scale: {
+                x: "shared",
+            },
+        },
+        config: {
+            view: {
+                stroke: "lightgray",
+            },
+        },
+    };
+}
+
+/**
+ * @param {import("./view.js").default} viewRoot
+ */
+function createHierarchySnapshot(viewRoot) {
+    const views = viewRoot.getDescendants();
+    const viewIndexes = new Map(views.map((view, index) => [view, index]));
+
+    return views.map((view) => ({
+        name: view.name,
+        explicitName: view.explicitName,
+        defaultName: view.defaultName,
+        type: view.constructor.name,
+        dataState: view.getDataInitializationState(),
+        visibleInSpec: view.isVisibleInSpec(),
+        configuredVisible: view.isConfiguredVisible(),
+        layoutParent: getViewIndex(viewIndexes, view.layoutParent),
+        dataParent: getViewIndex(viewIndexes, view.dataParent),
+        children: getLayoutChildren(view).map((child) =>
+            getRequiredViewIndex(viewIndexes, child)
+        ),
+        flowHandle: {
+            dataSource: Boolean(view.flowHandle?.dataSource),
+            collector: Boolean(view.flowHandle?.collector),
+        },
+        resolutions: createResolutionSnapshot(view, viewIndexes),
+    }));
+}
+
+/**
+ * @param {Map<import("./view.js").default, number>} viewIndexes
+ * @param {import("./view.js").default | null | undefined} view
+ */
+function getViewIndex(viewIndexes, view) {
+    return view ? getRequiredViewIndex(viewIndexes, view) : undefined;
+}
+
+/**
+ * @param {Map<import("./view.js").default, number>} viewIndexes
+ * @param {import("./view.js").default} view
+ */
+function getRequiredViewIndex(viewIndexes, view) {
+    const index = viewIndexes.get(view);
+    if (index === undefined) {
+        throw new Error("Expected view to be included in the hierarchy.");
+    }
+
+    return index;
+}
+
+/**
+ * @param {import("./view.js").default} view
+ * @returns {import("./view.js").default[]}
+ */
+function getLayoutChildren(view) {
+    const children = /** @type {{ children?: unknown }} */ (view).children;
+    return Array.isArray(children)
+        ? /** @type {import("./view.js").default[]} */ (children)
+        : [];
+}
+
+/**
+ * @param {import("./view.js").default} view
+ * @param {Map<import("./view.js").default, number>} viewIndexes
+ */
+function createResolutionSnapshot(view, viewIndexes) {
+    return {
+        scale: Object.fromEntries(
+            Object.entries(view.resolutions.scale)
+                .filter((entry) => entry[1])
+                .map(([channel, resolution]) => [
+                    channel,
+                    resolution.getOrderedMembers().map((member) => ({
+                        view: getRequiredViewIndex(viewIndexes, member.view),
+                        channel: member.channel,
+                        contributesToDomain: member.contributesToDomain,
+                    })),
+                ])
+        ),
+        axis: Object.fromEntries(
+            Object.entries(view.resolutions.axis)
+                .filter((entry) => entry[1])
+                .map(([channel, resolution]) => [
+                    channel,
+                    {
+                        visible: resolution.hasVisibleNonChromeMember(),
+                        title: resolution.getTitle(),
+                    },
+                ])
+        ),
+        legend: Object.fromEntries(
+            Object.entries(view.resolutions.legend)
+                .filter((entry) => entry[1])
+                .map(([channel, resolution]) => [
+                    channel,
+                    {
+                        visible: resolution.hasVisibleNonChromeMember(),
+                        definitions: resolution
+                            .getLegendDefs()
+                            .map((definition) => ({
+                                view: getRequiredViewIndex(
+                                    viewIndexes,
+                                    definition.view
+                                ),
+                                channel: definition.channel,
+                                type: definition.type,
+                                field: definition.field,
+                            })),
+                    },
+                ])
+        ),
+    };
+}
+
+describe("View mutation acid scenarios", () => {
+    test("restores the internal hierarchy after an immediately canceled mutation sequence", async () => {
+        const { view } = await createHeadlessEngine(makeAcidSpec());
+        const api = createViewMutationApi({ viewRoot: view });
+        const baselineViews = view.getDescendants();
+        const baselineCollectors = baselineViews.map(
+            (descendant) => descendant.flowHandle?.collector
+        );
+        const baselineSnapshot = createHierarchySnapshot(view);
+        const baselineLayout = renderToLayout(view);
+
+        await api.transaction(async (views) => {
+            const trackA = views.get({ scope: [], view: "trackA" });
+            const summary = await views.insert(
+                "root",
+                makeTrackSpec("summary", "Summary"),
+                { index: 1, scope: "summaryScope" }
+            );
+
+            await views.move(trackA, { index: 2 });
+            await views.move(trackA, { index: 0 });
+            await views.remove(summary);
+        });
+
+        expect(createHierarchySnapshot(view)).toEqual(baselineSnapshot);
+        expect(renderToLayout(view)).toEqual(baselineLayout);
+
+        const restoredViews = view.getDescendants();
+        expect(restoredViews).toHaveLength(baselineViews.length);
+        for (const [index, restoredView] of restoredViews.entries()) {
+            expect(restoredView).toBe(baselineViews[index]);
+            expect(restoredView.flowHandle?.collector).toBe(
+                baselineCollectors[index]
+            );
+        }
+    });
+});

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import DataSource from "../data/sources/dataSource.js";
 import { loadViewSubtreeData } from "../data/flowInit.js";
@@ -677,6 +677,59 @@ describe("View mutation acid scenarios", () => {
             overviewTrackCollector
         );
         expect(createMutationAcidSnapshot(view)).toEqual(baselineSnapshot);
+    });
+
+    test("batches multi-step transactions into one layout reflow", async () => {
+        const requestLayoutReflow = vi.fn();
+        const { view, api, context } = await createViewMutationAcidHarness(
+            makeEmptyTracksSpec(),
+            { contextOptions: { requestLayoutReflow } }
+        );
+
+        requestLayoutReflow.mockClear();
+
+        /** @type {import("../data/sources/dataSource.js").default | undefined} */
+        let removedDataSource;
+        /** @type {import("../data/collector.js").default | undefined} */
+        let removedCollector;
+        /** @type {import("../types/embedApi.js").ViewHandle | undefined} */
+        let removedHandle;
+
+        // Multiple child operations should publish one final layout reflow
+        // after the outer transaction, while still cleaning up the branch that
+        // was inserted and removed inside the same batch.
+        await api.transaction(async (views) => {
+            await views.insert("root", makeTrackSpec("trackA", "Track A"));
+            removedHandle = await views.insert(
+                "root",
+                makeTrackSpec("trackB", "Track B")
+            );
+            const trackC = await views.insert(
+                "root",
+                makeTrackSpec("trackC", "Track C")
+            );
+            const removedView = getRequiredView(view, "trackB");
+            removedDataSource = removedView.flowHandle?.dataSource;
+            removedCollector = removedView.flowHandle?.collector;
+
+            await views.move(trackC, { index: 0 });
+            await views.remove(removedHandle);
+
+            expect(requestLayoutReflow).not.toHaveBeenCalled();
+        });
+
+        expect(requestLayoutReflow).toHaveBeenCalledTimes(1);
+        expect(removedHandle?.isAlive()).toBe(false);
+        expect(context.dataFlow.dataSources).not.toContain(removedDataSource);
+        expect(context.dataFlow.collectors).not.toContain(removedCollector);
+        expect(
+            api
+                .root()
+                .children()
+                .map((child) => child.name)
+        ).toEqual(["trackC", "trackA"]);
+        expect(countCollectorRows(getRequiredView(view, "trackA"))).toBe(2);
+        expect(countCollectorRows(getRequiredView(view, "trackC"))).toBe(2);
     });
 });
 

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -896,6 +896,40 @@ describe("View mutation acid scenarios", () => {
             baselineCollectorCount
         );
     });
+
+    test("fails fast for duplicate names outside explicit scopes", async () => {
+        const { api } = await createViewMutationAcidHarness(
+            makeEmptyTracksSpec()
+        );
+
+        const first = await api.insert(
+            "root",
+            makeTrackSpec("duplicateTrack", "First duplicate"),
+            { scope: "first" }
+        );
+        const second = await api.insert(
+            "root",
+            makeTrackSpec("duplicateTrack", "Second duplicate"),
+            { scope: "second" }
+        );
+
+        expect(api.get({ scope: ["first"], view: "duplicateTrack" })).toBe(
+            first
+        );
+        expect(api.get({ scope: ["second"], view: "duplicateTrack" })).toBe(
+            second
+        );
+        expect(() =>
+            api.resolve({ scope: [], view: "duplicateTrack" })
+        ).toThrow(/ambiguous/i);
+
+        await api.remove(first);
+
+        expect(api.get({ scope: [], view: "duplicateTrack" })).toBe(second);
+        expect(
+            api.resolve({ scope: ["first"], view: "duplicateTrack" })
+        ).toBeUndefined();
+    });
 });
 
 /**

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -104,6 +104,24 @@ function makeAsyncAcidSpec() {
     };
 }
 
+/**
+ * @returns {import("../spec/view.js").VConcatSpec}
+ */
+function makeSharedGuideAcidSpec() {
+    return {
+        name: "tracks",
+        vconcat: [
+            makeTrackSpec("trackA", "Track A"),
+            makeTrackSpec("trackB", "Track B"),
+        ],
+        resolve: {
+            axis: { x: "shared" },
+            scale: { x: "shared", color: "shared" },
+            legend: { color: "shared" },
+        },
+    };
+}
+
 describe("View mutation acid scenarios", () => {
     test("restores the internal hierarchy after an immediately canceled mutation sequence", async () => {
         const { view, api } =
@@ -246,6 +264,40 @@ describe("View mutation acid scenarios", () => {
             unregister();
         }
     });
+
+    test("keeps shared guide ownership live after add move and remove", async () => {
+        const { view, api } = await createViewMutationAcidHarness(
+            makeSharedGuideAcidSpec()
+        );
+        const trackAView = getRequiredView(view, "trackA");
+        const trackA = api.get({ scope: [], view: "trackA" });
+        expect(getLegendDefinitionNames(view, "tracks", "color")).toEqual([
+            "trackA",
+        ]);
+
+        const inserted = await api.insert(
+            "root",
+            makeTrackSpec("trackC", "Track C"),
+            { index: 0, scope: "trackC" }
+        );
+        await api.move(inserted, { index: 2 });
+        await api.remove(trackA);
+
+        const liveViews = new Set(view.getDescendants());
+        expect(liveViews.has(trackAView)).toBe(false);
+        expect(
+            getScaleMemberNames(view, "tracks", "x").filter((name) =>
+                name.startsWith("track")
+            )
+        ).toEqual(["trackB", "trackC"]);
+        expect(getLegendDefinitionNames(view, "tracks", "color")).toEqual([
+            "trackB",
+        ]);
+
+        for (const owner of getLegendDefinitionViews(view, "tracks", "color")) {
+            expect(liveViews.has(owner)).toBe(true);
+        }
+    });
 });
 
 /**
@@ -285,4 +337,50 @@ function registerControlledAsyncSource(loadPlans, loadCalls) {
         (params) => /** @type {any} */ (params).type === "acidAsync",
         ControlledAsyncSource
     );
+}
+
+/**
+ * @param {import("./view.js").default} viewRoot
+ * @param {string} viewName
+ * @param {import("../spec/channel.js").ChannelWithScale} channel
+ * @returns {string[]}
+ */
+function getScaleMemberNames(viewRoot, viewName, channel) {
+    const resolution = getRequiredView(viewRoot, viewName).resolutions.scale[
+        channel
+    ];
+    if (!resolution) {
+        throw new Error("Expected scale resolution for channel: " + channel);
+    }
+
+    return resolution.getOrderedMembers().map((member) => member.view.name);
+}
+
+/**
+ * @param {import("./view.js").default} viewRoot
+ * @param {string} viewName
+ * @param {import("../spec/channel.js").ChannelWithScale} channel
+ * @returns {string[]}
+ */
+function getLegendDefinitionNames(viewRoot, viewName, channel) {
+    return getLegendDefinitionViews(viewRoot, viewName, channel).map(
+        (view) => view.name
+    );
+}
+
+/**
+ * @param {import("./view.js").default} viewRoot
+ * @param {string} viewName
+ * @param {import("../spec/channel.js").ChannelWithScale} channel
+ * @returns {import("./view.js").default[]}
+ */
+function getLegendDefinitionViews(viewRoot, viewName, channel) {
+    const resolution = getRequiredView(viewRoot, viewName).resolutions.legend[
+        channel
+    ];
+    if (!resolution) {
+        throw new Error("Expected legend resolution for channel: " + channel);
+    }
+
+    return resolution.getLegendDefs().map((definition) => definition.view);
 }

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -13,6 +13,11 @@ import {
     waitUntil,
 } from "./viewMutationAcidTestUtils.js";
 
+// These acid scenarios intentionally drive mutations through the public
+// ViewMutationApi. The assertions inspect normalized internal state because
+// the goal is to catch stale views, dataflow objects, resolutions, and guides
+// that remain after realistic public API operations.
+
 /**
  * @typedef {{ pos: number, value: number, group: string }} TrackDatum
  */
@@ -129,6 +134,9 @@ describe("View mutation acid scenarios", () => {
         const baselineIdentity = captureMutationAcidIdentities(view);
         const baselineSnapshot = createMutationAcidSnapshot(view);
 
+        // This is the core acid invariant: a complex no-op mutation round trip
+        // must restore the normalized internal hierarchy and preserve the
+        // pre-existing view/collector objects.
         await api.transaction(async (views) => {
             const trackA = views.get({ scope: [], view: "trackA" });
             const summary = await views.insert(
@@ -157,6 +165,9 @@ describe("View mutation acid scenarios", () => {
     });
 
     test("feeds an inserted lazy branch while a shared source is loading", async () => {
+        // The deferred second load keeps the shared data source in flight while
+        // the new branch is inserted. The inserted view must attach to that
+        // source and receive propagated rows once the load completes.
         /** @type {{ promise: Promise<TrackDatum[]>, resolve: (value: TrackDatum[]) => void, reject: (reason?: unknown) => void }} */
         const secondLoad = createDeferred();
         /** @type {Promise<TrackDatum[]>[]} */
@@ -204,6 +215,8 @@ describe("View mutation acid scenarios", () => {
     });
 
     test("restores hierarchy after canceling an async inserted branch", async () => {
+        // Async insertion creates dataflow state that must be fully disposed
+        // when the branch is immediately removed again.
         /** @type {Promise<TrackDatum[]>[]} */
         const loadPlans = [
             Promise.resolve([{ pos: 1, value: 2, group: "a" }]),
@@ -275,6 +288,9 @@ describe("View mutation acid scenarios", () => {
             "trackA",
         ]);
 
+        // Removing the original guide owner should transfer shared legend
+        // ownership to a remaining live child and should not leave stale
+        // resolution members behind.
         const inserted = await api.insert(
             "root",
             makeTrackSpec("trackC", "Track C"),
@@ -325,6 +341,8 @@ function registerControlledAsyncSource(loadPlans, loadCalls) {
             this.reset();
             this.beginBatch({ type: "file" });
 
+            // Propagate rows through the real dataflow path so the tests cover
+            // collector wiring, not just source registration.
             for (const datum of data ?? []) {
                 this._propagate(datum);
             }

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -190,6 +190,28 @@ function makeEmptyTracksSpec() {
 }
 
 /**
+ * @returns {import("../spec/view.js").VConcatSpec}
+ */
+function makeNestedContainerAcidSpec() {
+    return {
+        name: "dashboard",
+        vconcat: [
+            {
+                name: "overview",
+                vconcat: [makeTrackSpec("overviewTrack", "Overview")],
+            },
+            {
+                name: "tracks",
+                vconcat: [
+                    makeTrackSpec("trackA", "Track A"),
+                    makeTrackSpec("trackB", "Track B"),
+                ],
+            },
+        ],
+    };
+}
+
+/**
  * @param {string} name
  * @param {string} title
  * @returns {import("../spec/view.js").UnitSpec}
@@ -623,6 +645,38 @@ describe("View mutation acid scenarios", () => {
         expect(context.dataFlow.collectors).toHaveLength(
             baselineCollectorCount
         );
+    });
+
+    test("restores nested container mutations without disturbing sibling branches", async () => {
+        const { view, api } = await createViewMutationAcidHarness(
+            makeNestedContainerAcidSpec()
+        );
+        const baselineSnapshot = createMutationAcidSnapshot(view);
+        const overviewView = getRequiredView(view, "overview");
+        const overviewTrackView = getRequiredView(view, "overviewTrack");
+        const overviewTrackCollector = overviewTrackView.flowHandle?.collector;
+
+        // Mutating an inner concat should use that concat's child list and
+        // guide/data lifecycle without touching sibling branches.
+        await api.transaction(async (views) => {
+            const tracks = views.get({ scope: [], view: "tracks" });
+            const trackB = views.get({ scope: [], view: "trackB" });
+            const inserted = await views.insert(
+                tracks,
+                makeTrackSpec("trackC", "Track C"),
+                { index: 1, scope: "trackC" }
+            );
+
+            await views.move(trackB, { index: 1 });
+            await views.remove(inserted);
+        });
+
+        expect(getRequiredView(view, "overview")).toBe(overviewView);
+        expect(getRequiredView(view, "overviewTrack")).toBe(overviewTrackView);
+        expect(overviewTrackView.flowHandle?.collector).toBe(
+            overviewTrackCollector
+        );
+        expect(createMutationAcidSnapshot(view)).toEqual(baselineSnapshot);
     });
 });
 

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -127,6 +127,47 @@ function makeSharedGuideAcidSpec() {
     };
 }
 
+/**
+ * @returns {import("../spec/view.js").VConcatSpec}
+ */
+function makeInheritedDataAcidSpec() {
+    return {
+        name: "tracks",
+        data: {
+            values: [
+                { pos: 1, value: 2, group: "a" },
+                { pos: 2, value: 4, group: "b" },
+            ],
+        },
+        transform: [
+            {
+                type: "formula",
+                expr: "datum.value * 2",
+                as: "scaledValue",
+            },
+        ],
+        vconcat: [makeInheritedTrackSpec("trackA", "Track A")],
+    };
+}
+
+/**
+ * @param {string} name
+ * @param {string} title
+ * @returns {import("../spec/view.js").UnitSpec}
+ */
+function makeInheritedTrackSpec(name, title) {
+    return {
+        name,
+        title,
+        mark: "point",
+        encoding: {
+            x: { field: "pos", type: "quantitative" },
+            y: { field: "scaledValue", type: "quantitative" },
+            color: { field: "group", type: "nominal" },
+        },
+    };
+}
+
 describe("View mutation acid scenarios", () => {
     test("restores the internal hierarchy after an immediately canceled mutation sequence", async () => {
         const { view, api } =
@@ -314,6 +355,56 @@ describe("View mutation acid scenarios", () => {
             expect(liveViews.has(owner)).toBe(true);
         }
     });
+
+    test("restores inherited dataflow after inserting and removing an inherited track", async () => {
+        const { view, api, context } = await createViewMutationAcidHarness(
+            makeInheritedDataAcidSpec()
+        );
+        const baselineSnapshot = createMutationAcidSnapshot(view);
+        const baselineIdentity = captureMutationAcidIdentities(view);
+        const baselineDataSourceCount = context.dataFlow.dataSources.length;
+        const baselineCollectorCount = context.dataFlow.collectors.length;
+        const tracksView = getRequiredView(view, "tracks");
+
+        // The inserted child has no local data declaration. It must inherit the
+        // parent branch, including the parent formula transform, and then
+        // dispose back to the baseline without reloading or duplicating sources.
+        await api.transaction(async (views) => {
+            const inserted = await views.insert(
+                "root",
+                makeInheritedTrackSpec("summary", "Summary"),
+                { index: 1, scope: "summary" }
+            );
+            const insertedView = getRequiredView(view, "summary");
+
+            expect(insertedView.dataParent).toBe(tracksView);
+            expect(insertedView.flowHandle?.dataSource).toBeUndefined();
+            expect(
+                getCollectorData(insertedView).map((datum) => datum.scaledValue)
+            ).toEqual([4, 8]);
+
+            await views.remove(inserted);
+        });
+
+        expect(createMutationAcidSnapshot(view)).toEqual(baselineSnapshot);
+        expect(context.dataFlow.dataSources).toHaveLength(
+            baselineDataSourceCount
+        );
+        expect(context.dataFlow.collectors).toHaveLength(
+            baselineCollectorCount
+        );
+
+        const restoredIdentity = captureMutationAcidIdentities(view);
+        expect(restoredIdentity.views).toHaveLength(
+            baselineIdentity.views.length
+        );
+        for (const [index, restoredView] of restoredIdentity.views.entries()) {
+            expect(restoredView).toBe(baselineIdentity.views[index]);
+            expect(restoredIdentity.collectors[index]).toBe(
+                baselineIdentity.collectors[index]
+            );
+        }
+    });
 });
 
 /**
@@ -401,4 +492,17 @@ function getLegendDefinitionViews(viewRoot, viewName, channel) {
     }
 
     return resolution.getLegendDefs().map((definition) => definition.view);
+}
+
+/**
+ * @param {import("./view.js").default} view
+ * @returns {import("../data/flowNode.js").Datum[]}
+ */
+function getCollectorData(view) {
+    const collector = view.flowHandle?.collector;
+    if (!collector) {
+        throw new Error("Expected view to have a collector.");
+    }
+
+    return Array.from(collector.getData());
 }

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "vitest";
 
-import { createViewMutationApi } from "./viewMutationApi.js";
-import { createHeadlessEngine } from "../genomeSpy/headlessBootstrap.js";
-import { renderToLayout } from "./testUtils.js";
+import {
+    captureMutationAcidIdentities,
+    createMutationAcidSnapshot,
+    createViewMutationAcidHarness,
+} from "./viewMutationAcidTestUtils.js";
 
 /**
  * @param {string} name
@@ -51,129 +53,12 @@ function makeAcidSpec() {
     };
 }
 
-/**
- * @param {import("./view.js").default} viewRoot
- */
-function createHierarchySnapshot(viewRoot) {
-    const views = viewRoot.getDescendants();
-    const viewIndexes = new Map(views.map((view, index) => [view, index]));
-
-    return views.map((view) => ({
-        name: view.name,
-        explicitName: view.explicitName,
-        defaultName: view.defaultName,
-        type: view.constructor.name,
-        dataState: view.getDataInitializationState(),
-        visibleInSpec: view.isVisibleInSpec(),
-        configuredVisible: view.isConfiguredVisible(),
-        layoutParent: getViewIndex(viewIndexes, view.layoutParent),
-        dataParent: getViewIndex(viewIndexes, view.dataParent),
-        children: getLayoutChildren(view).map((child) =>
-            getRequiredViewIndex(viewIndexes, child)
-        ),
-        flowHandle: {
-            dataSource: Boolean(view.flowHandle?.dataSource),
-            collector: Boolean(view.flowHandle?.collector),
-        },
-        resolutions: createResolutionSnapshot(view, viewIndexes),
-    }));
-}
-
-/**
- * @param {Map<import("./view.js").default, number>} viewIndexes
- * @param {import("./view.js").default | null | undefined} view
- */
-function getViewIndex(viewIndexes, view) {
-    return view ? getRequiredViewIndex(viewIndexes, view) : undefined;
-}
-
-/**
- * @param {Map<import("./view.js").default, number>} viewIndexes
- * @param {import("./view.js").default} view
- */
-function getRequiredViewIndex(viewIndexes, view) {
-    const index = viewIndexes.get(view);
-    if (index === undefined) {
-        throw new Error("Expected view to be included in the hierarchy.");
-    }
-
-    return index;
-}
-
-/**
- * @param {import("./view.js").default} view
- * @returns {import("./view.js").default[]}
- */
-function getLayoutChildren(view) {
-    const children = /** @type {{ children?: unknown }} */ (view).children;
-    return Array.isArray(children)
-        ? /** @type {import("./view.js").default[]} */ (children)
-        : [];
-}
-
-/**
- * @param {import("./view.js").default} view
- * @param {Map<import("./view.js").default, number>} viewIndexes
- */
-function createResolutionSnapshot(view, viewIndexes) {
-    return {
-        scale: Object.fromEntries(
-            Object.entries(view.resolutions.scale)
-                .filter((entry) => entry[1])
-                .map(([channel, resolution]) => [
-                    channel,
-                    resolution.getOrderedMembers().map((member) => ({
-                        view: getRequiredViewIndex(viewIndexes, member.view),
-                        channel: member.channel,
-                        contributesToDomain: member.contributesToDomain,
-                    })),
-                ])
-        ),
-        axis: Object.fromEntries(
-            Object.entries(view.resolutions.axis)
-                .filter((entry) => entry[1])
-                .map(([channel, resolution]) => [
-                    channel,
-                    {
-                        visible: resolution.hasVisibleNonChromeMember(),
-                        title: resolution.getTitle(),
-                    },
-                ])
-        ),
-        legend: Object.fromEntries(
-            Object.entries(view.resolutions.legend)
-                .filter((entry) => entry[1])
-                .map(([channel, resolution]) => [
-                    channel,
-                    {
-                        visible: resolution.hasVisibleNonChromeMember(),
-                        definitions: resolution
-                            .getLegendDefs()
-                            .map((definition) => ({
-                                view: getRequiredViewIndex(
-                                    viewIndexes,
-                                    definition.view
-                                ),
-                                channel: definition.channel,
-                                type: definition.type,
-                                field: definition.field,
-                            })),
-                    },
-                ])
-        ),
-    };
-}
-
 describe("View mutation acid scenarios", () => {
     test("restores the internal hierarchy after an immediately canceled mutation sequence", async () => {
-        const { view } = await createHeadlessEngine(makeAcidSpec());
-        const api = createViewMutationApi({ viewRoot: view });
-        const baselineViews = view.getDescendants();
-        const baselineCollectors = baselineViews.map(
-            (descendant) => descendant.flowHandle?.collector
-        );
-        const baselineSnapshot = createHierarchySnapshot(view);
-        const baselineLayout = renderToLayout(view);
+        const { view, api } =
+            await createViewMutationAcidHarness(makeAcidSpec());
+        const baselineIdentity = captureMutationAcidIdentities(view);
+        const baselineSnapshot = createMutationAcidSnapshot(view);
 
         await api.transaction(async (views) => {
             const trackA = views.get({ scope: [], view: "trackA" });
@@ -188,15 +73,16 @@ describe("View mutation acid scenarios", () => {
             await views.remove(summary);
         });
 
-        expect(createHierarchySnapshot(view)).toEqual(baselineSnapshot);
-        expect(renderToLayout(view)).toEqual(baselineLayout);
+        expect(createMutationAcidSnapshot(view)).toEqual(baselineSnapshot);
 
-        const restoredViews = view.getDescendants();
-        expect(restoredViews).toHaveLength(baselineViews.length);
-        for (const [index, restoredView] of restoredViews.entries()) {
-            expect(restoredView).toBe(baselineViews[index]);
-            expect(restoredView.flowHandle?.collector).toBe(
-                baselineCollectors[index]
+        const restoredIdentity = captureMutationAcidIdentities(view);
+        expect(restoredIdentity.views).toHaveLength(
+            baselineIdentity.views.length
+        );
+        for (const [index, restoredView] of restoredIdentity.views.entries()) {
+            expect(restoredView).toBe(baselineIdentity.views[index]);
+            expect(restoredIdentity.collectors[index]).toBe(
+                baselineIdentity.collectors[index]
             );
         }
     });

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -180,6 +180,16 @@ function makeParamAcidSpec() {
 }
 
 /**
+ * @returns {import("../spec/view.js").VConcatSpec}
+ */
+function makeEmptyTracksSpec() {
+    return {
+        name: "tracks",
+        vconcat: [],
+    };
+}
+
+/**
  * @param {string} name
  * @param {string} title
  * @returns {import("../spec/view.js").UnitSpec}
@@ -555,6 +565,64 @@ describe("View mutation acid scenarios", () => {
         } finally {
             unsubscribeRoot();
         }
+    });
+
+    test("inserts the same spec object multiple times using independent scopes", async () => {
+        const { view, api, context } = await createViewMutationAcidHarness(
+            makeEmptyTracksSpec()
+        );
+        const baselineSnapshot = createMutationAcidSnapshot(view);
+        const baselineDataSourceCount = context.dataFlow.dataSources.length;
+        const baselineCollectorCount = context.dataFlow.collectors.length;
+        const reusableSpec = makeTrackSpec("reusedTrack", "Reusable");
+        const originalReusableSpec = structuredClone(reusableSpec);
+
+        // Public insertion must clone the caller's spec. Scopes make the two
+        // otherwise identical view names independently addressable.
+        const first = await api.insert("root", reusableSpec, {
+            scope: "sampleA",
+        });
+        const second = await api.insert("root", reusableSpec, {
+            scope: "sampleB",
+        });
+
+        expect(reusableSpec).toEqual(originalReusableSpec);
+        expect(first).not.toBe(second);
+        expect(first.selector).toEqual({
+            scope: ["sampleA"],
+            view: "reusedTrack",
+        });
+        expect(second.selector).toEqual({
+            scope: ["sampleB"],
+            view: "reusedTrack",
+        });
+        expect(api.get({ scope: ["sampleA"], view: "reusedTrack" })).toBe(
+            first
+        );
+        expect(api.get({ scope: ["sampleB"], view: "reusedTrack" })).toBe(
+            second
+        );
+
+        await api.remove(first);
+
+        expect(first.isAlive()).toBe(false);
+        expect(second.isAlive()).toBe(true);
+        expect(
+            api.resolve({ scope: ["sampleA"], view: "reusedTrack" })
+        ).toBeUndefined();
+        expect(countCollectorRows(getRequiredView(view, "reusedTrack"))).toBe(
+            2
+        );
+
+        await api.remove(second);
+
+        expect(createMutationAcidSnapshot(view)).toEqual(baselineSnapshot);
+        expect(context.dataFlow.dataSources).toHaveLength(
+            baselineDataSourceCount
+        );
+        expect(context.dataFlow.collectors).toHaveLength(
+            baselineCollectorCount
+        );
     });
 });
 

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -150,38 +150,7 @@ describe("View mutation acid scenarios", () => {
         /** @type {DataSource[]} */
         const loadCalls = [];
 
-        class ControlledAsyncSource extends DataSource {
-            /**
-             * @param {{ sourceId: string }} params
-             * @param {import("./view.js").default} view
-             */
-            constructor(params, view) {
-                super(view);
-                this.params = params;
-            }
-
-            get identifier() {
-                return this.params.sourceId;
-            }
-
-            async load() {
-                loadCalls.push(this);
-                const data = await loadPlans.shift();
-                this.reset();
-                this.beginBatch({ type: "file" });
-
-                for (const datum of data ?? []) {
-                    this._propagate(datum);
-                }
-
-                this.complete();
-            }
-        }
-
-        const unregister = registerLazyDataSource(
-            (params) => /** @type {any} */ (params).type === "acidAsync",
-            ControlledAsyncSource
-        );
+        const unregister = registerControlledAsyncSource(loadPlans, loadCalls);
 
         try {
             const { view, api } =
@@ -215,4 +184,105 @@ describe("View mutation acid scenarios", () => {
             unregister();
         }
     });
+
+    test("restores hierarchy after canceling an async inserted branch", async () => {
+        /** @type {Promise<TrackDatum[]>[]} */
+        const loadPlans = [
+            Promise.resolve([{ pos: 1, value: 2, group: "a" }]),
+            Promise.resolve([{ pos: 5, value: 8, group: "b" }]),
+        ];
+        /** @type {DataSource[]} */
+        const loadCalls = [];
+        const unregister = registerControlledAsyncSource(loadPlans, loadCalls);
+
+        try {
+            const { view, api, context } =
+                await createViewMutationAcidHarness(makeAsyncAcidSpec());
+            const baselineIdentity = captureMutationAcidIdentities(view);
+            const baselineSnapshot = createMutationAcidSnapshot(view);
+            const baselineDataSourceCount = context.dataFlow.dataSources.length;
+            const baselineCollectorCount = context.dataFlow.collectors.length;
+
+            await api.transaction(async (views) => {
+                const trackA = views.get({ scope: [], view: "trackA" });
+                const temporary = await views.insert(
+                    "root",
+                    makeAsyncTrackSpec(
+                        "temporary",
+                        "Temporary async track",
+                        "temporary"
+                    ),
+                    { index: 1, scope: "temporary" }
+                );
+
+                await views.move(trackA, { index: 1 });
+                await views.move(trackA, { index: 0 });
+                await views.remove(temporary);
+            });
+
+            expect(createMutationAcidSnapshot(view)).toEqual(baselineSnapshot);
+            expect(context.dataFlow.dataSources).toHaveLength(
+                baselineDataSourceCount
+            );
+            expect(context.dataFlow.collectors).toHaveLength(
+                baselineCollectorCount
+            );
+
+            const restoredIdentity = captureMutationAcidIdentities(view);
+            expect(restoredIdentity.views).toHaveLength(
+                baselineIdentity.views.length
+            );
+            for (const [
+                index,
+                restoredView,
+            ] of restoredIdentity.views.entries()) {
+                expect(restoredView).toBe(baselineIdentity.views[index]);
+                expect(restoredIdentity.collectors[index]).toBe(
+                    baselineIdentity.collectors[index]
+                );
+            }
+            expect(loadCalls).toHaveLength(2);
+        } finally {
+            unregister();
+        }
+    });
 });
+
+/**
+ * @param {Promise<TrackDatum[]>[]} loadPlans
+ * @param {DataSource[]} loadCalls
+ */
+function registerControlledAsyncSource(loadPlans, loadCalls) {
+    class ControlledAsyncSource extends DataSource {
+        /**
+         * @param {{ sourceId: string }} params
+         * @param {import("./view.js").default} view
+         */
+        constructor(params, view) {
+            super(view);
+            this.params = params;
+        }
+
+        get identifier() {
+            return this.params.sourceId;
+        }
+
+        async load() {
+            loadCalls.push(this);
+            const data = await loadPlans.shift();
+            this.reset();
+            this.beginBatch({ type: "file" });
+
+            for (const datum of data ?? []) {
+                this._propagate(datum);
+            }
+
+            this.complete();
+        }
+    }
+
+    return registerLazyDataSource(
+        (params) => /** @type {any} */ (params).type === "acidAsync",
+        ControlledAsyncSource
+    );
+}

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -168,6 +168,70 @@ function makeInheritedTrackSpec(name, title) {
     };
 }
 
+/**
+ * @returns {import("../spec/view.js").VConcatSpec}
+ */
+function makeParamAcidSpec() {
+    return {
+        name: "tracks",
+        params: [{ name: "threshold", value: 3 }],
+        vconcat: [makeParamTrackSpec("trackA", "Track A")],
+    };
+}
+
+/**
+ * @param {string} name
+ * @param {string} title
+ * @returns {import("../spec/view.js").UnitSpec}
+ */
+function makeParamTrackSpec(name, title) {
+    return {
+        name,
+        title,
+        data: {
+            values: [
+                { pos: 1, value: 2 },
+                { pos: 2, value: 4 },
+            ],
+        },
+        mark: "point",
+        encoding: {
+            x: { field: "pos", type: "quantitative" },
+            y: {
+                field: "value",
+                type: "quantitative",
+                scale: { domain: { expr: "[0, threshold]" } },
+            },
+        },
+    };
+}
+
+/**
+ * @param {string} name
+ * @param {string} title
+ * @param {number} threshold
+ * @returns {import("../spec/view.js").UnitSpec}
+ */
+function makeScopedParamTrackSpec(name, title, threshold) {
+    const spec = makeParamTrackSpec(name, title);
+
+    return {
+        ...spec,
+        params: [
+            { name: "threshold", value: threshold },
+            { name: "expandedThreshold", expr: "threshold + 1" },
+        ],
+        encoding: {
+            ...spec.encoding,
+            y: {
+                field: "value",
+                type: "quantitative",
+                scale: { domain: { expr: "[0, expandedThreshold]" } },
+            },
+        },
+    };
+}
+
 describe("View mutation acid scenarios", () => {
     test("restores the internal hierarchy after an immediately canceled mutation sequence", async () => {
         const { view, api } =
@@ -403,6 +467,93 @@ describe("View mutation acid scenarios", () => {
             expect(restoredIdentity.collectors[index]).toBe(
                 baselineIdentity.collectors[index]
             );
+        }
+    });
+
+    test("keeps scoped params independent and disposes inserted subscriptions", async () => {
+        const { view, api } =
+            await createViewMutationAcidHarness(makeParamAcidSpec());
+        const tracksView = getRequiredView(view, "tracks");
+        const baselineHierarchy = createMutationAcidSnapshot(view).hierarchy;
+        let rootThresholdCalls = 0;
+        const unsubscribeRoot = tracksView.paramRuntime.subscribe(
+            "threshold",
+            () => {
+                rootThresholdCalls += 1;
+            }
+        );
+
+        try {
+            /** @type {import("./view.js").default | undefined} */
+            let insertedView;
+            let expandedThresholdCalls = 0;
+
+            // The inserted branch reuses the ancestor parameter name in its
+            // own scope. Updating either scope must not cross-write the other,
+            // and the inserted expression subscription must be disposed with
+            // the removed branch.
+            await api.transaction(async (views) => {
+                const inserted = await views.insert(
+                    "root",
+                    makeScopedParamTrackSpec("scopedTrack", "Scoped", 7),
+                    { scope: "sampleA" }
+                );
+                insertedView = getRequiredView(view, "scopedTrack");
+                insertedView.paramRuntime.subscribe("expandedThreshold", () => {
+                    expandedThresholdCalls += 1;
+                });
+
+                expect(
+                    api.get({ scope: ["sampleA"], view: "scopedTrack" })
+                ).toBe(inserted);
+                expect(insertedView.paramRuntime.findValue("threshold")).toBe(
+                    7
+                );
+                expect(
+                    insertedView.paramRuntime.findValue("expandedThreshold")
+                ).toBe(8);
+
+                tracksView.paramRuntime.setValue("threshold", 4);
+                await tracksView.paramRuntime.whenPropagated();
+
+                expect(rootThresholdCalls).toBe(1);
+                expect(insertedView.paramRuntime.findValue("threshold")).toBe(
+                    7
+                );
+
+                insertedView.paramRuntime.setValue("threshold", 9);
+                await insertedView.paramRuntime.whenPropagated();
+
+                expect(
+                    insertedView.paramRuntime.findValue("expandedThreshold")
+                ).toBe(10);
+                expect(expandedThresholdCalls).toBe(1);
+                expect(tracksView.paramRuntime.findValue("threshold")).toBe(4);
+
+                tracksView.paramRuntime.setValue("threshold", 3);
+                await tracksView.paramRuntime.whenPropagated();
+                await views.remove(inserted);
+            });
+
+            expect(insertedView?.paramRuntime.getValue("threshold")).toBe(
+                undefined
+            );
+
+            tracksView.paramRuntime.setValue("threshold", 5);
+            await tracksView.paramRuntime.whenPropagated();
+
+            expect(rootThresholdCalls).toBe(3);
+            expect(expandedThresholdCalls).toBe(1);
+
+            tracksView.paramRuntime.setValue("threshold", 3);
+            await tracksView.paramRuntime.whenPropagated();
+
+            expect(rootThresholdCalls).toBe(4);
+            expect(createMutationAcidSnapshot(view).hierarchy).toEqual(
+                baselineHierarchy
+            );
+        } finally {
+            unsubscribeRoot();
         }
     });
 });

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -1009,6 +1009,36 @@ describe("View mutation acid scenarios", () => {
             api.resolve({ scope: ["trackB"], view: "trackB" })
         ).toBeUndefined();
     });
+
+    test("marks nested parent and descendant handles stale after subtree removal", async () => {
+        const { api } = await createViewMutationAcidHarness(
+            makeNestedContainerAcidSpec()
+        );
+        const overview = api.get({ scope: [], view: "overview" });
+        const tracks = api.get({ scope: [], view: "tracks" });
+        const trackA = api.get({ scope: [], view: "trackA" });
+        const trackB = api.get({ scope: [], view: "trackB" });
+
+        await api.remove(tracks);
+
+        for (const handle of [tracks, trackA, trackB]) {
+            expect(handle.isAlive()).toBe(false);
+            expect(handle.parent()).toBeUndefined();
+            expect(handle.children()).toEqual([]);
+            expect(api.resolve(handle)).toBeUndefined();
+            expect(() => api.get(handle)).toThrow(/stale/i);
+            expect(api.getLayoutBounds(handle)).toBeUndefined();
+            await expect(api.move(handle, { index: 0 })).rejects.toMatchObject({
+                code: "staleHandle",
+            });
+            await expect(api.remove(handle)).rejects.toMatchObject({
+                code: "staleHandle",
+            });
+        }
+
+        expect(overview.isAlive()).toBe(true);
+        expect(api.root().children()).toEqual([overview]);
+    });
 });
 
 /**

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -226,6 +226,36 @@ function makeMoveFreshnessAcidSpec() {
 }
 
 /**
+ * @returns {import("../spec/view.js").VConcatSpec}
+ */
+function makeNamedDataAcidSpec() {
+    return {
+        name: "tracks",
+        vconcat: [makeNamedDataTrackSpec("trackA", "Track A", "dynamicData")],
+    };
+}
+
+/**
+ * @param {string} name
+ * @param {string} title
+ * @param {string} dataName
+ * @returns {import("../spec/view.js").UnitSpec}
+ */
+function makeNamedDataTrackSpec(name, title, dataName) {
+    return {
+        name,
+        title,
+        data: { name: dataName },
+        mark: "point",
+        encoding: {
+            x: { field: "pos", type: "quantitative" },
+            y: { field: "value", type: "quantitative" },
+            color: { field: "group", type: "nominal" },
+        },
+    };
+}
+
+/**
  * @param {string} name
  * @param {string} title
  * @param {number} height
@@ -928,6 +958,55 @@ describe("View mutation acid scenarios", () => {
         expect(api.get({ scope: [], view: "duplicateTrack" })).toBe(second);
         expect(
             api.resolve({ scope: ["first"], view: "duplicateTrack" })
+        ).toBeUndefined();
+    });
+
+    test("updates named data after removing an inserted named-data track", async () => {
+        const { view, api, context } = await createViewMutationAcidHarness(
+            makeNamedDataAcidSpec(),
+            {
+                contextOptions: {
+                    getNamedDataFromProvider: () => [
+                        { pos: 1, value: 2, group: "a" },
+                    ],
+                },
+            }
+        );
+        const namedSource = context.dataFlow.findNamedDataSource("dynamicData");
+        if (!namedSource) {
+            throw new Error("Expected named data source.");
+        }
+
+        const trackAView = getRequiredView(view, "trackA");
+        const inserted = await api.insert(
+            "root",
+            makeNamedDataTrackSpec("trackB", "Track B", "dynamicData"),
+            { scope: "trackB" }
+        );
+        const trackBView = getRequiredView(view, "trackB");
+        const trackBCollector = trackBView.flowHandle?.collector;
+
+        // Both tracks share one named data source. Removing the inserted track
+        // must dispose only its collector branch, leaving later named-data
+        // updates connected to the original track.
+        namedSource.dataSource.updateDynamicData([
+            { pos: 1, value: 3, group: "a" },
+            { pos: 2, value: 5, group: "b" },
+        ]);
+
+        expect(countCollectorRows(trackAView)).toBe(2);
+        expect(countCollectorRows(trackBView)).toBe(2);
+
+        await api.remove(inserted);
+
+        namedSource.dataSource.updateDynamicData([
+            { pos: 3, value: 8, group: "c" },
+        ]);
+
+        expect(countCollectorRows(trackAView)).toBe(1);
+        expect(context.dataFlow.collectors).not.toContain(trackBCollector);
+        expect(
+            api.resolve({ scope: ["trackB"], view: "trackB" })
         ).toBeUndefined();
     });
 });

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -731,6 +731,43 @@ describe("View mutation acid scenarios", () => {
         expect(countCollectorRows(getRequiredView(view, "trackA"))).toBe(2);
         expect(countCollectorRows(getRequiredView(view, "trackC"))).toBe(2);
     });
+
+    test("rolls back failed insertion without leaving partial lifecycle state", async () => {
+        const requestLayoutReflow = vi.fn();
+        const { view, api, context } = await createViewMutationAcidHarness(
+            makeEmptyTracksSpec(),
+            { contextOptions: { requestLayoutReflow } }
+        );
+        const baselineSnapshot = createMutationAcidSnapshot(view);
+        const baselineDataSourceCount = context.dataFlow.dataSources.length;
+        const baselineCollectorCount = context.dataFlow.collectors.length;
+
+        requestLayoutReflow.mockClear();
+
+        // The child is structurally inserted before data initialization fails.
+        // Rollback must remove the spec, view, dataflow branch, and pending
+        // layout work as if the public insert never happened.
+        await expect(
+            api.insert("root", {
+                name: "badTrack",
+                mark: "point",
+                encoding: {
+                    x: { field: "x", type: "quantitative" },
+                },
+            })
+        ).rejects.toThrow(/data source/i);
+
+        expect(requestLayoutReflow).not.toHaveBeenCalled();
+        expect(api.root().children()).toEqual([]);
+        expect(api.resolve({ scope: [], view: "badTrack" })).toBeUndefined();
+        expect(context.dataFlow.dataSources).toHaveLength(
+            baselineDataSourceCount
+        );
+        expect(context.dataFlow.collectors).toHaveLength(
+            baselineCollectorCount
+        );
+        expect(createMutationAcidSnapshot(view)).toEqual(baselineSnapshot);
+    });
 });
 
 /**

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -212,6 +212,33 @@ function makeNestedContainerAcidSpec() {
 }
 
 /**
+ * @returns {import("../spec/view.js").VConcatSpec}
+ */
+function makeMoveFreshnessAcidSpec() {
+    return {
+        name: "tracks",
+        vconcat: [
+            makeFixedHeightTrackSpec("trackA", "Track A", 40),
+            makeFixedHeightTrackSpec("trackB", "Track B", 50),
+            makeFixedHeightTrackSpec("trackC", "Track C", 60),
+        ],
+    };
+}
+
+/**
+ * @param {string} name
+ * @param {string} title
+ * @param {number} height
+ * @returns {import("../spec/view.js").UnitSpec}
+ */
+function makeFixedHeightTrackSpec(name, title, height) {
+    return {
+        ...makeTrackSpec(name, title),
+        height,
+    };
+}
+
+/**
  * @param {string} name
  * @param {string} title
  * @returns {import("../spec/view.js").UnitSpec}
@@ -767,6 +794,68 @@ describe("View mutation acid scenarios", () => {
             baselineCollectorCount
         );
         expect(createMutationAcidSnapshot(view)).toEqual(baselineSnapshot);
+    });
+
+    test("updates layout bounds and listeners after moving a child", async () => {
+        /** @type {Set<(message: import("./view.js").BroadcastMessage) => void>} */
+        const layoutListeners = new Set();
+        /** @type {import("./view.js").default | undefined} */
+        let viewRoot;
+        const requestLayoutReflow = vi.fn(() => {
+            if (viewRoot) {
+                createMutationAcidSnapshot(viewRoot);
+                for (const listener of layoutListeners) {
+                    listener({ type: "layoutComputed" });
+                }
+            }
+        });
+        const { view, api } = await createViewMutationAcidHarness(
+            makeMoveFreshnessAcidSpec(),
+            {
+                contextOptions: {
+                    requestLayoutReflow,
+                    addBroadcastListener: (type, listener) => {
+                        if (type === "layoutComputed") {
+                            layoutListeners.add(listener);
+                        }
+                    },
+                    removeBroadcastListener: (type, listener) => {
+                        if (type === "layoutComputed") {
+                            layoutListeners.delete(listener);
+                        }
+                    },
+                },
+            }
+        );
+        viewRoot = view;
+        createMutationAcidSnapshot(view);
+        requestLayoutReflow.mockClear();
+
+        const trackC = api.get({ scope: [], view: "trackC" });
+        const beforeMove = api.getLayoutBounds(trackC);
+        let layoutEvents = 0;
+        const unsubscribe = api.subscribeToLayout(() => {
+            layoutEvents += 1;
+        });
+
+        try {
+            // Moving an existing view should synchronously request a fresh
+            // layout and make overlay-style callers see the new bounds.
+            await api.move(trackC, { index: 0 });
+
+            const afterMove = api.getLayoutBounds(trackC);
+            expect(requestLayoutReflow).toHaveBeenCalledTimes(1);
+            expect(layoutEvents).toBe(1);
+            expect(afterMove?.y).not.toBe(beforeMove?.y);
+            expect(
+                api
+                    .root()
+                    .children()
+                    .map((child) => child.name)
+            ).toEqual(["trackC", "trackA", "trackB"]);
+        } finally {
+            unsubscribe();
+        }
     });
 });
 

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -12,6 +12,7 @@ import {
     getRequiredView,
     waitUntil,
 } from "./viewMutationAcidTestUtils.js";
+import AxisView from "./axisView.js";
 
 // These acid scenarios intentionally drive mutations through the public
 // ViewMutationApi. The assertions inspect normalized internal state because
@@ -507,6 +508,33 @@ describe("View mutation acid scenarios", () => {
         for (const owner of getLegendDefinitionViews(view, "tracks", "color")) {
             expect(liveViews.has(owner)).toBe(true);
         }
+    });
+
+    test("keeps shared axis initialized when the penultimate child moves last", async () => {
+        const { view, api } = await createViewMutationAcidHarness({
+            ...makeSharedGuideAcidSpec(),
+            vconcat: [
+                makeTrackSpec("trackA", "Track A"),
+                makeTrackSpec("trackB", "Track B"),
+                makeTrackSpec("trackC", "Track C"),
+            ],
+        });
+
+        const beforeMoveAxisStates = getAxisDataStates(view, "bottom");
+        expect(beforeMoveAxisStates).not.toContain("none");
+
+        // Moving the second-last track to the end changes shared x-axis
+        // ownership. The regenerated axis must be initialized immediately, not
+        // only after a later insert/remove mutation refreshes chrome again.
+        await api.move(api.get({ scope: [], view: "trackB" }), { index: 2 });
+
+        expect(
+            api
+                .root()
+                .children()
+                .map((child) => child.name)
+        ).toEqual(["trackA", "trackC", "trackB"]);
+        expect(getAxisDataStates(view, "bottom")).toEqual(beforeMoveAxisStates);
     });
 
     test("restores inherited dataflow after inserting and removing an inherited track", async () => {
@@ -1126,6 +1154,28 @@ function getLegendDefinitionViews(viewRoot, viewName, channel) {
     }
 
     return resolution.getLegendDefs().map((definition) => definition.view);
+}
+
+/**
+ * @param {import("./view.js").default} viewRoot
+ * @param {import("../spec/axis.js").AxisOrient} orient
+ * @returns {string[]}
+ */
+function getAxisDataStates(viewRoot, orient) {
+    const axisView = viewRoot
+        .getDescendants()
+        .find(
+            (view) =>
+                view instanceof AxisView && view.axisProps.orient === orient
+        );
+
+    if (!axisView) {
+        throw new Error("Expected shared axis with orient: " + orient);
+    }
+
+    return axisView
+        .getDescendants()
+        .map((view) => view.getDataInitializationState());
 }
 
 /**

--- a/packages/core/src/view/viewMutationApi.acid.test.js
+++ b/packages/core/src/view/viewMutationApi.acid.test.js
@@ -857,6 +857,45 @@ describe("View mutation acid scenarios", () => {
             unsubscribe();
         }
     });
+
+    test("addresses an authored unit inside an implicit mutable root", async () => {
+        const { api, context } = await createViewMutationAcidHarness(
+            makeTrackSpec("authoredTrack", "Authored track"),
+            { contextOptions: { viewFactoryOptions: { wrapRoot: true } } }
+        );
+        const baselineDataSourceCount = context.dataFlow.dataSources.length;
+        const baselineCollectorCount = context.dataFlow.collectors.length;
+        const root = api.root();
+        const authored = api.get({ scope: [], view: "authoredTrack" });
+
+        // Root-unit specs are wrapped in an implicit container for chrome.
+        // Mutations should target that layout tree while selectors still find
+        // the authored unit view inside it.
+        expect(root.type).toBe("concat");
+        expect(root.name).toBe("implicitRoot");
+        expect(root.children()).toEqual([authored]);
+        expect(authored.type).toBe("unit");
+        expect(authored.parent()).toBe(root);
+
+        const inserted = await api.insert(
+            root,
+            makeTrackSpec("summary", "Summary"),
+            { scope: "summary" }
+        );
+
+        expect(api.root().children()).toEqual([authored, inserted]);
+        expect(api.get({ scope: ["summary"], view: "summary" })).toBe(inserted);
+
+        await api.remove(inserted);
+
+        expect(api.root().children()).toEqual([authored]);
+        expect(context.dataFlow.dataSources).toHaveLength(
+            baselineDataSourceCount
+        );
+        expect(context.dataFlow.collectors).toHaveLength(
+            baselineCollectorCount
+        );
+    });
 });
 
 /**

--- a/packages/core/src/view/viewMutationApi.js
+++ b/packages/core/src/view/viewMutationApi.js
@@ -52,7 +52,11 @@ export function createViewMutationApi(genomeSpy) {
 
     let nextHandleId = 0;
     let transactionDepth = 0;
+    let transactionRequestedLayoutReflow = false;
     let queue = Promise.resolve();
+
+    /** @type {(() => void) | undefined} */
+    let restoreTransactionLayoutReflow;
 
     /**
      * @returns {import("./view.js").default}
@@ -251,6 +255,49 @@ export function createViewMutationApi(genomeSpy) {
      * @returns {void}
      */
     function clearQueueValue() {}
+
+    /**
+     * @returns {void}
+     */
+    function beginTransaction() {
+        if (transactionDepth === 0) {
+            const context = getRootView().context;
+            const requestLayoutReflow = context.requestLayoutReflow;
+            transactionRequestedLayoutReflow = false;
+            context.requestLayoutReflow = () => {
+                transactionRequestedLayoutReflow = true;
+            };
+            restoreTransactionLayoutReflow = () => {
+                context.requestLayoutReflow = requestLayoutReflow;
+                if (transactionRequestedLayoutReflow) {
+                    requestLayoutReflow.call(context);
+                }
+
+                transactionRequestedLayoutReflow = false;
+                restoreTransactionLayoutReflow = undefined;
+            };
+        }
+
+        transactionDepth++;
+    }
+
+    /**
+     * @returns {void}
+     */
+    function endTransaction() {
+        transactionDepth--;
+
+        if (transactionDepth === 0) {
+            if (!restoreTransactionLayoutReflow) {
+                throw new ViewMutationError(
+                    "invalidTransactionState",
+                    "Transaction cleanup state is missing."
+                );
+            }
+
+            restoreTransactionLayoutReflow();
+        }
+    }
 
     /**
      * @param {ViewAddress} parentAddress
@@ -594,11 +641,11 @@ export function createViewMutationApi(genomeSpy) {
 
         transaction: (/** @type {(views: typeof api) => any} */ callback) =>
             enqueue(async () => {
-                transactionDepth++;
+                beginTransaction();
                 try {
                     return await callback(api);
                 } finally {
-                    transactionDepth--;
+                    endTransaction();
                 }
             }),
     };

--- a/packages/core/src/view/viewMutationApi.js
+++ b/packages/core/src/view/viewMutationApi.js
@@ -1,0 +1,317 @@
+import ConcatView from "./concatView.js";
+import GridView from "./gridView/gridView.js";
+import LayerView from "./layerView.js";
+import UnitView from "./unitView.js";
+import { getViewSelector, resolveViewSelector } from "./viewSelectors.js";
+
+/**
+ * Error thrown by the public view mutation API.
+ */
+export class ViewMutationError extends Error {
+    /**
+     * @param {string} code
+     * @param {string} message
+     */
+    constructor(code, message) {
+        super(message);
+        this.name = "ViewMutationError";
+
+        /**
+         * Stable error code for programmatic handling.
+         */
+        this.code = code;
+    }
+}
+
+/**
+ * Creates the public view mutation API for a GenomeSpy instance.
+ *
+ * @param {{ viewRoot: import("./view.js").default }} genomeSpy
+ * @returns {import("../types/embedApi.js").ViewMutationApi}
+ */
+export function createViewMutationApi(genomeSpy) {
+    /**
+     * @typedef {import("../types/embedApi.js").ViewAddress} ViewAddress
+     * @typedef {import("../types/embedApi.js").ViewHandle} ViewHandle
+     * @typedef {import("../view/viewUtilTypes.d.ts").ViewSelector} ViewSelector
+     */
+
+    /** @type {WeakMap<import("./view.js").default, import("../types/embedApi.js").ViewHandle>} */
+    const handlesByView = new WeakMap();
+
+    /** @type {WeakMap<import("../types/embedApi.js").ViewHandle, import("./view.js").default>} */
+    const viewsByHandle = new WeakMap();
+
+    let nextHandleId = 0;
+    let transactionDepth = 0;
+    let queue = Promise.resolve();
+
+    /**
+     * @returns {import("./view.js").default}
+     */
+    function getRootView() {
+        return genomeSpy.viewRoot;
+    }
+
+    /**
+     * @param {import("./view.js").default} view
+     * @returns {boolean}
+     */
+    function isLiveView(view) {
+        const root = getRootView();
+        return (
+            view === root || Boolean(root?.getDescendants?.().includes(view))
+        );
+    }
+
+    /**
+     * @param {import("./view.js").default} view
+     * @returns {import("../types/embedApi.js").ViewHandleType}
+     */
+    function getHandleType(view) {
+        if (view instanceof ConcatView) {
+            return "concat";
+        } else if (view instanceof LayerView) {
+            return "layer";
+        } else if (view instanceof UnitView) {
+            return "unit";
+        } else if (view instanceof GridView) {
+            return "grid";
+        } else {
+            return "unknown";
+        }
+    }
+
+    /**
+     * @param {import("./view.js").default} view
+     * @returns {ViewSelector | undefined}
+     */
+    function getSelector(view) {
+        if (!view.explicitName) {
+            return undefined;
+        }
+
+        try {
+            return getViewSelector(view);
+        } catch {
+            return undefined;
+        }
+    }
+
+    /**
+     * @param {import("./view.js").default} view
+     * @returns {import("../types/embedApi.js").ViewHandle}
+     */
+    function getHandle(view) {
+        let handle = handlesByView.get(view);
+        if (handle) {
+            return handle;
+        }
+
+        const id = "view-" + nextHandleId;
+        nextHandleId++;
+
+        handle = {
+            id,
+
+            get name() {
+                return view.explicitName;
+            },
+
+            get selector() {
+                return getSelector(view);
+            },
+
+            get type() {
+                return getHandleType(view);
+            },
+
+            isAlive: () => isLiveView(view),
+
+            parent: () => {
+                if (!isLiveView(view) || !view.layoutParent) {
+                    return undefined;
+                }
+
+                return getHandle(view.layoutParent);
+            },
+
+            children: () => {
+                const children = getLayoutChildren(view);
+                if (!isLiveView(view) || !children) {
+                    return [];
+                }
+
+                return children.map((child) => getHandle(child));
+            },
+        };
+
+        handlesByView.set(view, handle);
+        viewsByHandle.set(handle, view);
+        return handle;
+    }
+
+    /**
+     * @param {import("./view.js").default} view
+     * @returns {import("./view.js").default[] | undefined}
+     */
+    function getLayoutChildren(view) {
+        const children = /** @type {{ children?: unknown }} */ (view).children;
+        return Array.isArray(children)
+            ? /** @type {import("./view.js").default[]} */ (children)
+            : undefined;
+    }
+
+    /**
+     * @param {ViewAddress} address
+     * @returns {import("../types/embedApi.js").ViewHandle | undefined}
+     */
+    function resolve(address) {
+        if (address === "root") {
+            return getHandle(getRootView());
+        } else if (isViewHandle(address)) {
+            return viewsByHandle.has(address) && address.isAlive()
+                ? address
+                : undefined;
+        } else if (isViewSelector(address)) {
+            const view = resolveViewSelector(getRootView(), address);
+            return view ? getHandle(view) : undefined;
+        } else {
+            throw new ViewMutationError(
+                "invalidAddress",
+                'View address must be a handle, selector, or "root".'
+            );
+        }
+    }
+
+    /**
+     * @param {ViewAddress} address
+     * @returns {import("../types/embedApi.js").ViewHandle}
+     */
+    function get(address) {
+        const handle = resolve(address);
+        if (handle) {
+            return handle;
+        }
+
+        if (isViewHandle(address) && viewsByHandle.has(address)) {
+            throw new ViewMutationError(
+                "staleHandle",
+                "Stale view handle no longer refers to a live view."
+            );
+        }
+
+        throw new ViewMutationError(
+            "unresolvedAddress",
+            "View address did not resolve to a live view."
+        );
+    }
+
+    /**
+     * @template T
+     * @param {() => T | Promise<T>} operation
+     * @returns {Promise<T>}
+     */
+    function enqueue(operation) {
+        if (transactionDepth > 0) {
+            return Promise.resolve(operation());
+        }
+
+        const next = queue.then(operation, operation);
+        queue = next.then(clearQueueValue, clearQueueValue);
+        return next;
+    }
+
+    /**
+     * @returns {void}
+     */
+    function clearQueueValue() {}
+
+    /**
+     * @returns {Promise<ViewHandle>}
+     */
+    function rejectInsert() {
+        return Promise.reject(
+            new ViewMutationError(
+                "notImplemented",
+                "View insertion is not implemented yet."
+            )
+        );
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    function rejectRemove() {
+        return Promise.reject(
+            new ViewMutationError(
+                "notImplemented",
+                "View removal is not implemented yet."
+            )
+        );
+    }
+
+    /**
+     * @returns {Promise<ViewHandle>}
+     */
+    function rejectMove() {
+        return Promise.reject(
+            new ViewMutationError(
+                "notImplemented",
+                "View reordering is not implemented yet."
+            )
+        );
+    }
+
+    /** @type {import("../types/embedApi.js").ViewMutationApi} */
+    const api = {
+        root: () => getHandle(getRootView()),
+
+        resolve,
+
+        get,
+
+        insert: () => enqueue(rejectInsert),
+
+        remove: () => enqueue(rejectRemove),
+
+        move: () => enqueue(rejectMove),
+
+        transaction: (/** @type {(views: typeof api) => any} */ callback) =>
+            enqueue(async () => {
+                transactionDepth++;
+                try {
+                    return await callback(api);
+                } finally {
+                    transactionDepth--;
+                }
+            }),
+    };
+
+    return api;
+}
+
+/**
+ * @param {unknown} address
+ * @returns {address is import("../types/embedApi.js").ViewHandle}
+ */
+function isViewHandle(address) {
+    return (
+        typeof address === "object" &&
+        address !== null &&
+        typeof (/** @type {any} */ (address).isAlive) === "function"
+    );
+}
+
+/**
+ * @param {unknown} address
+ * @returns {address is import("../view/viewUtilTypes.d.ts").ViewSelector}
+ */
+function isViewSelector(address) {
+    return (
+        typeof address === "object" &&
+        address !== null &&
+        Array.isArray(/** @type {any} */ (address).scope) &&
+        typeof (/** @type {any} */ (address).view) === "string"
+    );
+}

--- a/packages/core/src/view/viewMutationApi.js
+++ b/packages/core/src/view/viewMutationApi.js
@@ -1,8 +1,16 @@
 import ConcatView from "./concatView.js";
 import GridView from "./gridView/gridView.js";
 import LayerView from "./layerView.js";
+import { isMultiscaleSpec } from "./multiscale.js";
 import UnitView from "./unitView.js";
-import { getViewSelector, resolveViewSelector } from "./viewSelectors.js";
+import { isImportSpec, isLayerSpec, isUnitSpec } from "./viewSpecGuards.js";
+import {
+    getImportScopeInfo,
+    getViewScopeChain,
+    getViewSelector,
+    registerImportInstance,
+    resolveViewSelector,
+} from "./viewSelectors.js";
 
 /**
  * Error thrown by the public view mutation API.
@@ -208,6 +216,23 @@ export function createViewMutationApi(genomeSpy) {
     }
 
     /**
+     * @param {ViewAddress} address
+     * @returns {import("./view.js").default}
+     */
+    function getView(address) {
+        const handle = get(address);
+        const view = viewsByHandle.get(handle);
+        if (!view) {
+            throw new ViewMutationError(
+                "invalidAddress",
+                "View handle is not owned by this GenomeSpy instance."
+            );
+        }
+
+        return view;
+    }
+
+    /**
      * @template T
      * @param {() => T | Promise<T>} operation
      * @returns {Promise<T>}
@@ -228,14 +253,189 @@ export function createViewMutationApi(genomeSpy) {
     function clearQueueValue() {}
 
     /**
+     * @param {ViewAddress} parentAddress
+     * @param {import("../spec/view.js").ViewSpec | import("../spec/view.js").ImportSpec} spec
+     * @param {import("../types/embedApi.js").InsertViewOptions} [options]
      * @returns {Promise<ViewHandle>}
      */
-    function rejectInsert() {
-        return Promise.reject(
-            new ViewMutationError(
-                "notImplemented",
-                "View insertion is not implemented yet."
-            )
+    function insert(parentAddress, spec, options = {}) {
+        return enqueue(async () => {
+            const parentView = getView(parentAddress);
+            const childCount = getMutableContainerChildCount(parentView);
+            const index = getInsertIndex(options.index, childCount);
+            const scopeName = getInsertScopeName(spec, options);
+
+            if (scopeName !== undefined && typeof scopeName === "string") {
+                ensureScopeNameIsAvailable(parentView, scopeName);
+            }
+
+            const childSpec = structuredClone(spec);
+            const childView = await addChildToMutableContainer(
+                parentView,
+                childSpec,
+                index
+            );
+
+            if (options.scope !== undefined) {
+                registerImportInstance(childView, options.scope);
+            }
+
+            return getHandle(childView);
+        });
+    }
+
+    /**
+     * @param {import("./view.js").default} parentView
+     * @returns {number}
+     */
+    function getMutableContainerChildCount(parentView) {
+        if (
+            !(parentView instanceof ConcatView) &&
+            !(parentView instanceof LayerView)
+        ) {
+            throw new ViewMutationError(
+                "unsupportedContainer",
+                "Only concat and layer views support child insertion."
+            );
+        }
+
+        const children = getLayoutChildren(parentView);
+        if (!children) {
+            throw new ViewMutationError(
+                "unsupportedContainer",
+                "Mutable container does not expose layout children."
+            );
+        }
+
+        return children.length;
+    }
+
+    /**
+     * @param {import("./view.js").default} parentView
+     * @param {import("../spec/view.js").ViewSpec | import("../spec/view.js").ImportSpec} childSpec
+     * @param {number} index
+     * @returns {Promise<import("./view.js").default>}
+     */
+    async function addChildToMutableContainer(parentView, childSpec, index) {
+        if (parentView instanceof ConcatView) {
+            return parentView.addChildSpec(childSpec, index);
+        } else if (parentView instanceof LayerView) {
+            if (!isLayerChildSpec(childSpec)) {
+                throw new ViewMutationError(
+                    "unsupportedChildSpec",
+                    "Layer views accept only unit, layer, multiscale, or import specs as children."
+                );
+            }
+
+            return parentView.addChildSpec(childSpec, index);
+        }
+
+        throw new ViewMutationError(
+            "unsupportedContainer",
+            "Only concat and layer views support child insertion."
+        );
+    }
+
+    /**
+     * @param {number | undefined} index
+     * @param {number} childCount
+     * @returns {number}
+     */
+    function getInsertIndex(index, childCount) {
+        const insertIndex = index ?? childCount;
+
+        if (!Number.isInteger(insertIndex)) {
+            throw new ViewMutationError(
+                "invalidIndex",
+                "Insert index must be an integer."
+            );
+        }
+
+        if (insertIndex < 0 || insertIndex > childCount) {
+            throw new ViewMutationError(
+                "invalidIndex",
+                "Insert index must be between 0 and the current child count."
+            );
+        }
+
+        return insertIndex;
+    }
+
+    /**
+     * @param {import("../spec/view.js").ViewSpec | import("../spec/view.js").ImportSpec} spec
+     * @param {import("../types/embedApi.js").InsertViewOptions} options
+     * @returns {string | null | undefined}
+     */
+    function getInsertScopeName(spec, options) {
+        const importScopeName =
+            isImportSpec(spec) && "name" in spec ? spec.name : undefined;
+
+        if (
+            options.scope !== undefined &&
+            importScopeName !== undefined &&
+            options.scope !== importScopeName
+        ) {
+            throw new ViewMutationError(
+                "scopeMismatch",
+                "Insert scope must match the import instance name."
+            );
+        }
+
+        return options.scope ?? importScopeName;
+    }
+
+    /**
+     * @param {import("./view.js").default} parentView
+     * @param {string} scopeName
+     */
+    function ensureScopeNameIsAvailable(parentView, scopeName) {
+        const parentScope = getViewScopeChain(parentView);
+        const targetScope = parentScope.concat(scopeName);
+
+        getRootView().visit((view) => {
+            const info = getImportScopeInfo(view);
+            if (
+                info &&
+                info.name === scopeName &&
+                scopesEqual(getViewScopeChain(view), targetScope)
+            ) {
+                throw new ViewMutationError(
+                    "duplicateScope",
+                    'Scope "' + scopeName + '" already exists.'
+                );
+            }
+        });
+    }
+
+    /**
+     * @param {string[]} a
+     * @param {string[]} b
+     * @returns {boolean}
+     */
+    function scopesEqual(a, b) {
+        if (a.length !== b.length) {
+            return false;
+        }
+
+        return a.every((value, index) => value === b[index]);
+    }
+
+    /**
+     * @param {import("../spec/view.js").ViewSpec | import("../spec/view.js").ImportSpec} spec
+     * @returns {spec is import("../spec/view.js").UnitSpec | import("../spec/view.js").LayerSpec | import("../spec/view.js").MultiscaleSpec | import("../spec/view.js").ImportSpec}
+     */
+    function isLayerChildSpec(spec) {
+        if (isImportSpec(spec)) {
+            return true;
+        }
+
+        const viewSpec = /** @type {import("../spec/view.js").ViewSpec} */ (
+            spec
+        );
+        return (
+            isUnitSpec(viewSpec) ||
+            isLayerSpec(viewSpec) ||
+            isMultiscaleSpec(viewSpec)
         );
     }
 
@@ -271,7 +471,7 @@ export function createViewMutationApi(genomeSpy) {
 
         get,
 
-        insert: () => enqueue(rejectInsert),
+        insert,
 
         remove: () => enqueue(rejectRemove),
 

--- a/packages/core/src/view/viewMutationApi.js
+++ b/packages/core/src/view/viewMutationApi.js
@@ -32,10 +32,10 @@ export class ViewMutationError extends Error {
 }
 
 /**
- * Creates the public view mutation API for a GenomeSpy instance.
+ * Creates the public view hierarchy API for a GenomeSpy instance.
  *
  * @param {{ viewRoot: import("./view.js").default }} genomeSpy
- * @returns {import("../types/embedApi.js").ViewMutationApi}
+ * @returns {import("../types/embedApi.js").ViewApi}
  */
 export function createViewMutationApi(genomeSpy) {
     /**
@@ -234,6 +234,46 @@ export function createViewMutationApi(genomeSpy) {
         }
 
         return view;
+    }
+
+    /**
+     * @param {ViewAddress} address
+     * @returns {import("../types/embedApi.js").ViewLayoutBounds | undefined}
+     */
+    function getLayoutBounds(address) {
+        const handle = resolve(address);
+        if (!handle) {
+            return undefined;
+        }
+
+        const view = viewsByHandle.get(handle);
+        const coords = view?.coords;
+        if (!coords) {
+            return undefined;
+        }
+
+        return {
+            x: coords.x,
+            y: coords.y,
+            width: coords.width,
+            height: coords.height,
+        };
+    }
+
+    /**
+     * @param {() => void} listener
+     * @returns {() => void}
+     */
+    function subscribeToLayout(listener) {
+        const context = getRootView().context;
+        const broadcastListener = () => listener();
+        context.addBroadcastListener("layoutComputed", broadcastListener);
+
+        return () =>
+            context.removeBroadcastListener(
+                "layoutComputed",
+                broadcastListener
+            );
     }
 
     /**
@@ -629,13 +669,17 @@ export function createViewMutationApi(genomeSpy) {
         }
     }
 
-    /** @type {import("../types/embedApi.js").ViewMutationApi} */
+    /** @type {import("../types/embedApi.js").ViewApi} */
     const api = {
         root: () => getHandle(getRootView()),
 
         resolve,
 
         get,
+
+        getLayoutBounds,
+
+        subscribeToLayout,
 
         insert,
 

--- a/packages/core/src/view/viewMutationApi.js
+++ b/packages/core/src/view/viewMutationApi.js
@@ -440,15 +440,55 @@ export function createViewMutationApi(genomeSpy) {
     }
 
     /**
+     * @param {ViewAddress} targetAddress
      * @returns {Promise<void>}
      */
-    function rejectRemove() {
-        return Promise.reject(
-            new ViewMutationError(
-                "notImplemented",
-                "View removal is not implemented yet."
-            )
-        );
+    function remove(targetAddress) {
+        return enqueue(async () => {
+            const targetView = getView(targetAddress);
+            if (targetView === getRootView() || !targetView.layoutParent) {
+                throw new ViewMutationError(
+                    "cannotRemoveRoot",
+                    "Removing the root view is not supported."
+                );
+            }
+
+            const parentView = targetView.layoutParent;
+            const children = getLayoutChildren(parentView);
+            if (!children) {
+                throw new ViewMutationError(
+                    "unsupportedContainer",
+                    "Parent view does not expose layout children."
+                );
+            }
+
+            const index = children.indexOf(targetView);
+            if (index < 0) {
+                throw new ViewMutationError(
+                    "invalidHierarchy",
+                    "Target view is not a child of its layout parent."
+                );
+            }
+
+            await removeChildFromMutableContainer(parentView, index);
+        });
+    }
+
+    /**
+     * @param {import("./view.js").default} parentView
+     * @param {number} index
+     */
+    async function removeChildFromMutableContainer(parentView, index) {
+        if (parentView instanceof ConcatView) {
+            await parentView.removeChildAt(index);
+        } else if (parentView instanceof LayerView) {
+            await parentView.removeChildAt(index);
+        } else {
+            throw new ViewMutationError(
+                "unsupportedContainer",
+                "Only concat and layer views support child removal."
+            );
+        }
     }
 
     /**
@@ -473,7 +513,7 @@ export function createViewMutationApi(genomeSpy) {
 
         insert,
 
-        remove: () => enqueue(rejectRemove),
+        remove,
 
         move: () => enqueue(rejectMove),
 

--- a/packages/core/src/view/viewMutationApi.js
+++ b/packages/core/src/view/viewMutationApi.js
@@ -578,7 +578,7 @@ export function createViewMutationApi(genomeSpy) {
             }
 
             const index = getMoveIndex(options.index, children.length - 1);
-            moveChildWithinMutableContainer(parentView, fromIndex, index);
+            await moveChildWithinMutableContainer(parentView, fromIndex, index);
 
             return getHandle(targetView);
         });
@@ -612,9 +612,13 @@ export function createViewMutationApi(genomeSpy) {
      * @param {number} fromIndex
      * @param {number} index
      */
-    function moveChildWithinMutableContainer(parentView, fromIndex, index) {
+    async function moveChildWithinMutableContainer(
+        parentView,
+        fromIndex,
+        index
+    ) {
         if (parentView instanceof ConcatView) {
-            parentView.moveChildAt(fromIndex, index);
+            await parentView.moveChildAt(fromIndex, index);
         } else if (parentView instanceof LayerView) {
             parentView.moveChildAt(fromIndex, index);
         } else {

--- a/packages/core/src/view/viewMutationApi.js
+++ b/packages/core/src/view/viewMutationApi.js
@@ -492,15 +492,90 @@ export function createViewMutationApi(genomeSpy) {
     }
 
     /**
+     * @param {ViewAddress} targetAddress
+     * @param {import("../types/embedApi.js").MoveViewOptions} options
      * @returns {Promise<ViewHandle>}
      */
-    function rejectMove() {
-        return Promise.reject(
-            new ViewMutationError(
-                "notImplemented",
-                "View reordering is not implemented yet."
-            )
-        );
+    function move(targetAddress, options) {
+        return enqueue(async () => {
+            const targetView = getView(targetAddress);
+            if (targetView === getRootView() || !targetView.layoutParent) {
+                throw new ViewMutationError(
+                    "cannotMoveRoot",
+                    "Moving the root view is not supported."
+                );
+            }
+
+            const parentView = targetView.layoutParent;
+            const children = getLayoutChildren(parentView);
+            if (!children) {
+                throw new ViewMutationError(
+                    "unsupportedContainer",
+                    "Parent view does not expose layout children."
+                );
+            }
+
+            const fromIndex = children.indexOf(targetView);
+            if (fromIndex < 0) {
+                throw new ViewMutationError(
+                    "invalidHierarchy",
+                    "Target view is not a child of its layout parent."
+                );
+            }
+
+            if (!options) {
+                throw new ViewMutationError(
+                    "invalidIndex",
+                    "Move options with an index are required."
+                );
+            }
+
+            const index = getMoveIndex(options.index, children.length - 1);
+            moveChildWithinMutableContainer(parentView, fromIndex, index);
+
+            return getHandle(targetView);
+        });
+    }
+
+    /**
+     * @param {number | undefined} index
+     * @param {number} remainingChildCount
+     * @returns {number}
+     */
+    function getMoveIndex(index, remainingChildCount) {
+        if (!Number.isInteger(index)) {
+            throw new ViewMutationError(
+                "invalidIndex",
+                "Move index must be an integer."
+            );
+        }
+
+        if (index < 0 || index > remainingChildCount) {
+            throw new ViewMutationError(
+                "invalidIndex",
+                "Move index must be between 0 and the remaining child count."
+            );
+        }
+
+        return index;
+    }
+
+    /**
+     * @param {import("./view.js").default} parentView
+     * @param {number} fromIndex
+     * @param {number} index
+     */
+    function moveChildWithinMutableContainer(parentView, fromIndex, index) {
+        if (parentView instanceof ConcatView) {
+            parentView.moveChildAt(fromIndex, index);
+        } else if (parentView instanceof LayerView) {
+            parentView.moveChildAt(fromIndex, index);
+        } else {
+            throw new ViewMutationError(
+                "unsupportedContainer",
+                "Only concat and layer views support child reordering."
+            );
+        }
     }
 
     /** @type {import("../types/embedApi.js").ViewMutationApi} */
@@ -515,7 +590,7 @@ export function createViewMutationApi(genomeSpy) {
 
         remove,
 
-        move: () => enqueue(rejectMove),
+        move,
 
         transaction: (/** @type {(views: typeof api) => any} */ callback) =>
             enqueue(async () => {

--- a/packages/core/src/view/viewMutationApi.js
+++ b/packages/core/src/view/viewMutationApi.js
@@ -32,6 +32,17 @@ export class ViewMutationError extends Error {
 }
 
 /**
+ * @typedef {{
+ *   depth: number,
+ *   queue: Promise<void>,
+ *   failed: boolean,
+ *   error: unknown | undefined,
+ *   requestedLayoutReflow: boolean,
+ *   restoreLayoutReflow: () => void
+ * }} TransactionState
+ */
+
+/**
  * Creates the public view hierarchy API for a GenomeSpy instance.
  *
  * @param {{ viewRoot: import("./view.js").default }} genomeSpy
@@ -51,12 +62,10 @@ export function createViewMutationApi(genomeSpy) {
     const viewsByHandle = new WeakMap();
 
     let nextHandleId = 0;
-    let transactionDepth = 0;
-    let transactionRequestedLayoutReflow = false;
     let queue = Promise.resolve();
 
-    /** @type {(() => void) | undefined} */
-    let restoreTransactionLayoutReflow;
+    /** @type {TransactionState | undefined} */
+    let activeTransaction;
 
     /**
      * @returns {import("./view.js").default}
@@ -282,12 +291,36 @@ export function createViewMutationApi(genomeSpy) {
      * @returns {Promise<T>}
      */
     function enqueue(operation) {
-        if (transactionDepth > 0) {
-            return Promise.resolve(operation());
+        if (activeTransaction) {
+            return enqueueTransactionOperation(activeTransaction, operation);
         }
 
+        return enqueueTopLevelOperation(operation);
+    }
+
+    /**
+     * @template T
+     * @param {() => T | Promise<T>} operation
+     * @returns {Promise<T>}
+     */
+    function enqueueTopLevelOperation(operation) {
         const next = queue.then(operation, operation);
         queue = next.then(clearQueueValue, clearQueueValue);
+        return next;
+    }
+
+    /**
+     * @template T
+     * @param {TransactionState} transaction
+     * @param {() => T | Promise<T>} operation
+     * @returns {Promise<T>}
+     */
+    function enqueueTransactionOperation(transaction, operation) {
+        const next = transaction.queue.then(operation, operation);
+        transaction.queue = next.then(clearQueueValue, (error) => {
+            transaction.failed = true;
+            transaction.error = error;
+        });
         return next;
     }
 
@@ -297,45 +330,102 @@ export function createViewMutationApi(genomeSpy) {
     function clearQueueValue() {}
 
     /**
-     * @returns {void}
+     * @returns {TransactionState}
      */
     function beginTransaction() {
-        if (transactionDepth === 0) {
-            const context = getRootView().context;
-            const requestLayoutReflow = context.requestLayoutReflow;
-            transactionRequestedLayoutReflow = false;
-            context.requestLayoutReflow = () => {
-                transactionRequestedLayoutReflow = true;
-            };
-            restoreTransactionLayoutReflow = () => {
-                context.requestLayoutReflow = requestLayoutReflow;
-                if (transactionRequestedLayoutReflow) {
-                    requestLayoutReflow.call(context);
-                }
-
-                transactionRequestedLayoutReflow = false;
-                restoreTransactionLayoutReflow = undefined;
-            };
+        const transaction = activeTransaction;
+        if (transaction) {
+            transaction.depth++;
+            return transaction;
         }
 
-        transactionDepth++;
+        const context = getRootView().context;
+        const requestLayoutReflow = context.requestLayoutReflow;
+        /** @type {TransactionState} */
+        const topLevelTransaction = {
+            depth: 1,
+            queue: Promise.resolve(),
+            failed: false,
+            error: undefined,
+            requestedLayoutReflow: false,
+            restoreLayoutReflow: () => {
+                context.requestLayoutReflow = requestLayoutReflow;
+                if (topLevelTransaction.requestedLayoutReflow) {
+                    requestLayoutReflow.call(context);
+                }
+            },
+        };
+
+        context.requestLayoutReflow = () => {
+            topLevelTransaction.requestedLayoutReflow = true;
+        };
+        activeTransaction = topLevelTransaction;
+        return topLevelTransaction;
     }
 
     /**
+     * @param {TransactionState} transaction
      * @returns {void}
      */
-    function endTransaction() {
-        transactionDepth--;
+    function endTransaction(transaction) {
+        transaction.depth--;
 
-        if (transactionDepth === 0) {
-            if (!restoreTransactionLayoutReflow) {
-                throw new ViewMutationError(
-                    "invalidTransactionState",
-                    "Transaction cleanup state is missing."
-                );
+        if (transaction.depth === 0) {
+            transaction.restoreLayoutReflow();
+            activeTransaction = undefined;
+        }
+    }
+
+    /**
+     * Mutations may enqueue more mutations from promise continuations. Keep
+     * draining until the transaction queue stops changing.
+     *
+     * @param {TransactionState} transaction
+     * @returns {Promise<void>}
+     */
+    async function waitForTransactionQueue(transaction) {
+        let currentQueue;
+        do {
+            currentQueue = transaction.queue;
+            await currentQueue;
+        } while (transaction.queue !== currentQueue);
+    }
+
+    /**
+     * @template T
+     * @param {(views: import("../types/embedApi.js").ViewApi) => T | Promise<T>} callback
+     * @returns {Promise<T>}
+     */
+    async function runTransaction(callback) {
+        const transaction = beginTransaction();
+        const previouslyFailed = transaction.failed;
+        /** @type {T | undefined} */
+        let result;
+        /** @type {unknown} */
+        let callbackError;
+        let callbackFailed = false;
+
+        try {
+            result = await callback(api);
+        } catch (error) {
+            callbackError = error;
+            callbackFailed = true;
+        }
+
+        await waitForTransactionQueue(transaction);
+
+        try {
+            if (callbackFailed) {
+                throw callbackError;
             }
 
-            restoreTransactionLayoutReflow();
+            if (transaction.failed && transaction.failed !== previouslyFailed) {
+                throw transaction.error;
+            }
+
+            return /** @type {T} */ (result);
+        } finally {
+            endTransaction(transaction);
         }
     }
 
@@ -687,15 +777,10 @@ export function createViewMutationApi(genomeSpy) {
 
         move,
 
-        transaction: (/** @type {(views: typeof api) => any} */ callback) =>
-            enqueue(async () => {
-                beginTransaction();
-                try {
-                    return await callback(api);
-                } finally {
-                    endTransaction();
-                }
-            }),
+        transaction: (callback) =>
+            activeTransaction
+                ? runTransaction(callback)
+                : enqueueTopLevelOperation(() => runTransaction(callback)),
     };
 
     return api;

--- a/packages/core/src/view/viewMutationApi.js
+++ b/packages/core/src/view/viewMutationApi.js
@@ -8,7 +8,7 @@ import {
     getImportScopeInfo,
     getViewScopeChain,
     getViewSelector,
-    registerImportInstance,
+    registerViewScope,
     resolveViewSelector,
 } from "./viewSelectors.js";
 
@@ -454,7 +454,7 @@ export function createViewMutationApi(genomeSpy) {
             );
 
             if (options.scope !== undefined) {
-                registerImportInstance(childView, options.scope);
+                registerViewScope(childView, options.scope);
             }
 
             return getHandle(childView);

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -80,4 +80,120 @@ describe("ViewMutationApi", () => {
         expect(api.resolve(child)).toBeUndefined();
         expect(() => api.get(child)).toThrow(/stale/i);
     });
+
+    test("inserts a direct spec into a concat container", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            vconcat: [],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        const childSpec = makeUnitSpec("trackA");
+        const inserted = await api.insert("root", childSpec, { index: 0 });
+
+        expect(inserted.name).toBe("trackA");
+        expect(inserted.parent()).toBe(api.root());
+        expect(api.root().children()).toEqual([inserted]);
+        expect(api.get({ scope: [], view: "trackA" })).toBe(inserted);
+        expect(/** @type {any} */ (view).spec.vconcat[0]).not.toBe(childSpec);
+    });
+
+    test("inserts a direct spec into a layer container", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            layer: [],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        const inserted = await api.insert("root", makeUnitSpec("trackA"));
+
+        expect(inserted.type).toBe("unit");
+        expect(api.root().children()).toEqual([inserted]);
+    });
+
+    test("registers explicit scopes for inserted direct specs", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            vconcat: [],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        await api.insert(
+            "root",
+            {
+                name: "summary",
+                vconcat: [makeUnitSpec("coverage")],
+            },
+            { scope: "sampleA" }
+        );
+
+        expect(api.get({ scope: ["sampleA"], view: "coverage" }).name).toBe(
+            "coverage"
+        );
+    });
+
+    test("rejects invalid insert indexes without mutating the container", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            vconcat: [],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+
+        await expect(
+            api.insert("root", makeUnitSpec("trackA"), { index: 1 })
+        ).rejects.toMatchObject({ code: "invalidIndex" });
+        expect(api.root().children()).toHaveLength(0);
+    });
+
+    test("rejects duplicate scopes in the same scope", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            vconcat: [],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+
+        await api.insert("root", makeUnitSpec("trackA"), {
+            scope: "sampleA",
+        });
+
+        await expect(
+            api.insert("root", makeUnitSpec("trackB"), {
+                scope: "sampleA",
+            })
+        ).rejects.toMatchObject({ code: "duplicateScope" });
+        expect(api.root().children()).toHaveLength(1);
+    });
+
+    test("rejects insertion under unsupported parent views", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            vconcat: [makeUnitSpec("trackA")],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        const unit = api.get({ scope: [], view: "trackA" });
+
+        await expect(
+            api.insert(unit, makeUnitSpec("trackB"))
+        ).rejects.toMatchObject({ code: "unsupportedContainer" });
+    });
+
+    test("rejects unsupported child specs for layer containers", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            layer: [],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+
+        await expect(
+            api.insert("root", {
+                name: "nestedConcat",
+                vconcat: [makeUnitSpec("trackA")],
+            })
+        ).rejects.toMatchObject({ code: "unsupportedChildSpec" });
+        expect(api.root().children()).toHaveLength(0);
+    });
 });

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -892,4 +892,84 @@ describe("ViewMutationApi", () => {
                 .map((child) => child.name)
         ).toEqual(["trackA", "trackB"]);
     });
+
+    test("serializes concurrently started mutations inside a transaction", async () => {
+        const { view } = await createHeadlessEngine({
+            name: "tracks",
+            vconcat: [],
+        });
+        const api = createViewMutationApi({ viewRoot: view });
+
+        // Concurrent callers should still observe the same serialized mutation
+        // semantics as mutations that are started outside a transaction.
+        await api.transaction(async (views) => {
+            await Promise.all([
+                views.insert("root", makeUnitSpec("trackA")),
+                views.insert("root", makeUnitSpec("trackB")),
+            ]);
+        });
+
+        expect(
+            api
+                .root()
+                .children()
+                .map((child) => child.name)
+        ).toEqual(["trackA", "trackB"]);
+    });
+
+    test("waits for unawaited transaction mutations before resolving", async () => {
+        const requestLayoutReflow = vi.fn();
+        const { view } = await createHeadlessEngine(
+            {
+                name: "tracks",
+                vconcat: [],
+            },
+            {
+                contextOptions: {
+                    requestLayoutReflow,
+                },
+            }
+        );
+
+        requestLayoutReflow.mockClear();
+
+        const api = createViewMutationApi({ viewRoot: view });
+        // The transaction boundary is the commit point, so even fire-and-forget
+        // mutations started inside it must finish before the promise resolves.
+        await api.transaction((views) => {
+            views.insert("root", makeUnitSpec("trackA"));
+            views.insert("root", makeUnitSpec("trackB"));
+        });
+
+        expect(requestLayoutReflow).toHaveBeenCalledTimes(1);
+        expect(
+            api
+                .root()
+                .children()
+                .map((child) => child.name)
+        ).toEqual(["trackA", "trackB"]);
+    });
+
+    test("waits for chained unawaited transaction mutations before resolving", async () => {
+        const { view } = await createHeadlessEngine({
+            name: "tracks",
+            vconcat: [],
+        });
+        const api = createViewMutationApi({ viewRoot: view });
+
+        // Promise continuations can enqueue more mutation work before the
+        // transaction closes. The commit boundary must include that work too.
+        await api.transaction((views) => {
+            views
+                .insert("root", makeUnitSpec("trackA"))
+                .then(() => views.insert("root", makeUnitSpec("trackB")));
+        });
+
+        expect(
+            api
+                .root()
+                .children()
+                .map((child) => child.name)
+        ).toEqual(["trackA", "trackB"]);
+    });
 });

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "vitest";
+
+import { createHeadlessViewHierarchy } from "../genomeSpy/headlessBootstrap.js";
+import { createViewMutationApi } from "./viewMutationApi.js";
+
+/**
+ * @param {string} name
+ * @returns {import("../spec/view.js").UnitSpec}
+ */
+function makeUnitSpec(name) {
+    return {
+        name,
+        data: {
+            values: [{ x: 1, y: 2 }],
+        },
+        mark: "point",
+        encoding: {
+            x: { field: "x", type: "quantitative" },
+            y: { field: "y", type: "quantitative" },
+        },
+    };
+}
+
+describe("ViewMutationApi", () => {
+    test("returns handles for the root and layout children", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            vconcat: [
+                {
+                    name: "tracks",
+                    vconcat: [makeUnitSpec("trackA")],
+                },
+            ],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        const root = api.root();
+
+        expect(root.isAlive()).toBe(true);
+        expect(root.type).toBe("concat");
+        expect(root.children()).toHaveLength(1);
+        expect(root.children()[0].name).toBe("tracks");
+        expect(root.parent()).toBeUndefined();
+    });
+
+    test("resolves scoped selectors to stable handles", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            vconcat: [
+                {
+                    name: "tracks",
+                    vconcat: [makeUnitSpec("trackA")],
+                },
+            ],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        const first = api.get({ scope: [], view: "tracks" });
+        const second = api.resolve({ scope: [], view: "tracks" });
+
+        expect(second).toBe(first);
+        expect(first.selector).toEqual({ scope: [], view: "tracks" });
+        expect(first.children()[0].selector).toEqual({
+            scope: [],
+            view: "trackA",
+        });
+    });
+
+    test("treats detached handles as stale", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            layer: [makeUnitSpec("trackA")],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        const child = api.get({ scope: [], view: "trackA" });
+
+        await /** @type {import("./layerView.js").default} */ (
+            view
+        ).removeChildAt(0);
+
+        expect(child.isAlive()).toBe(false);
+        expect(api.resolve(child)).toBeUndefined();
+        expect(() => api.get(child)).toThrow(/stale/i);
+    });
+});

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import {
     createHeadlessEngine,
@@ -144,6 +144,103 @@ describe("ViewMutationApi", () => {
         expect(
             chrome.map((descendant) => descendant.getDataInitializationState())
         ).not.toContain("none");
+    });
+
+    test("waits for inserted view fonts before loading data", async () => {
+        const fontEntry = /** @type {any} */ ({
+            metrics: undefined,
+            texture: undefined,
+        });
+        /** @type {(() => void) | undefined} */
+        let resolveFont;
+        let fontRequested = false;
+        const fontReady = new Promise((resolve) => {
+            resolveFont = () => {
+                fontEntry.metrics = /** @type {any} */ ({
+                    capHeight: 8,
+                    descent: 2,
+                    common: { base: 10 },
+                    measureWidth: (
+                        /** @type {string} */ text,
+                        /** @type {number} */ size
+                    ) => text.length * size,
+                });
+                resolve();
+            };
+        });
+        const fontManager = /** @type {any} */ ({
+            getFont: vi.fn(() => {
+                fontRequested = true;
+                return fontEntry;
+            }),
+            getDefaultFont: () => ({
+                metrics: {
+                    capHeight: 8,
+                    descent: 2,
+                    common: { base: 10 },
+                    measureWidth: (
+                        /** @type {string} */ text,
+                        /** @type {number} */ size
+                    ) => text.length * size,
+                },
+            }),
+            waitUntilReady: vi.fn(() =>
+                fontRequested ? fontReady : Promise.resolve()
+            ),
+        });
+        const { view } = await createHeadlessEngine(
+            {
+                name: "tracks",
+                vconcat: [],
+            },
+            {
+                contextOptions: {
+                    fontManager,
+                },
+            }
+        );
+
+        const api = createViewMutationApi({ viewRoot: view });
+        let resolved = false;
+        const insertPromise = api
+            .insert("root", {
+                name: "summary",
+                data: { values: [{ label: "abcd" }] },
+                transform: [
+                    {
+                        type: "measureText",
+                        field: "label",
+                        font: "Roboto Condensed",
+                        fontSize: 6,
+                        as: "width",
+                    },
+                ],
+                mark: "point",
+                encoding: {
+                    x: { field: "width", type: "quantitative" },
+                },
+            })
+            .then(() => {
+                resolved = true;
+            });
+
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        if (!resolveFont) {
+            throw new Error("Expected font resolver.");
+        }
+        resolveFont();
+        await insertPromise;
+
+        const summary = view
+            .getDescendants()
+            .find((descendant) => descendant.name === "summary");
+        const datum = summary?.flowHandle?.collector
+            ? Array.from(summary.flowHandle.collector.getData())[0]
+            : undefined;
+        expect(fontManager.waitUntilReady).toHaveBeenCalled();
+        expect(datum?.width).toBe(24);
     });
 
     test("inserts a direct spec into a layer container", async () => {

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -291,6 +291,31 @@ describe("ViewMutationApi", () => {
         expect(api.root().children()).toHaveLength(0);
     });
 
+    test("rolls back partially inserted views when initialization fails", async () => {
+        const { view } = await createHeadlessEngine({
+            name: "tracks",
+            vconcat: [],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+
+        await expect(
+            api.insert("root", {
+                name: "badTrack",
+                mark: "point",
+                encoding: {
+                    x: { field: "x", type: "quantitative" },
+                },
+            })
+        ).rejects.toThrow(/data source/i);
+        expect(api.root().children()).toHaveLength(0);
+        expect(
+            /** @type {import("../spec/view.js").VConcatSpec} */ (view.spec)
+                .vconcat
+        ).toHaveLength(0);
+        expect(api.resolve({ scope: [], view: "badTrack" })).toBeUndefined();
+    });
+
     test("rejects duplicate scopes in the same scope", async () => {
         const { view } = await createHeadlessViewHierarchy({
             name: "tracks",

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -196,4 +196,58 @@ describe("ViewMutationApi", () => {
         ).rejects.toMatchObject({ code: "unsupportedChildSpec" });
         expect(api.root().children()).toHaveLength(0);
     });
+
+    test("removes a child from a concat container", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            vconcat: [makeUnitSpec("trackA"), makeUnitSpec("trackB")],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        const trackA = api.get({ scope: [], view: "trackA" });
+
+        await api.remove(trackA);
+
+        expect(trackA.isAlive()).toBe(false);
+        expect(api.resolve(trackA)).toBeUndefined();
+        expect(api.resolve({ scope: [], view: "trackA" })).toBeUndefined();
+        expect(
+            api
+                .root()
+                .children()
+                .map((child) => child.name)
+        ).toEqual(["trackB"]);
+    });
+
+    test("removes a child from a layer container", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            layer: [makeUnitSpec("trackA"), makeUnitSpec("trackB")],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+
+        await api.remove({ scope: [], view: "trackB" });
+
+        expect(
+            api
+                .root()
+                .children()
+                .map((child) => child.name)
+        ).toEqual(["trackA"]);
+    });
+
+    test("rejects removing the root view", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            vconcat: [makeUnitSpec("trackA")],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+
+        await expect(api.remove("root")).rejects.toMatchObject({
+            code: "cannotRemoveRoot",
+        });
+        expect(api.root().children()).toHaveLength(1);
+    });
 });

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -513,4 +513,39 @@ describe("ViewMutationApi", () => {
             code: "cannotMoveRoot",
         });
     });
+
+    test("defers layout reflow until the outer transaction completes", async () => {
+        const requestLayoutReflow = vi.fn();
+        const { view } = await createHeadlessEngine(
+            {
+                name: "tracks",
+                vconcat: [],
+            },
+            {
+                contextOptions: {
+                    requestLayoutReflow,
+                },
+            }
+        );
+
+        requestLayoutReflow.mockClear();
+
+        const api = createViewMutationApi({ viewRoot: view });
+        await api.transaction(async (views) => {
+            await views.insert("root", makeUnitSpec("trackA"));
+            await views.transaction(async (nestedViews) => {
+                await nestedViews.insert("root", makeUnitSpec("trackB"));
+            });
+
+            expect(requestLayoutReflow).not.toHaveBeenCalled();
+        });
+
+        expect(requestLayoutReflow).toHaveBeenCalledTimes(1);
+        expect(
+            api
+                .root()
+                .children()
+                .map((child) => child.name)
+        ).toEqual(["trackA", "trackB"]);
+    });
 });

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -5,6 +5,7 @@ import {
     createHeadlessViewHierarchy,
 } from "../genomeSpy/headlessBootstrap.js";
 import AxisView from "./axisView.js";
+import LegendView from "./legendView.js";
 import { renderToLayout } from "./testUtils.js";
 import { createViewMutationApi } from "./viewMutationApi.js";
 
@@ -120,6 +121,42 @@ function countRenderedViews(layout, viewName) {
             (count, child) => count + countRenderedViews(child, viewName),
             0
         )
+    );
+}
+
+/**
+ * @param {{ viewName: string, children: any[] }} layout
+ * @returns {{ viewName: string, coords: string, children: any[] }[]}
+ */
+function getRenderedLegendRegions(layout) {
+    return [
+        ...(layout.viewName.startsWith("legend_region_") ? [layout] : []),
+        ...layout.children.flatMap((child) => getRenderedLegendRegions(child)),
+    ];
+}
+
+/**
+ * @param {string} coords
+ * @returns {number}
+ */
+function getLayoutHeight(coords) {
+    const match = coords.match(/height: (?<height>\d+)/);
+    if (!match?.groups) {
+        throw new Error("Cannot parse layout height: " + coords);
+    }
+
+    return Number(match.groups.height);
+}
+
+/**
+ * @param {import("./view.js").default} view
+ * @returns {LegendView[]}
+ */
+function getLegends(view) {
+    return /** @type {LegendView[]} */ (
+        view
+            .getDescendants()
+            .filter((descendant) => descendant instanceof LegendView)
     );
 }
 
@@ -546,6 +583,56 @@ describe("ViewMutationApi", () => {
         expect(
             getBottomAxisSubtreeViews(tracksView).map((descendant) =>
                 descendant.getDataInitializationState()
+            )
+        ).not.toContain("none");
+    });
+
+    test("measures legends for inserted concat children", async () => {
+        const { view } = await createHeadlessEngine({
+            vconcat: [
+                {
+                    name: "tracks",
+                    spacing: 4,
+                    resolve: {
+                        axis: { x: "shared" },
+                    },
+                    vconcat: [
+                        makeSignalTrackSpec("signal", 80, "steelblue"),
+                        makeVariantsTrackSpec(),
+                    ],
+                },
+            ],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        expect(getRenderedLegendRegions(renderToLayout(view))).toHaveLength(1);
+        expect(getLegends(view)).toHaveLength(1);
+
+        await api.insert(
+            { scope: [], view: "tracks" },
+            makeVariantsTrackSpec(),
+            { scope: "variants-2" }
+        );
+
+        const renderedLegendRegions = getRenderedLegendRegions(
+            renderToLayout(view)
+        );
+        expect(renderedLegendRegions).toHaveLength(2);
+        expect(getLegends(view).map((legend) => legend.isActive())).toEqual([
+            true,
+            true,
+        ]);
+        expect(
+            renderedLegendRegions.map(({ coords }) => getLayoutHeight(coords))
+        ).not.toContain(0);
+        expect(getLegends(view)).toHaveLength(2);
+        expect(
+            getLegends(view).flatMap((legend) =>
+                legend
+                    .getDescendants()
+                    .map((descendant) =>
+                        descendant.getDataInitializationState()
+                    )
             )
         ).not.toContain("none");
     });

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -637,6 +637,35 @@ describe("ViewMutationApi", () => {
         ).not.toContain("none");
     });
 
+    test("creates shared concat legends introduced by an inserted child", async () => {
+        const { view } = await createHeadlessEngine({
+            vconcat: [
+                {
+                    name: "tracks",
+                    spacing: 4,
+                    resolve: {
+                        axis: { x: "shared" },
+                        scale: { color: "shared" },
+                        legend: { color: "shared" },
+                    },
+                    vconcat: [makeSignalTrackSpec("signal", 80, "steelblue")],
+                },
+            ],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        expect(getLegends(view)).toHaveLength(0);
+
+        await api.insert(
+            { scope: [], view: "tracks" },
+            makeVariantsTrackSpec(),
+            { scope: "variants-1" }
+        );
+
+        expect(getLegends(view)).toHaveLength(1);
+        expect(getRenderedLegendRegions(renderToLayout(view))).toHaveLength(1);
+    });
+
     test("removes a child from a layer container", async () => {
         const { view } = await createHeadlessViewHierarchy({
             name: "tracks",

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -125,7 +125,7 @@ function countRenderedViews(layout, viewName) {
 }
 
 /**
- * @param {{ viewName: string, children: any[] }} layout
+ * @param {{ viewName: string, coords: string, children: any[] }} layout
  * @returns {{ viewName: string, coords: string, children: any[] }[]}
  */
 function getRenderedLegendRegions(layout) {
@@ -789,6 +789,73 @@ describe("ViewMutationApi", () => {
         await expect(api.move("root", { index: 0 })).rejects.toMatchObject({
             code: "cannotMoveRoot",
         });
+    });
+
+    test("returns layout bounds for addressed views after rendering", async () => {
+        const { view } = await createHeadlessEngine({
+            name: "tracks",
+            vconcat: [
+                makeSignalTrackSpec("signal", 80, "steelblue"),
+                makeVariantsTrackSpec(),
+            ],
+        });
+        const api = createViewMutationApi({ viewRoot: view });
+
+        expect(
+            api.getLayoutBounds({ scope: [], view: "signal" })
+        ).toBeUndefined();
+
+        renderToLayout(view);
+
+        expect(api.getLayoutBounds({ scope: [], view: "signal" })).toEqual({
+            x: expect.any(Number),
+            y: expect.any(Number),
+            width: expect.any(Number),
+            height: 80,
+        });
+    });
+
+    test("subscribes to layout updates", async () => {
+        /** @type {Map<import("../genomeSpy.js").BroadcastEventType, Set<(message: import("./view.js").BroadcastMessage) => void>>} */
+        const listeners = new Map();
+        /** @type {(type: import("../genomeSpy.js").BroadcastEventType, listener: (message: import("./view.js").BroadcastMessage) => void) => void} */
+        const addBroadcastListener = (type, listener) => {
+            const typeListeners = listeners.get(type) ?? new Set();
+            typeListeners.add(listener);
+            listeners.set(type, typeListeners);
+        };
+        /** @type {(type: import("../genomeSpy.js").BroadcastEventType, listener: (message: import("./view.js").BroadcastMessage) => void) => void} */
+        const removeBroadcastListener = (type, listener) => {
+            listeners.get(type)?.delete(listener);
+        };
+        const emit = (
+            /** @type {import("../genomeSpy.js").BroadcastEventType} */ type
+        ) => {
+            for (const listener of listeners.get(type) ?? []) {
+                listener({ type });
+            }
+        };
+        const { view } = await createHeadlessEngine(
+            {
+                name: "tracks",
+                vconcat: [makeUnitSpec("trackA")],
+            },
+            {
+                contextOptions: {
+                    addBroadcastListener,
+                    removeBroadcastListener,
+                },
+            }
+        );
+        const api = createViewMutationApi({ viewRoot: view });
+        const listener = vi.fn();
+
+        const unsubscribe = api.subscribeToLayout(listener);
+        emit("layoutComputed");
+        unsubscribe();
+        emit("layoutComputed");
+
+        expect(listener).toHaveBeenCalledTimes(1);
     });
 
     test("defers layout reflow until the outer transaction completes", async () => {

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -250,4 +250,97 @@ describe("ViewMutationApi", () => {
         });
         expect(api.root().children()).toHaveLength(1);
     });
+
+    test("moves a concat child within its current parent", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            vconcat: [
+                makeUnitSpec("trackA"),
+                makeUnitSpec("trackB"),
+                makeUnitSpec("trackC"),
+            ],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        const trackB = api.get({ scope: [], view: "trackB" });
+        const moved = await api.move(trackB, { index: 2 });
+
+        expect(moved).toBe(trackB);
+        expect(trackB.isAlive()).toBe(true);
+        expect(
+            api
+                .root()
+                .children()
+                .map((child) => child.name)
+        ).toEqual(["trackA", "trackC", "trackB"]);
+        const spec = /** @type {import("../spec/view.js").VConcatSpec} */ (
+            view.spec
+        );
+        expect(spec.vconcat.map((childSpec) => childSpec.name)).toEqual([
+            "trackA",
+            "trackC",
+            "trackB",
+        ]);
+    });
+
+    test("moves a layer child within its current parent", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            layer: [
+                makeUnitSpec("trackA"),
+                makeUnitSpec("trackB"),
+                makeUnitSpec("trackC"),
+            ],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        await api.move({ scope: [], view: "trackC" }, { index: 0 });
+
+        expect(
+            api
+                .root()
+                .children()
+                .map((child) => child.name)
+        ).toEqual(["trackC", "trackA", "trackB"]);
+        const spec = /** @type {import("../spec/view.js").LayerSpec} */ (
+            view.spec
+        );
+        expect(spec.layer.map((childSpec) => childSpec.name)).toEqual([
+            "trackC",
+            "trackA",
+            "trackB",
+        ]);
+    });
+
+    test("rejects invalid move indexes without mutating the container", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            vconcat: [makeUnitSpec("trackA"), makeUnitSpec("trackB")],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+
+        await expect(
+            api.move({ scope: [], view: "trackA" }, { index: 2 })
+        ).rejects.toMatchObject({ code: "invalidIndex" });
+        expect(
+            api
+                .root()
+                .children()
+                .map((child) => child.name)
+        ).toEqual(["trackA", "trackB"]);
+    });
+
+    test("rejects moving the root view", async () => {
+        const { view } = await createHeadlessViewHierarchy({
+            name: "tracks",
+            vconcat: [makeUnitSpec("trackA")],
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+
+        await expect(api.move("root", { index: 0 })).rejects.toMatchObject({
+            code: "cannotMoveRoot",
+        });
+    });
 });

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -4,6 +4,8 @@ import {
     createHeadlessEngine,
     createHeadlessViewHierarchy,
 } from "../genomeSpy/headlessBootstrap.js";
+import AxisView from "./axisView.js";
+import { renderToLayout } from "./testUtils.js";
 import { createViewMutationApi } from "./viewMutationApi.js";
 
 /**
@@ -22,6 +24,103 @@ function makeUnitSpec(name) {
             y: { field: "y", type: "quantitative" },
         },
     };
+}
+
+/**
+ * @param {string} name
+ * @param {number} height
+ * @param {string} color
+ * @returns {import("../spec/view.js").UnitSpec}
+ */
+function makeSignalTrackSpec(name, height, color) {
+    return {
+        name,
+        height,
+        data: {
+            values: [
+                { pos: 0, value: 0.2 },
+                { pos: 1, value: 0.8 },
+                { pos: 2, value: 0.4 },
+                { pos: 3, value: 0.9 },
+            ],
+        },
+        mark: "rect",
+        encoding: {
+            x: { field: "pos", type: "index" },
+            y: { field: "value", type: "quantitative" },
+            color: { value: color },
+        },
+    };
+}
+
+/**
+ * @returns {import("../spec/view.js").UnitSpec}
+ */
+function makeVariantsTrackSpec() {
+    return {
+        name: "variants",
+        height: 30,
+        data: {
+            values: [
+                { pos: 0.5, type: "SNV" },
+                { pos: 1.5, type: "DEL" },
+                { pos: 2.5, type: "SNV" },
+            ],
+        },
+        mark: { type: "point", size: 140 },
+        encoding: {
+            x: { field: "pos", type: "index" },
+            color: { field: "type", type: "nominal" },
+        },
+    };
+}
+
+/**
+ * @param {import("./view.js").default} view
+ * @returns {number}
+ */
+function countBottomAxes(view) {
+    return view
+        .getDescendants()
+        .filter(
+            (descendant) =>
+                descendant instanceof AxisView &&
+                descendant.axisProps.orient === "bottom"
+        ).length;
+}
+
+/**
+ * @param {import("./view.js").default} view
+ * @returns {import("./view.js").default[]}
+ */
+function getBottomAxisSubtreeViews(view) {
+    const bottomAxis = view
+        .getDescendants()
+        .find(
+            (descendant) =>
+                descendant instanceof AxisView &&
+                descendant.axisProps.orient === "bottom"
+        );
+    if (!bottomAxis) {
+        return [];
+    }
+
+    return bottomAxis.getDescendants();
+}
+
+/**
+ * @param {{ viewName: string, children: any[] }} layout
+ * @param {string} viewName
+ * @returns {number}
+ */
+function countRenderedViews(layout, viewName) {
+    return (
+        (layout.viewName === viewName ? 1 : 0) +
+        layout.children.reduce(
+            (count, child) => count + countRenderedViews(child, viewName),
+            0
+        )
+    );
 }
 
 describe("ViewMutationApi", () => {
@@ -387,6 +486,68 @@ describe("ViewMutationApi", () => {
                 .children()
                 .map((child) => child.name)
         ).toEqual(["trackB"]);
+    });
+
+    test("keeps shared concat axes after removing an inserted child", async () => {
+        const { view } = await createHeadlessEngine({
+            vconcat: [
+                {
+                    name: "tracks",
+                    spacing: 4,
+                    resolve: {
+                        axis: { x: "shared" },
+                    },
+                    vconcat: [
+                        makeSignalTrackSpec("signal", 80, "steelblue"),
+                        makeVariantsTrackSpec(),
+                    ],
+                },
+            ],
+            config: {
+                view: {
+                    stroke: "lightgray",
+                },
+            },
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        const tracksView = view
+            .getDescendants()
+            .find((descendant) => descendant.name === "tracks");
+        if (!tracksView) {
+            throw new Error("Expected tracks view.");
+        }
+
+        expect(countBottomAxes(tracksView)).toBe(1);
+        expect(countRenderedViews(renderToLayout(view), "axis_bottom")).toBe(1);
+        expect(
+            getBottomAxisSubtreeViews(tracksView).map((descendant) =>
+                descendant.getDataInitializationState()
+            )
+        ).not.toContain("none");
+
+        const inserted = await api.insert(
+            { scope: [], view: "tracks" },
+            makeSignalTrackSpec("summary", 50, "seagreen"),
+            { scope: "summary-1" }
+        );
+        expect(countBottomAxes(tracksView)).toBe(1);
+        expect(countRenderedViews(renderToLayout(view), "axis_bottom")).toBe(1);
+        expect(
+            getBottomAxisSubtreeViews(tracksView).map((descendant) =>
+                descendant.getDataInitializationState()
+            )
+        ).not.toContain("none");
+
+        await api.remove(inserted);
+
+        expect(countBottomAxes(tracksView)).toBe(1);
+        expect(countRenderedViews(renderToLayout(view), "axis_bottom")).toBe(1);
+        expect(
+            getBottomAxisSubtreeViews(tracksView).map((descendant) =>
+                descendant.getDataInitializationState()
+            )
+        ).not.toContain("none");
     });
 
     test("removes a child from a layer container", async () => {

--- a/packages/core/src/view/viewMutationApi.test.js
+++ b/packages/core/src/view/viewMutationApi.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 
-import { createHeadlessViewHierarchy } from "../genomeSpy/headlessBootstrap.js";
+import {
+    createHeadlessEngine,
+    createHeadlessViewHierarchy,
+} from "../genomeSpy/headlessBootstrap.js";
 import { createViewMutationApi } from "./viewMutationApi.js";
 
 /**
@@ -96,6 +99,51 @@ describe("ViewMutationApi", () => {
         expect(api.root().children()).toEqual([inserted]);
         expect(api.get({ scope: [], view: "trackA" })).toBe(inserted);
         expect(/** @type {any} */ (view).spec.vconcat[0]).not.toBe(childSpec);
+    });
+
+    test("initializes chrome views for dynamically inserted concat children", async () => {
+        const { view } = await createHeadlessEngine({
+            vconcat: [
+                {
+                    name: "tracks",
+                    vconcat: [],
+                },
+            ],
+            config: {
+                view: {
+                    stroke: "lightgray",
+                },
+            },
+        });
+
+        const api = createViewMutationApi({ viewRoot: view });
+        await api.insert(
+            { scope: [], view: "tracks" },
+            {
+                ...makeUnitSpec("summary"),
+                title: "Summary track",
+            }
+        );
+
+        const summary = view
+            .getDescendants()
+            .find((descendant) => descendant.name === "summary");
+        const chrome = view
+            .getDescendants()
+            .filter(
+                (descendant) =>
+                    descendant !== summary && descendant.dataParent === summary
+            );
+        expect(chrome.map((descendant) => descendant.name)).toEqual(
+            expect.arrayContaining([
+                expect.stringMatching(/^axis_/),
+                expect.stringMatching(/^backgroundStroke/),
+                expect.stringMatching(/^title/),
+            ])
+        );
+        expect(
+            chrome.map((descendant) => descendant.getDataInitializationState())
+        ).not.toContain("none");
     });
 
     test("inserts a direct spec into a layer container", async () => {

--- a/packages/core/src/view/viewSelectors.js
+++ b/packages/core/src/view/viewSelectors.js
@@ -43,8 +43,30 @@ const chromeOverrides = new WeakMap();
  * @param {string | null} scopeName
  */
 export function registerImportInstance(view, scopeName) {
+    registerScope(view, scopeName, "Import");
+}
+
+/**
+ * Marks a view as the root of a named selector scope.
+ *
+ * Import instances and dynamically inserted views share the same selector scope
+ * model, even though imports were the original use case.
+ *
+ * @param {import("./view.js").default} view
+ * @param {string | null} scopeName
+ */
+export function registerViewScope(view, scopeName) {
+    registerScope(view, scopeName, "View");
+}
+
+/**
+ * @param {import("./view.js").default} view
+ * @param {string | null} scopeName
+ * @param {string} scopeKind
+ */
+function registerScope(view, scopeName, scopeKind) {
     if (scopeName !== null && typeof scopeName !== "string") {
-        throw new Error("Import scope name must be a string or null.");
+        throw new Error(scopeKind + " scope name must be a string or null.");
     }
 
     importScopes.set(view, { name: scopeName });

--- a/packages/embed-examples/src/index.html
+++ b/packages/embed-examples/src/index.html
@@ -25,6 +25,9 @@
                 >
             </li>
             <li>
+                <a href="viewMutationApi.html">View mutation API</a>
+            </li>
+            <li>
                 <a href="dynamicNamedData.html"
                     >Dynamically updated named data</a
                 >

--- a/packages/embed-examples/src/viewMutationApi.html
+++ b/packages/embed-examples/src/viewMutationApi.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <link rel="stylesheet" href="style.scss" />
+        <title>View Mutation API</title>
+    </head>
+
+    <body>
+        <h1>View Mutation API</h1>
+        <div id="container"></div>
+        <div id="dashboard"></div>
+        <script type="module" src="/viewMutationApi.js"></script>
+    </body>
+</html>

--- a/packages/embed-examples/src/viewMutationApi.html
+++ b/packages/embed-examples/src/viewMutationApi.html
@@ -1,15 +1,38 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <link rel="stylesheet" href="style.scss" />
-        <title>View Mutation API</title>
-    </head>
 
-    <body>
-        <h1>View Mutation API</h1>
+<head>
+    <meta charset="UTF-8" />
+    <title>View Mutation API</title>
+    <style>
+        #view-mutation-stage {
+            position: relative;
+        }
+
+        #track-controls {
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+        }
+
+        .track-controls {
+            position: absolute;
+            display: flex;
+            gap: 4px;
+            pointer-events: auto;
+            transform: translateX(-100%);
+        }
+    </style>
+</head>
+
+<body>
+    <h1>View Mutation API</h1>
+    <div id="dashboard"></div>
+    <div id="view-mutation-stage">
         <div id="container"></div>
-        <div id="dashboard"></div>
-        <script type="module" src="/viewMutationApi.js"></script>
-    </body>
+        <div id="track-controls"></div>
+    </div>
+    <script type="module" src="/viewMutationApi.js"></script>
+</body>
+
 </html>

--- a/packages/embed-examples/src/viewMutationApi.js
+++ b/packages/embed-examples/src/viewMutationApi.js
@@ -1,75 +1,11 @@
 import { embed } from "@genome-spy/core/minimal";
 import { html, render } from "lit";
 
-/** @type {import("@genome-spy/core/spec/view.js").UnitSpec} */
-const signalTrack = {
-    name: "signal",
-    title: "Signal track",
-    height: 80,
-    data: {
-        values: [
-            { pos: 0, value: 0.2 },
-            { pos: 1, value: 0.8 },
-            { pos: 2, value: 0.4 },
-            { pos: 3, value: 0.9 },
-        ],
-    },
-    mark: "rect",
-    encoding: {
-        x: {
-            field: "pos",
-            type: "index",
-        },
-        y: { field: "value", type: "quantitative" },
-        color: { value: "steelblue" },
-    },
-};
+const container = document.getElementById("container");
+const dashboard = document.getElementById("dashboard");
+const trackCounts = { signal: 0, variants: 0 };
 
-/** @type {import("@genome-spy/core/spec/view.js").UnitSpec} */
-const summaryTrack = {
-    name: "summary",
-    height: 50,
-    title: "Summary track",
-    data: {
-        values: [
-            { pos: 0, value: 0.35 },
-            { pos: 1, value: 0.7 },
-            { pos: 2, value: 0.5 },
-            { pos: 3, value: 0.65 },
-        ],
-    },
-    mark: "rect",
-    encoding: {
-        x: {
-            field: "pos",
-            type: "index",
-        },
-        y: { field: "value", type: "quantitative" },
-        color: { value: "seagreen" },
-    },
-};
-
-/** @type {import("@genome-spy/core/spec/view.js").UnitSpec} */
-const variantsTrack = {
-    name: "variants",
-    title: "Variants track",
-    height: 30,
-    data: {
-        values: [
-            { pos: 0.5, type: "SNV" },
-            { pos: 1.5, type: "DEL" },
-            { pos: 2.5, type: "SNV" },
-        ],
-    },
-    mark: { type: "point", size: 140 },
-    encoding: {
-        x: {
-            field: "pos",
-            type: "index",
-        },
-        color: { field: "type", type: "nominal" },
-    },
-};
+const initialTrackSpecs = [createSignalTrack(), createVariantsTrack()];
 
 /** @type {import("@genome-spy/core/spec/root.js").RootSpec} */
 const spec = {
@@ -77,7 +13,8 @@ const spec = {
         {
             name: "tracks",
             spacing: 4,
-            vconcat: [signalTrack, variantsTrack],
+            resolve: { axis: { x: "shared" } },
+            vconcat: initialTrackSpecs,
         },
     ],
 
@@ -88,186 +25,181 @@ const spec = {
     },
 };
 
-const container = document.getElementById("container");
-const dashboard = document.getElementById("dashboard");
-
 const api = await embed(container, spec);
+const tracksContainer = api.views.get({ scope: [], view: "tracks" });
 
-const root = api.views.root();
-const tracks = api.views.get({ scope: [], view: "tracks" });
-const signal = api.views.get({ scope: [], view: "signal" });
+/** @type {TrackItem[]} */
+const tracks = initialTrackSpecs.map((spec) => ({
+    title: /** @type {string} */ (spec.title),
+    handle: api.views.get({
+        scope: [],
+        view: /** @type {string} */ (spec.name),
+    }),
+}));
 
-/** @type {{ scope: string, handle: import("@genome-spy/core/types/embedApi.js").ViewHandle }[]} */
-const insertedSummaries = [];
-
-let nextSummaryIndex = 1;
 let status = "Ready";
-
-updateDashboard();
-
-async function insertSummaryTrack() {
-    const scope = "summary-" + nextSummaryIndex;
-
-    try {
-        const handle = await api.views.insert(tracks, summaryTrack, {
-            scope,
-        });
-        insertedSummaries.push({ scope, handle });
-        nextSummaryIndex++;
-        status = "Inserted " + scope;
-    } catch (error) {
-        status =
-            error instanceof Error ? error.message : "Summary insert failed";
-    }
-
-    updateDashboard();
-}
+updateControls();
 
 /**
- * @param {{ scope: string, handle: import("@genome-spy/core/types/embedApi.js").ViewHandle }} summary
+ * @typedef {{
+ *   title: string,
+ *   handle: import("@genome-spy/core/types/embedApi.js").ViewHandle,
+ *   scope?: string
+ * }} TrackItem
  */
-async function removeSummaryTrack(summary) {
-    try {
-        await api.views.remove(summary.handle);
-        status = "Removed " + summary.scope;
-    } catch (error) {
-        status =
-            error instanceof Error ? error.message : "Summary removal failed";
-    }
 
-    updateDashboard();
+/**
+ * @returns {import("@genome-spy/core/spec/view.js").UnitSpec}
+ */
+function createSignalTrack() {
+    const number = ++trackCounts.signal;
+
+    return {
+        name: "signal",
+        title: "Signal track " + number,
+        height: 80,
+        data: {
+            values: Array.from({ length: 64 }, (_, pos) => ({
+                pos,
+                value: Math.random(),
+            })),
+        },
+        mark: "rect",
+        encoding: {
+            x: { field: "pos", type: "index" },
+            y: { field: "value", type: "quantitative" },
+            color: { value: "steelblue" },
+        },
+    };
 }
 
 /**
- * @param {{ scope: string, handle: import("@genome-spy/core/types/embedApi.js").ViewHandle }} summary
+ * @returns {import("@genome-spy/core/spec/view.js").UnitSpec}
+ */
+function createVariantsTrack() {
+    const number = ++trackCounts.variants;
+    const variantTypes = ["SNV", "DEL", "DUP"];
+
+    return {
+        name: "variants",
+        title: "Variants track " + number,
+        height: 36,
+        data: {
+            values: Array.from({ length: 12 }, () => ({
+                pos: Math.random() * 63,
+                type: variantTypes[
+                    Math.floor(Math.random() * variantTypes.length)
+                ],
+            })).sort((a, b) => a.pos - b.pos),
+        },
+        mark: { type: "point", size: 120 },
+        encoding: {
+            x: { field: "pos", type: "index" },
+            color: { field: "type", type: "nominal" },
+        },
+    };
+}
+
+/**
+ * @param {"signal" | "variants"} type
+ * @returns {Promise<void>}
+ */
+async function addTrack(type) {
+    const spec =
+        type === "signal" ? createSignalTrack() : createVariantsTrack();
+    const title = /** @type {string} */ (spec.title);
+    const scope = type + "-" + trackCounts[type];
+
+    try {
+        // Scope lets this ordinary spec be inserted repeatedly while remaining
+        // addressable by selectors such as { scope: ["signal-2"], view: "signal" }.
+        const handle = await api.views.insert(tracksContainer, spec, { scope });
+        tracks.push({ title, handle, scope });
+        status = "Added " + title;
+    } catch (error) {
+        status = error instanceof Error ? error.message : "Track insert failed";
+    }
+
+    updateControls();
+}
+
+/**
+ * @param {TrackItem} track
+ * @returns {Promise<void>}
+ */
+async function removeTrack(track) {
+    try {
+        await api.views.remove(track.handle);
+        tracks.splice(tracks.indexOf(track), 1);
+        status = "Removed " + track.title;
+    } catch (error) {
+        status =
+            error instanceof Error ? error.message : "Track removal failed";
+    }
+
+    updateControls();
+}
+
+/**
+ * @param {TrackItem} track
  * @param {number} offset
+ * @returns {Promise<void>}
  */
-async function moveSummaryTrack(summary, offset) {
+async function moveTrack(track, offset) {
+    const from = tracks.indexOf(track);
+    const to = from + offset;
+
     try {
-        const currentIndex = getTrackIndex(summary.handle);
-        await api.views.move(summary.handle, {
-            index: currentIndex + offset,
-        });
-        status = "Moved " + summary.scope;
+        // The destination index uses the order after the target has been removed.
+        await api.views.move(track.handle, { index: to });
+        tracks.splice(from, 1);
+        tracks.splice(to, 0, track);
+        status = "Moved " + track.title;
     } catch (error) {
-        status = error instanceof Error ? error.message : "Summary move failed";
+        status = error instanceof Error ? error.message : "Track move failed";
     }
 
-    updateDashboard();
+    updateControls();
 }
 
-function updateDashboard() {
+/**
+ * @returns {void}
+ */
+function updateControls() {
     render(
         html`
             <p>
-                <button @click=${updateDashboard}>Refresh handles</button>
-                <button @click=${insertSummaryTrack}>
-                    Insert summary track
+                <button @click=${() => addTrack("signal")}>Add signal</button>
+                <button @click=${() => addTrack("variants")}>
+                    Add variants
                 </button>
             </p>
             <p>Status: ${status}</p>
-            <dl>
-                <dt>Root</dt>
-                <dd><code>${JSON.stringify(summarizeHandle(root))}</code></dd>
-
-                <dt>Tracks</dt>
-                <dd><code>${JSON.stringify(summarizeHandle(tracks))}</code></dd>
-
-                <dt>Signal</dt>
-                <dd><code>${JSON.stringify(summarizeHandle(signal))}</code></dd>
-
-                <dt>Inserted summaries</dt>
-                <dd>
-                    ${insertedSummaries.map(
-                        (summary) => html`
-                            <p>
-                                <button
-                                    ?disabled=${!canMoveTrack(
-                                        summary.handle,
-                                        -1
-                                    )}
-                                    @click=${() =>
-                                        moveSummaryTrack(summary, -1)}
-                                >
-                                    Up
-                                </button>
-                                <button
-                                    ?disabled=${!canMoveTrack(
-                                        summary.handle,
-                                        1
-                                    )}
-                                    @click=${() => moveSummaryTrack(summary, 1)}
-                                >
-                                    Down
-                                </button>
-                                <button
-                                    ?disabled=${!summary.handle.isAlive()}
-                                    @click=${() => removeSummaryTrack(summary)}
-                                >
-                                    Remove ${summary.scope}
-                                </button>
-                                <code
-                                    >${JSON.stringify(
-                                        summarizeInsertedSummary(summary)
-                                    )}</code
-                                >
-                            </p>
-                        `
-                    )}
-                </dd>
-            </dl>
+            <ol>
+                ${tracks.map(
+                    (track, index) => html`
+                        <li>
+                            ${track.title}
+                            <button
+                                ?disabled=${index === 0}
+                                @click=${() => moveTrack(track, -1)}
+                            >
+                                Up
+                            </button>
+                            <button
+                                ?disabled=${index === tracks.length - 1}
+                                @click=${() => moveTrack(track, 1)}
+                            >
+                                Down
+                            </button>
+                            <button @click=${() => removeTrack(track)}>
+                                Remove
+                            </button>
+                        </li>
+                    `
+                )}
+            </ol>
         `,
         dashboard
     );
-}
-
-/**
- * @param {import("@genome-spy/core/types/embedApi.js").ViewHandle} handle
- */
-function getTrackIndex(handle) {
-    return tracks.children().indexOf(handle);
-}
-
-/**
- * @param {import("@genome-spy/core/types/embedApi.js").ViewHandle} handle
- * @param {number} offset
- */
-function canMoveTrack(handle, offset) {
-    const currentIndex = getTrackIndex(handle);
-    const destinationIndex = currentIndex + offset;
-    return (
-        currentIndex >= 0 &&
-        destinationIndex >= 0 &&
-        destinationIndex <= tracks.children().length - 1
-    );
-}
-
-/**
- * @param {import("@genome-spy/core/types/embedApi.js").ViewHandle} handle
- */
-function summarizeHandle(handle) {
-    return {
-        id: handle.id,
-        name: handle.name,
-        selector: handle.selector,
-        type: handle.type,
-        alive: handle.isAlive(),
-        parent: handle.parent()?.name,
-        children: handle.children().map((child) => child.name ?? child.id),
-    };
-}
-
-/**
- * @param {{ scope: string, handle: import("@genome-spy/core/types/embedApi.js").ViewHandle }} summary
- */
-function summarizeInsertedSummary(summary) {
-    const selector = summary.handle.isAlive()
-        ? api.views.get({ scope: [summary.scope], view: "summary" }).selector
-        : undefined;
-
-    return {
-        scope: summary.scope,
-        handle: summarizeHandle(summary.handle),
-        scopedSelector: selector,
-    };
 }

--- a/packages/embed-examples/src/viewMutationApi.js
+++ b/packages/embed-examples/src/viewMutationApi.js
@@ -26,6 +26,30 @@ const signalTrack = {
 };
 
 /** @type {import("@genome-spy/core/spec/view.js").UnitSpec} */
+const summaryTrack = {
+    name: "summary",
+    height: 50,
+    data: {
+        values: [
+            { pos: 0, value: 0.35 },
+            { pos: 1, value: 0.7 },
+            { pos: 2, value: 0.5 },
+            { pos: 3, value: 0.65 },
+        ],
+    },
+    mark: "bar",
+    encoding: {
+        x: {
+            field: "pos",
+            type: "index",
+            scale: { name: "position" },
+        },
+        y: { field: "value", type: "quantitative" },
+        color: { value: "seagreen" },
+    },
+};
+
+/** @type {import("@genome-spy/core/spec/view.js").UnitSpec} */
 const variantsTrack = {
     name: "variants",
     height: 60,
@@ -68,14 +92,42 @@ const root = api.views.root();
 const tracks = api.views.get({ scope: [], view: "tracks" });
 const signal = api.views.get({ scope: [], view: "signal" });
 
+/** @type {{ scope: string, handle: import("@genome-spy/core/types/embedApi.js").ViewHandle }[]} */
+const insertedSummaries = [];
+
+let nextSummaryIndex = 1;
+let status = "Ready";
+
 updateDashboard();
+
+async function insertSummaryTrack() {
+    const scope = "summary-" + nextSummaryIndex;
+
+    try {
+        const handle = await api.views.insert(tracks, summaryTrack, {
+            scope,
+        });
+        insertedSummaries.push({ scope, handle });
+        nextSummaryIndex++;
+        status = "Inserted " + scope;
+    } catch (error) {
+        status =
+            error instanceof Error ? error.message : "Summary insert failed";
+    }
+
+    updateDashboard();
+}
 
 function updateDashboard() {
     render(
         html`
             <p>
                 <button @click=${updateDashboard}>Refresh handles</button>
+                <button @click=${insertSummaryTrack}>
+                    Insert summary track
+                </button>
             </p>
+            <p>Status: ${status}</p>
             <dl>
                 <dt>Root</dt>
                 <dd><code>${JSON.stringify(summarizeHandle(root))}</code></dd>
@@ -85,6 +137,22 @@ function updateDashboard() {
 
                 <dt>Signal</dt>
                 <dd><code>${JSON.stringify(summarizeHandle(signal))}</code></dd>
+
+                <dt>Inserted summaries</dt>
+                <dd>
+                    <code
+                        >${JSON.stringify(
+                            insertedSummaries.map(({ scope, handle }) => ({
+                                scope,
+                                handle: summarizeHandle(handle),
+                                scopedSelector: api.views.get({
+                                    scope: [scope],
+                                    view: "summary",
+                                }).selector,
+                            }))
+                        )}</code
+                    >
+                </dd>
             </dl>
         `,
         dashboard

--- a/packages/embed-examples/src/viewMutationApi.js
+++ b/packages/embed-examples/src/viewMutationApi.js
@@ -118,6 +118,21 @@ async function insertSummaryTrack() {
     updateDashboard();
 }
 
+/**
+ * @param {{ scope: string, handle: import("@genome-spy/core/types/embedApi.js").ViewHandle }} summary
+ */
+async function removeSummaryTrack(summary) {
+    try {
+        await api.views.remove(summary.handle);
+        status = "Removed " + summary.scope;
+    } catch (error) {
+        status =
+            error instanceof Error ? error.message : "Summary removal failed";
+    }
+
+    updateDashboard();
+}
+
 function updateDashboard() {
     render(
         html`
@@ -140,18 +155,23 @@ function updateDashboard() {
 
                 <dt>Inserted summaries</dt>
                 <dd>
-                    <code
-                        >${JSON.stringify(
-                            insertedSummaries.map(({ scope, handle }) => ({
-                                scope,
-                                handle: summarizeHandle(handle),
-                                scopedSelector: api.views.get({
-                                    scope: [scope],
-                                    view: "summary",
-                                }).selector,
-                            }))
-                        )}</code
-                    >
+                    ${insertedSummaries.map(
+                        (summary) => html`
+                            <p>
+                                <button
+                                    ?disabled=${!summary.handle.isAlive()}
+                                    @click=${() => removeSummaryTrack(summary)}
+                                >
+                                    Remove ${summary.scope}
+                                </button>
+                                <code
+                                    >${JSON.stringify(
+                                        summarizeInsertedSummary(summary)
+                                    )}</code
+                                >
+                            </p>
+                        `
+                    )}
                 </dd>
             </dl>
         `,
@@ -171,5 +191,20 @@ function summarizeHandle(handle) {
         alive: handle.isAlive(),
         parent: handle.parent()?.name,
         children: handle.children().map((child) => child.name ?? child.id),
+    };
+}
+
+/**
+ * @param {{ scope: string, handle: import("@genome-spy/core/types/embedApi.js").ViewHandle }} summary
+ */
+function summarizeInsertedSummary(summary) {
+    const selector = summary.handle.isAlive()
+        ? api.views.get({ scope: [summary.scope], view: "summary" }).selector
+        : undefined;
+
+    return {
+        scope: summary.scope,
+        handle: summarizeHandle(summary.handle),
+        scopedSelector: selector,
     };
 }

--- a/packages/embed-examples/src/viewMutationApi.js
+++ b/packages/embed-examples/src/viewMutationApi.js
@@ -1,6 +1,19 @@
 import { embed } from "@genome-spy/core/minimal";
 import { html, render } from "lit";
 
+/*
+ * This example demonstrates the public view hierarchy API from an embedding
+ * application. It starts with a small genome-browser-like stack of tracks and
+ * lets the user add, remove, and reorder tracks without rebuilding the whole
+ * GenomeSpy instance.
+ *
+ * The key API pieces are:
+ * - named container lookup with api.views.get(...)
+ * - repeated insertion of ordinary specs using explicit scopes
+ * - stable ViewHandle objects for later move/remove operations
+ * - layout bounds and layout subscriptions for positioning external controls
+ */
+
 const container = document.getElementById("container");
 const dashboard = document.getElementById("dashboard");
 const trackControls = document.getElementById("track-controls");
@@ -12,9 +25,14 @@ const initialTrackSpecs = [createSignalTrack(), createVariantsTrack()];
 const spec = {
     vconcat: [
         {
+            // The mutable part of the visualization is a normal vconcat view.
+            // Its name gives the embedding code a stable address for inserting
+            // and reordering child tracks.
             name: "tracks",
             spacing: 5,
             resolve: {
+                // Shared x axes and color legends continue to work when tracks
+                // are inserted, removed, or reordered dynamically.
                 axis: { x: "shared" },
                 scale: { color: "shared" },
                 legend: { color: "shared" },
@@ -37,11 +55,18 @@ const spec = {
 };
 
 const api = await embed(container, spec);
+
+// Resolve the container once and keep the handle. Handles remain valid while
+// their views are live, even if sibling tracks are inserted or reordered.
 const tracksContainer = api.views.get({ scope: [], view: "tracks" });
 
 /** @type {TrackItem[]} */
+// Local UI model for the external controls. GenomeSpy state lives in the view
+// hierarchy; this array just mirrors successful hierarchy mutations.
 const tracks = initialTrackSpecs.map((spec) => ({
     title: getTitleText(spec.title),
+    // Initial views were not inserted with extra scopes, so they live in the
+    // root selector scope and are addressable directly by their spec names.
     handle: api.views.get({
         scope: [],
         view: /** @type {string} */ (spec.name),
@@ -49,14 +74,16 @@ const tracks = initialTrackSpecs.map((spec) => ({
 }));
 
 let status = "Ready";
+
+// Layout changes after data loading, mutations, and resizes. The subscription
+// keeps the external overlay controls aligned with the rendered tracks.
 api.views.subscribeToLayout(updateControls);
 updateControls();
 
 /**
  * @typedef {{
  *   title: string,
- *   handle: import("@genome-spy/core/types/embedApi.js").ViewHandle,
- *   scope?: string
+ *   handle: import("@genome-spy/core/types/embedApi.js").ViewHandle
  * }} TrackItem
  */
 
@@ -82,10 +109,7 @@ function createSignalTrack() {
         title: { text: "Signal track " + number, style: "overlay-title" },
         height: 80,
         data: {
-            values: Array.from({ length: 64 }, (_, pos) => ({
-                pos,
-                value: Math.random(),
-            })),
+            values: createSignalValues(),
         },
         mark: "rect",
         encoding: {
@@ -101,19 +125,13 @@ function createSignalTrack() {
  */
 function createVariantsTrack() {
     const number = ++trackCounts.variants;
-    const variantTypes = ["SNV", "DEL", "DUP"];
 
     return {
         name: "variants",
         title: { text: "Variants track " + number, style: "overlay-title" },
         height: 36,
         data: {
-            values: Array.from({ length: 12 }, () => ({
-                pos: Math.random() * 63,
-                type: variantTypes[
-                    Math.floor(Math.random() * variantTypes.length)
-                ],
-            })).sort((a, b) => a.pos - b.pos),
+            values: createVariantValues(),
         },
         mark: { type: "point", size: 120 },
         encoding: {
@@ -134,10 +152,11 @@ async function addTrack(type) {
     const scope = type + "-" + trackCounts[type];
 
     try {
-        // Scope lets this ordinary spec be inserted repeatedly while remaining
-        // addressable by selectors such as { scope: ["signal-2"], view: "signal" }.
+        // Scope lets the same ordinary spec shape be inserted repeatedly while
+        // remaining addressable by selectors such as
+        // { scope: ["signal-2"], view: "signal" }.
         const handle = await api.views.insert(tracksContainer, spec, { scope });
-        tracks.push({ title, handle, scope });
+        tracks.push({ title, handle });
         status = "Added " + title;
     } catch (error) {
         status = error instanceof Error ? error.message : "Track insert failed";
@@ -246,4 +265,26 @@ function updateControls() {
         `,
         trackControls
     );
+}
+
+/**
+ * @returns {{ pos: number, value: number }[]}
+ */
+function createSignalValues() {
+    return Array.from({ length: 64 }, (_, pos) => ({
+        pos,
+        value: Math.random(),
+    }));
+}
+
+/**
+ * @returns {{ pos: number, type: string }[]}
+ */
+function createVariantValues() {
+    const variantTypes = ["SNV", "DEL", "DUP"];
+
+    return Array.from({ length: 12 }, () => ({
+        pos: Math.floor(Math.random() * 64),
+        type: variantTypes[Math.floor(Math.random() * variantTypes.length)],
+    })).sort((a, b) => a.pos - b.pos);
 }

--- a/packages/embed-examples/src/viewMutationApi.js
+++ b/packages/embed-examples/src/viewMutationApi.js
@@ -12,8 +12,12 @@ const spec = {
     vconcat: [
         {
             name: "tracks",
-            spacing: 4,
-            resolve: { axis: { x: "shared" } },
+            spacing: 5,
+            resolve: {
+                axis: { x: "shared" },
+                scale: { color: "shared" },
+                legend: { color: "shared" },
+            },
             vconcat: initialTrackSpecs,
         },
     ],
@@ -21,6 +25,12 @@ const spec = {
     config: {
         view: {
             stroke: "lightgray",
+        },
+        style: {
+            "overlay-title": {
+                offset: -5,
+                dx: 5,
+            },
         },
     },
 };
@@ -56,7 +66,7 @@ function createSignalTrack() {
 
     return {
         name: "signal",
-        title: "Signal track " + number,
+        title: { text: "Signal track " + number, style: "overlay-title" },
         height: 80,
         data: {
             values: Array.from({ length: 64 }, (_, pos) => ({
@@ -82,7 +92,7 @@ function createVariantsTrack() {
 
     return {
         name: "variants",
-        title: "Variants track " + number,
+        title: { text: "Variants track " + number, style: "overlay-title" },
         height: 36,
         data: {
             values: Array.from({ length: 12 }, () => ({

--- a/packages/embed-examples/src/viewMutationApi.js
+++ b/packages/embed-examples/src/viewMutationApi.js
@@ -4,6 +4,7 @@ import { html, render } from "lit";
 /** @type {import("@genome-spy/core/spec/view.js").UnitSpec} */
 const signalTrack = {
     name: "signal",
+    title: "Signal track",
     height: 80,
     data: {
         values: [
@@ -18,7 +19,6 @@ const signalTrack = {
         x: {
             field: "pos",
             type: "index",
-            scale: { name: "position", domain: [0, 4] },
         },
         y: { field: "value", type: "quantitative" },
         color: { value: "steelblue" },
@@ -29,6 +29,7 @@ const signalTrack = {
 const summaryTrack = {
     name: "summary",
     height: 50,
+    title: "Summary track",
     data: {
         values: [
             { pos: 0, value: 0.35 },
@@ -37,12 +38,11 @@ const summaryTrack = {
             { pos: 3, value: 0.65 },
         ],
     },
-    mark: "bar",
+    mark: "rect",
     encoding: {
         x: {
             field: "pos",
             type: "index",
-            scale: { name: "position" },
         },
         y: { field: "value", type: "quantitative" },
         color: { value: "seagreen" },
@@ -52,7 +52,8 @@ const summaryTrack = {
 /** @type {import("@genome-spy/core/spec/view.js").UnitSpec} */
 const variantsTrack = {
     name: "variants",
-    height: 60,
+    title: "Variants track",
+    height: 30,
     data: {
         values: [
             { pos: 0.5, type: "SNV" },
@@ -65,7 +66,6 @@ const variantsTrack = {
         x: {
             field: "pos",
             type: "index",
-            scale: { name: "position" },
         },
         color: { field: "type", type: "nominal" },
     },
@@ -73,7 +73,6 @@ const variantsTrack = {
 
 /** @type {import("@genome-spy/core/spec/root.js").RootSpec} */
 const spec = {
-    width: 600,
     vconcat: [
         {
             name: "tracks",
@@ -81,6 +80,12 @@ const spec = {
             vconcat: [signalTrack, variantsTrack],
         },
     ],
+
+    config: {
+        view: {
+            stroke: "lightgray",
+        },
+    },
 };
 
 const container = document.getElementById("container");

--- a/packages/embed-examples/src/viewMutationApi.js
+++ b/packages/embed-examples/src/viewMutationApi.js
@@ -133,6 +133,24 @@ async function removeSummaryTrack(summary) {
     updateDashboard();
 }
 
+/**
+ * @param {{ scope: string, handle: import("@genome-spy/core/types/embedApi.js").ViewHandle }} summary
+ * @param {number} offset
+ */
+async function moveSummaryTrack(summary, offset) {
+    try {
+        const currentIndex = getTrackIndex(summary.handle);
+        await api.views.move(summary.handle, {
+            index: currentIndex + offset,
+        });
+        status = "Moved " + summary.scope;
+    } catch (error) {
+        status = error instanceof Error ? error.message : "Summary move failed";
+    }
+
+    updateDashboard();
+}
+
 function updateDashboard() {
     render(
         html`
@@ -159,6 +177,25 @@ function updateDashboard() {
                         (summary) => html`
                             <p>
                                 <button
+                                    ?disabled=${!canMoveTrack(
+                                        summary.handle,
+                                        -1
+                                    )}
+                                    @click=${() =>
+                                        moveSummaryTrack(summary, -1)}
+                                >
+                                    Up
+                                </button>
+                                <button
+                                    ?disabled=${!canMoveTrack(
+                                        summary.handle,
+                                        1
+                                    )}
+                                    @click=${() => moveSummaryTrack(summary, 1)}
+                                >
+                                    Down
+                                </button>
+                                <button
                                     ?disabled=${!summary.handle.isAlive()}
                                     @click=${() => removeSummaryTrack(summary)}
                                 >
@@ -176,6 +213,27 @@ function updateDashboard() {
             </dl>
         `,
         dashboard
+    );
+}
+
+/**
+ * @param {import("@genome-spy/core/types/embedApi.js").ViewHandle} handle
+ */
+function getTrackIndex(handle) {
+    return tracks.children().indexOf(handle);
+}
+
+/**
+ * @param {import("@genome-spy/core/types/embedApi.js").ViewHandle} handle
+ * @param {number} offset
+ */
+function canMoveTrack(handle, offset) {
+    const currentIndex = getTrackIndex(handle);
+    const destinationIndex = currentIndex + offset;
+    return (
+        currentIndex >= 0 &&
+        destinationIndex >= 0 &&
+        destinationIndex <= tracks.children().length - 1
     );
 }
 

--- a/packages/embed-examples/src/viewMutationApi.js
+++ b/packages/embed-examples/src/viewMutationApi.js
@@ -1,0 +1,107 @@
+import { embed } from "@genome-spy/core/minimal";
+import { html, render } from "lit";
+
+/** @type {import("@genome-spy/core/spec/view.js").UnitSpec} */
+const signalTrack = {
+    name: "signal",
+    height: 80,
+    data: {
+        values: [
+            { pos: 0, value: 0.2 },
+            { pos: 1, value: 0.8 },
+            { pos: 2, value: 0.4 },
+            { pos: 3, value: 0.9 },
+        ],
+    },
+    mark: "rect",
+    encoding: {
+        x: {
+            field: "pos",
+            type: "index",
+            scale: { name: "position", domain: [0, 4] },
+        },
+        y: { field: "value", type: "quantitative" },
+        color: { value: "steelblue" },
+    },
+};
+
+/** @type {import("@genome-spy/core/spec/view.js").UnitSpec} */
+const variantsTrack = {
+    name: "variants",
+    height: 60,
+    data: {
+        values: [
+            { pos: 0.5, type: "SNV" },
+            { pos: 1.5, type: "DEL" },
+            { pos: 2.5, type: "SNV" },
+        ],
+    },
+    mark: { type: "point", size: 140 },
+    encoding: {
+        x: {
+            field: "pos",
+            type: "index",
+            scale: { name: "position" },
+        },
+        color: { field: "type", type: "nominal" },
+    },
+};
+
+/** @type {import("@genome-spy/core/spec/root.js").RootSpec} */
+const spec = {
+    width: 600,
+    vconcat: [
+        {
+            name: "tracks",
+            spacing: 4,
+            vconcat: [signalTrack, variantsTrack],
+        },
+    ],
+};
+
+const container = document.getElementById("container");
+const dashboard = document.getElementById("dashboard");
+
+const api = await embed(container, spec);
+
+const root = api.views.root();
+const tracks = api.views.get({ scope: [], view: "tracks" });
+const signal = api.views.get({ scope: [], view: "signal" });
+
+updateDashboard();
+
+function updateDashboard() {
+    render(
+        html`
+            <p>
+                <button @click=${updateDashboard}>Refresh handles</button>
+            </p>
+            <dl>
+                <dt>Root</dt>
+                <dd><code>${JSON.stringify(summarizeHandle(root))}</code></dd>
+
+                <dt>Tracks</dt>
+                <dd><code>${JSON.stringify(summarizeHandle(tracks))}</code></dd>
+
+                <dt>Signal</dt>
+                <dd><code>${JSON.stringify(summarizeHandle(signal))}</code></dd>
+            </dl>
+        `,
+        dashboard
+    );
+}
+
+/**
+ * @param {import("@genome-spy/core/types/embedApi.js").ViewHandle} handle
+ */
+function summarizeHandle(handle) {
+    return {
+        id: handle.id,
+        name: handle.name,
+        selector: handle.selector,
+        type: handle.type,
+        alive: handle.isAlive(),
+        parent: handle.parent()?.name,
+        children: handle.children().map((child) => child.name ?? child.id),
+    };
+}

--- a/packages/embed-examples/src/viewMutationApi.js
+++ b/packages/embed-examples/src/viewMutationApi.js
@@ -3,6 +3,7 @@ import { html, render } from "lit";
 
 const container = document.getElementById("container");
 const dashboard = document.getElementById("dashboard");
+const trackControls = document.getElementById("track-controls");
 const trackCounts = { signal: 0, variants: 0 };
 
 const initialTrackSpecs = [createSignalTrack(), createVariantsTrack()];
@@ -40,7 +41,7 @@ const tracksContainer = api.views.get({ scope: [], view: "tracks" });
 
 /** @type {TrackItem[]} */
 const tracks = initialTrackSpecs.map((spec) => ({
-    title: /** @type {string} */ (spec.title),
+    title: getTitleText(spec.title),
     handle: api.views.get({
         scope: [],
         view: /** @type {string} */ (spec.name),
@@ -48,6 +49,7 @@ const tracks = initialTrackSpecs.map((spec) => ({
 }));
 
 let status = "Ready";
+api.views.subscribeToLayout(updateControls);
 updateControls();
 
 /**
@@ -57,6 +59,17 @@ updateControls();
  *   scope?: string
  * }} TrackItem
  */
+
+/**
+ * @param {import("@genome-spy/core/spec/view.js").ViewSpec["title"]} title
+ */
+function getTitleText(title) {
+    if (typeof title === "string") {
+        return title;
+    }
+
+    return title?.text ?? "";
+}
 
 /**
  * @returns {import("@genome-spy/core/spec/view.js").UnitSpec}
@@ -117,7 +130,7 @@ function createVariantsTrack() {
 async function addTrack(type) {
     const spec =
         type === "signal" ? createSignalTrack() : createVariantsTrack();
-    const title = /** @type {string} */ (spec.title);
+    const title = getTitleText(spec.title);
     const scope = type + "-" + trackCounts[type];
 
     try {
@@ -185,31 +198,52 @@ function updateControls() {
                 </button>
             </p>
             <p>Status: ${status}</p>
-            <ol>
-                ${tracks.map(
-                    (track, index) => html`
-                        <li>
-                            ${track.title}
-                            <button
-                                ?disabled=${index === 0}
-                                @click=${() => moveTrack(track, -1)}
-                            >
-                                Up
-                            </button>
-                            <button
-                                ?disabled=${index === tracks.length - 1}
-                                @click=${() => moveTrack(track, 1)}
-                            >
-                                Down
-                            </button>
-                            <button @click=${() => removeTrack(track)}>
-                                Remove
-                            </button>
-                        </li>
-                    `
-                )}
-            </ol>
         `,
         dashboard
+    );
+    render(
+        html`
+            ${tracks.map((track, index) => {
+                const bounds = api.views.getLayoutBounds(track.handle);
+                if (!bounds) {
+                    return "";
+                }
+
+                // View bounds are in the GenomeSpy canvas coordinate space.
+                // The overlay shares that origin, so CSS pixels map directly.
+                const style =
+                    "left: " +
+                    (bounds.x + bounds.width - 4) +
+                    "px; top: " +
+                    (bounds.y + 4) +
+                    "px";
+
+                return html`
+                    <div class="track-controls" style=${style}>
+                        <button
+                            title=${"Move " + track.title + " up"}
+                            ?disabled=${index === 0}
+                            @click=${() => moveTrack(track, -1)}
+                        >
+                            Up
+                        </button>
+                        <button
+                            title=${"Move " + track.title + " down"}
+                            ?disabled=${index === tracks.length - 1}
+                            @click=${() => moveTrack(track, 1)}
+                        >
+                            Down
+                        </button>
+                        <button
+                            title=${"Remove " + track.title}
+                            @click=${() => removeTrack(track)}
+                        >
+                            Remove
+                        </button>
+                    </div>
+                `;
+            })}
+        `,
+        trackControls
     );
 }

--- a/packages/embed-examples/vite.config.js
+++ b/packages/embed-examples/vite.config.js
@@ -18,6 +18,7 @@ export default defineConfig({
                 scaleApi: "src/scaleApi.html",
                 paramApi: "src/paramApi.html",
                 brushLinkingApi: "src/brushLinkingApi.html",
+                viewMutationApi: "src/viewMutationApi.html",
                 linkedEmbeds: "src/linkedEmbeds.html",
                 dynamicNamedData: "src/dynamicNamedData.html",
                 multipleDynamicSources: "src/multipleDynamicSources.html",


### PR DESCRIPTION
This PR adds a conservative public view mutation API to the `embed()` result. The new API lets embedding applications inspect the live layout hierarchy, insert reusable view specs with scopes, remove views, reorder tracks, batch mutations, and position external UI next to rendered views without exposing internal `View` instances.

Key points:

- Adds `api.views` with opaque handles, scoped selectors, mutation methods, transactions, layout bounds, and layout subscriptions.
- Supports repeated insertion of ordinary specs and imported specs by passing an explicit mutation-time scope.
- Keeps dynamic guide/chrome, dataflow, named data, params, and shared scales/axes/legends synchronized after add/remove/reorder operations.
- Adds an embed example demonstrating add/remove/reorder controls overlaid next to tracks.
- Expands acid coverage for cancellation, inherited data, params, scoped reuse, transactions, rollback, stale handles, named data, implicit roots, and shared guide churn.
- Updates public API docs and getting-started snippets so examples bind the returned API object.

Basic usage:

```js
const api = await embed(container, spec);

const tracks = api.views.get({ scope: [], view: "tracks" });

const signalTrack = await api.views.insert(
  tracks,
  {
    name: "signalTrack",
    data: { values: signalValues },
    mark: "point",
    encoding: {
      x: { field: "position", type: "quantitative" },
      y: { field: "value", type: "quantitative" },
    },
  },
  { scope: "sample-1-signal" }
);

await api.views.move(signalTrack, { index: 0 });
await api.views.remove(signalTrack);
```

Repeated reusable specs can be addressed independently by scope:

```js
await api.views.insert(tracks, signalTrackSpec, { scope: "tumorA" });
await api.views.insert(tracks, signalTrackSpec, { scope: "tumorB" });

const tumorASignal = api.views.get({
  scope: ["tumorA"],
  view: "signalTrack",
});
```

External controls can follow live view layout:

```js
const unsubscribe = api.views.subscribeToLayout(() => {
  const bounds = api.views.getLayoutBounds(tumorASignal);
  if (bounds) {
    controls.style.left = bounds.x + bounds.width + "px";
    controls.style.top = bounds.y + "px";
  }
});
```

Multiple operations can be batched:

```js
await api.views.transaction(async (views) => {
  const inserted = await views.insert(tracks, variantTrackSpec, {
    scope: "sample-1-variants",
  });

  await views.move(inserted, { index: 1 });
});
```

Validation run:

```sh
npx vitest run
npm --workspaces run test:tsc --if-present
```