### PR TITLE
feat(core)!: standardize genomic data contracts for v2.0

### DIFF
--- a/docs/examples/genomic-data/gencode-gff3-gene-annotations.md
+++ b/docs/examples/genomic-data/gencode-gff3-gene-annotations.md
@@ -33,8 +33,9 @@ This example combines several GenomeSpy capabilities in one spec:
   from a tabix-indexed file.
 - [`flatten`](../../grammar/transform/flatten.md) expands hierarchical GFF3
   feature arrays.
-- [`project`](../../grammar/transform/project.md) extracts nested attributes
-  such as transcript IDs, transcript names, exon numbers, and feature types.
+- [`project`](../../grammar/transform/project.md) selects flattened GFF3
+  properties such as transcript IDs, transcript names, exon numbers, and
+  feature types.
 - [`collect`](../../grammar/transform/collect.md) sorts transcript features
   before lane assignment.
 - [`pileup`](../../grammar/transform/pileup.md) packs overlapping transcripts

--- a/docs/grammar/data/eager.md
+++ b/docs/grammar/data/eager.md
@@ -376,8 +376,7 @@ Behavior details:
   row.
 - BED12 rows use BED12 field names (for example `thickStart`, `thickEnd`,
   `itemRgb`, `blockCount`, `blockSizes`, `blockStarts`).
-- `strand` is normalized to numeric codes: `"+"` -> `1`, `"-"` -> `-1`, and
-  any other value -> `0`.
+- `strand` is `"+"`, `"-"`, or `null` when the record is unstranded.
 - `blockSizes` and `blockStarts` are parsed from comma-separated text into
   numeric arrays.
 - Non-BED12 extra columns are preserved as positional fallback fields (`fieldN`).
@@ -407,8 +406,8 @@ Behavior details:
   order or explicit names from `format.columns`.
 - Sentinel normalization: `.` -> `null` for string fields (`chrom*`, `name`);
   `-1` and `""` -> `null` for coordinates; `""` -> `null` for `score`.
-- `strand1` and `strand2` are normalized to numeric codes: `"+"` -> `1`,
-  `"-"` -> `-1`, and any other value -> `0`.
+- `strand1` and `strand2` are `"+"`, `"-"`, or `null` when an endpoint is
+  unstranded.
 - Extra trailing columns are preserved as positional fallback fields (`fieldN`,
   with 1-based indexing).
 - Rows with fewer than six columns are rejected with a parse error.

--- a/docs/grammar/data/lazy.md
+++ b/docs/grammar/data/lazy.md
@@ -201,14 +201,22 @@ EXAMPLE examples/docs/examples/genomic-data/clinvar-variants.json height=130 spe
 ## GFF3
 
 The tabix-based `"gff3"` source enables the retrieval of hierarchical data, such
-as genomic annotations stored in GFF3 files. GenomeSpy currently exposes the
-[gff-nostream 3.0.11 object
-format](https://github.com/GMOD/gff-nostream/blob/v3.0.11/README.md#object-format)
-directly. This parser-defined format will remain in GenomeSpy 1.x and will be
-replaced by a standardized row format in GenomeSpy 2.0. The
-[flatten](../transform/flatten.md) and [project](../transform/project.md)
-transforms are useful when extracting child features and attributes from the
-hierarchical data structure. See the visualization below.
+as genomic annotations stored in GFF3 files. It converts GFF3's one-based,
+closed coordinates to zero-based, half-open `start` and `end` values. Each
+feature has `chrom`, `source`, `type`, `start`, `end`, `score`, `strand`,
+`phase`, and `subfeatures` fields. `strand` is `"+"`, `"-"`, or `null`.
+
+GFF3 attributes are lowercased and flattened onto the feature object. A
+single-valued attribute is a scalar; a repeated attribute remains an array.
+Attribute names that collide with parser fields receive a numeric suffix. The
+adapter reserves `chrom`: an attribute with that name becomes `chrom2`, or the
+next available numeric suffix.
+
+Child features are nested directly under `subfeatures`. Multi-location lines
+remain separate features, and a feature with several parents is attached to
+each parent. A child whose parent is outside the fetched interval remains
+available as a top-level feature. Use [flatten](../transform/flatten.md) and
+[project](../transform/project.md) to reshape the hierarchy for a track.
 
 ### Parameters
 
@@ -231,8 +239,8 @@ EXAMPLE examples/docs/examples/genomic-data/gff3-gene-annotations.json height=36
     that all project data are open access.
 
 The data source is based on [GMOD](http://gmod.org/)'s
-[tabix-js 3.2.2](https://github.com/GMOD/tabix-js/tree/v3.2.2) and
-[gff-nostream 3.0.11](https://github.com/GMOD/gff-nostream/tree/v3.0.11)
+[tabix-js 3.8.1](https://github.com/GMOD/tabix-js/tree/v3.8.1) and
+[gff-nostream 5.2.1](https://github.com/GMOD/gff-nostream/tree/v5.2.1)
 libraries.
 
 ## BAM

--- a/docs/grammar/data/lazy.md
+++ b/docs/grammar/data/lazy.md
@@ -109,7 +109,8 @@ The data source is based on [GMOD](http://gmod.org/)'s
 The `"bigbed"` source enables the retrieval of segmented data, such as annotated
 genomic regions stored in BigBed files. The fields and their types are determined
 by the file's embedded AutoSQL schema, or by the standard BED schema when the
-file does not include one.
+file does not include one. When the schema includes a `strand` field, its value
+is normalized to `"+"`, `"-"`, or `null`.
 
 ### Parameters
 
@@ -144,7 +145,9 @@ field names from `columns`, from a commented header line in the tabix file
 header, or from the first row of a plain TSV header. Field types are inferred
 automatically unless you provide `parse` (see [eager data sources](eager.md#tabular-formats)
 for the supported syntax). If the file uses bare chromosome names, set
-`addChrPrefix` to `true` to align them with GenomeSpy's UCSC-style genomes.
+`addChrPrefix` to `true` so UCSC-style assembly names query the corresponding
+bare names in the index. This mapping does not rewrite chromosome fields in
+the loaded records.
 
 Advanced multi-file Tabix views can use a URL template together with an
 `indexUrl` template. See [URL templates and multiple files](multi-url.md).
@@ -249,7 +252,7 @@ Returned fields:
 | `name`            | string   | Read name.                                                                       |
 | `cigar`           | string   | CIGAR string, or `"*"` when unavailable.                                         |
 | `mapq`            | number   | Mapping quality.                                                                 |
-| `strand`          | string   | Read strand: `"+"` or `"-"`.                                                     |
+| `strand`          | string or null | Read strand: `"+"`, `"-"`, or `null` when unstranded.                     |
 | `seq`             | string   | Read sequence.                                                                   |
 | `qual`            | number[] | Base quality values, when available.                                             |
 | `md`              | string   | `MD` tag value, when available.                                                  |

--- a/docs/migration/v2-genomic-data.md
+++ b/docs/migration/v2-genomic-data.md
@@ -1,0 +1,67 @@
+# Migrating Genomic Data to GenomeSpy 2.0
+
+GenomeSpy 2.0 standardizes the records produced by built-in genomic data
+sources. Update expressions, transforms, scale domains, and tests that consume
+the changed fields.
+
+## Strand values
+
+BED, BEDPE, BigBed, BAM, and GFF3 sources now publish symbolic strand values:
+
+| Meaning | GenomeSpy 2.0 value |
+| --- | --- |
+| Forward strand | `"+"` |
+| Reverse strand | `"-"` |
+| Unknown or unstranded | `null` |
+
+Replace numeric strand conditions throughout the dataflow:
+
+```js
+datum.strand == 1   // Before
+datum.strand == "+" // GenomeSpy 2.0
+
+datum.strand == -1  // Before
+datum.strand == "-" // GenomeSpy 2.0
+
+datum.strand == 0    // Before
+datum.strand == null // GenomeSpy 2.0
+```
+
+Apply the same change to BEDPE's `strand1` and `strand2` fields. Nominal color
+or shape encodings that merely group strand values usually need no changes,
+but their scale domains may need updating.
+
+See [issue #459](https://github.com/genome-spy/genome-spy/issues/459) for the
+original change request.
+
+## GFF3 records
+
+The GFF3 source now emits zero-based, half-open coordinates and a simpler
+hierarchy. Attributes are lowercase top-level fields, and child features are
+direct objects under `subfeatures`.
+
+| GenomeSpy 1.x | GenomeSpy 2.0 |
+| --- | --- |
+| `seq_id` | `chrom` |
+| One-based `start` plus an encoding offset | Zero-based `start` without an offset |
+| Closed `end` | Exclusive `end` |
+| `child_features` nested arrays | `subfeatures` objects |
+| `attributes.ID[0]` | `id` |
+| `attributes.gene_name[0]` | `gene_name` |
+| Other `attributes.*` paths | Lowercase top-level fields |
+
+Singleton attributes are scalars, while repeated values remain arrays. An
+attribute that collides with a parser field receives a numeric suffix. The
+adapter reserves `chrom`, so a GFF3 attribute named `chrom` becomes `chrom2`,
+or the next available `chromN` field.
+
+Remove compatibility transforms that flatten the legacy outer arrays or copy
+nested attributes. Flatten `subfeatures` only at the hierarchy levels the
+visualization needs. Remove locus-encoding offsets previously used to correct
+GFF3 `start` values.
+
+See the [GFF3 source documentation](../grammar/data/lazy.md#gff3) and the
+[GENCODE example](../examples/genomic-data/gencode-gff3-gene-annotations.md)
+for the current record shape. See
+[issue #460](https://github.com/genome-spy/genome-spy/issues/460) for the
+original change request.

--- a/examples/docs/examples/genomic-data/gff3-gene-annotations.json
+++ b/examples/docs/examples/genomic-data/gff3-gene-annotations.json
@@ -25,41 +25,34 @@
   },
 
   "transform": [
-    { "type": "flatten" },
-    {
-      "type": "formula",
-      "expr": "datum.attributes.gene_name",
-      "as": "gene_name"
-    },
-    { "type": "flatten", "fields": ["child_features"] },
     {
       "type": "flatten",
-      "fields": ["child_features"],
-      "as": ["child_feature"]
+      "fields": ["subfeatures"],
+      "as": ["transcript"]
     },
     {
       "type": "project",
       "fields": [
         "gene_name",
-        "child_feature.type",
-        "child_feature.strand",
-        "child_feature.seq_id",
-        "child_feature.start",
-        "child_feature.end",
-        "child_feature.attributes.gene_type",
-        "child_feature.attributes.transcript_type",
-        "child_feature.attributes.gene_id",
-        "child_feature.attributes.transcript_id",
-        "child_feature.attributes.transcript_name",
-        "child_feature.attributes.tag",
-        "source",
-        "child_feature.child_features"
+        "transcript.type",
+        "transcript.strand",
+        "transcript.chrom",
+        "transcript.start",
+        "transcript.end",
+        "transcript.gene_type",
+        "transcript.transcript_type",
+        "transcript.gene_id",
+        "transcript.transcript_id",
+        "transcript.transcript_name",
+        "transcript.tag",
+        "transcript.source",
+        "transcript.subfeatures"
       ],
       "as": [
         "gene_name",
         "type",
         "strand",
-        "seq_id",
+        "chrom",
         "start",
         "end",
         "gene_type",
@@ -69,12 +62,12 @@
         "transcript_name",
         "tag",
         "source",
-        "_child_features"
+        "_subfeatures"
       ]
     },
     {
       "type": "collect",
-      "sort": { "field": ["seq_id", "start", "transcript_id"] }
+      "sort": { "field": ["chrom", "start", "transcript_id"] }
     },
     { "type": "pileup", "start": "start", "end": "end", "as": "_lane" }
   ],
@@ -90,12 +83,11 @@
 
   "encoding": {
     "x": {
-      "chrom": "seq_id",
+      "chrom": "chrom",
       "pos": "start",
-      "offset": 1,
       "type": "locus"
     },
-    "x2": { "chrom": "seq_id", "pos": "end" },
+    "x2": { "chrom": "chrom", "pos": "end" },
     "y": {
       "field": "_lane",
       "type": "index",
@@ -132,29 +124,28 @@
     {
       "name": "gencode-exons",
       "transform": [
-        { "type": "flatten", "fields": ["_child_features"] },
         {
           "type": "flatten",
-          "fields": ["_child_features"],
-          "as": ["child_feature"]
+          "fields": ["_subfeatures"],
+          "as": ["subfeature"]
         },
         {
           "type": "project",
           "fields": [
             "gene_name",
             "_lane",
-            "child_feature.type",
-            "child_feature.seq_id",
-            "child_feature.start",
-            "child_feature.end",
-            "child_feature.attributes.exon_number",
-            "child_feature.attributes.exon_id"
+            "subfeature.type",
+            "subfeature.chrom",
+            "subfeature.start",
+            "subfeature.end",
+            "subfeature.exon_number",
+            "subfeature.exon_id"
           ],
           "as": [
             "gene_name",
             "_lane",
             "type",
-            "seq_id",
+            "chrom",
             "start",
             "end",
             "exon_number",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8571,9 +8571,9 @@
       }
     },
     "node_modules/gff-nostream": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/gff-nostream/-/gff-nostream-3.0.11.tgz",
-      "integrity": "sha512-2JjwPuWJOsUcYh+aNMVDNrbF3+Nikb6zMNpDXx9Rtg+pxc6tl5MBp2q5Oomjcc+hDvANNJlmFgcqcQYP5oXYMA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/gff-nostream/-/gff-nostream-5.2.1.tgz",
+      "integrity": "sha512-ZeGFf3DE4+md6vNz6JRVd915I9C0btqf1Tv5yEDkGYE1OHOikJkD9CKxZ4Ykit8bWcfoDeTC4Szn8ck5+yea8w==",
       "license": "MIT"
     },
     "node_modules/git-raw-commits": {
@@ -14678,7 +14678,7 @@
         "events": "^3.3.0",
         "flatqueue": "^3.0.0",
         "generic-filehandle2": "^2.3.1",
-        "gff-nostream": "^3.0.2",
+        "gff-nostream": "^5.2.1",
         "hyparquet": "^1.25.0",
         "internmap": "^2.0.3",
         "lit": "^3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1324,40 +1324,15 @@
       }
     },
     "node_modules/@gmod/indexedfasta": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@gmod/indexedfasta/-/indexedfasta-2.1.1.tgz",
-      "integrity": "sha512-JM0n0EMHwOlur4ojUZ0FgloHtbFO1qJG2PZGg8NrRHUeBtTqfLebGg+38kJibotWwtKjH6AB8NK2HrdJMAMTLg==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@gmod/indexedfasta/-/indexedfasta-5.0.10.tgz",
+      "integrity": "sha512-XL5GcrvS9sbJchAWyPVbmrqs2H2SMRiVIBRPWsxlcsodBCg2sx/lkGL2mmDk59F2LQiN2IcN5JlSfYp3GHnotg==",
       "license": "MIT",
       "dependencies": {
-        "@gmod/bgzf-filehandle": "^1.4.0",
-        "generic-filehandle": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@gmod/indexedfasta/node_modules/@gmod/bgzf-filehandle": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@gmod/bgzf-filehandle/-/bgzf-filehandle-1.5.5.tgz",
-      "integrity": "sha512-3f4mvW0ov7rFip2TQneZJsYiQN6Be0M3ET+k4DS0Mc4GIJJblKARbY4lFt2pT5fpgOmrL55/8A0qwGawKwQN+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "es6-promisify": "^7.0.0",
-        "generic-filehandle": "^3.0.0",
-        "long": "^4.0.0",
-        "pako": "^1.0.11"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@gmod/indexedfasta/node_modules/es6-promisify": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-7.0.0.tgz",
-      "integrity": "sha512-ginqzK3J90Rd4/Yz7qRrqUeIpe3TwSXTPPZtPne7tGBPeAaQiU8qt4fpKApnxHcq1AwtUdHVg5P77x/yrggG8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
+        "@gmod/bgzf-filehandle": "^6.3.2",
+        "@gmod/shared-read-cache": "^1.5.1",
+        "@jbrowse/quick-lru": "^7.3.5",
+        "generic-filehandle2": "^2.2.1"
       }
     },
     "node_modules/@gmod/shared-read-cache": {
@@ -6057,26 +6032,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -6259,30 +6214,6 @@
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
       "dev": true
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -7711,12 +7642,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es6-promisify": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==",
-      "license": "MIT"
-    },
     "node_modules/esbuild": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
@@ -8565,18 +8490,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/generic-filehandle": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/generic-filehandle/-/generic-filehandle-3.4.0.tgz",
-      "integrity": "sha512-HQh9z5tDB/lWsMbjnGXjGVvKuYzM3JR9Fhb9hk1rESB6RQ1yGJGllnx4N2Hv795eyekzsfUaYBIE5AoGucacog==",
-      "license": "MIT",
-      "dependencies": {
-        "es6-promisify": "^6.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/generic-filehandle2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generic-filehandle2/-/generic-filehandle2-2.3.1.tgz",
@@ -9017,26 +8930,6 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -10263,12 +10156,6 @@
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
-    },
-    "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -11587,12 +11474,6 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "license": "(MIT AND Zlib)"
     },
     "node_modules/pako-esm2": {
       "version": "2.0.2",
@@ -14800,18 +14681,6 @@
         "@types/long": "^4.0.1"
       }
     },
-    "packages/core/node_modules/@gmod/indexedfasta": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@gmod/indexedfasta/-/indexedfasta-5.0.10.tgz",
-      "integrity": "sha512-XL5GcrvS9sbJchAWyPVbmrqs2H2SMRiVIBRPWsxlcsodBCg2sx/lkGL2mmDk59F2LQiN2IcN5JlSfYp3GHnotg==",
-      "license": "MIT",
-      "dependencies": {
-        "@gmod/bgzf-filehandle": "^6.3.2",
-        "@gmod/shared-read-cache": "^1.5.1",
-        "@jbrowse/quick-lru": "^7.3.5",
-        "generic-filehandle2": "^2.2.1"
-      }
-    },
     "packages/core/node_modules/@gmod/tabix": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@gmod/tabix/-/tabix-3.2.2.tgz",
@@ -14851,8 +14720,8 @@
         "@genome-spy/core": "^0.85.0",
         "@genome-spy/inspector": "^0.85.0",
         "@genome-spy/react-component": "^0.85.0",
-        "@gmod/indexedfasta": "^2.0.4",
-        "buffer": "^6.0.3",
+        "@gmod/indexedfasta": "^5.0.10",
+        "generic-filehandle2": "^2.3.1",
         "lit": "^3.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14661,6 +14661,7 @@
         "@gmod/bbi": "^11.1.0",
         "@gmod/bed": "^2.2.10",
         "@gmod/indexedfasta": "^5.0.10",
+        "@gmod/shared-read-cache": "^1.6.0",
         "@gmod/tabix": "3.8.1",
         "@gmod/vcf": "^7.2.0",
         "@types/d3-array": "^3.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1354,9 +1354,9 @@
       }
     },
     "node_modules/@gmod/vcf": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@gmod/vcf/-/vcf-7.0.9.tgz",
-      "integrity": "sha512-3QuZSblZ/larjVNOXyoTFV905s0lyZvOs2+7GALsWR6d9Fuj/+KNnrpNFr3LWCShgE+JqwYEUOfbUv0koct5Kw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@gmod/vcf/-/vcf-7.2.0.tgz",
+      "integrity": "sha512-F5uZ3j1hzpEBtPppveZt+ngJ/6CbGy9wfqNdExBQ6h853ABr/2mOWnuuq5Uv5ekslhQEgxWr0+r9z0JSZU596w==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
@@ -14662,7 +14662,7 @@
         "@gmod/bed": "^2.2.10",
         "@gmod/indexedfasta": "^5.0.10",
         "@gmod/tabix": "3.8.1",
-        "@gmod/vcf": "^7.0.0",
+        "@gmod/vcf": "^7.2.0",
         "@types/d3-array": "^3.2.2",
         "@types/d3-dsv": "^3.0.7",
         "@types/d3-ease": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1341,6 +1341,18 @@
       "integrity": "sha512-RrkbPdTFcKgtapYTCt8nwP4B/wzFlSLpPC4f5OfNAciC9o/Hxa1oW5qBVLk/4BEV61gp5x3sLjYHIXvMwklHDQ==",
       "license": "MIT"
     },
+    "node_modules/@gmod/tabix": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@gmod/tabix/-/tabix-3.8.1.tgz",
+      "integrity": "sha512-ZAA7we8dMwezKZX03h4kx4eKxBSQqJn9kxWE6rnmc8pHUNxDyynGd91GfUkj57z+ZNgA7yA/4yAMskHpLTiJdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@gmod/bgzf-filehandle": "^6.6.0",
+        "@gmod/shared-read-cache": "^1.5.1",
+        "@jbrowse/quick-lru": "^7.3.5",
+        "generic-filehandle2": "^2.2.1"
+      }
+    },
     "node_modules/@gmod/vcf": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@gmod/vcf/-/vcf-7.0.9.tgz",
@@ -14649,7 +14661,7 @@
         "@gmod/bbi": "^11.1.0",
         "@gmod/bed": "^2.2.10",
         "@gmod/indexedfasta": "^5.0.10",
-        "@gmod/tabix": "3.2.2",
+        "@gmod/tabix": "3.8.1",
         "@gmod/vcf": "^7.0.0",
         "@types/d3-array": "^3.2.2",
         "@types/d3-dsv": "^3.0.7",
@@ -14679,21 +14691,6 @@
       "devDependencies": {
         "@genome-spy/webgpu-renderer": "^0.64.0",
         "@types/long": "^4.0.1"
-      }
-    },
-    "packages/core/node_modules/@gmod/tabix": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@gmod/tabix/-/tabix-3.2.2.tgz",
-      "integrity": "sha512-lQQCuanjsnVNzH9n21LTMGykvRbpLbEQk3AL+aKnjf72gfV07mLZ116gtvDFu5huxbxWialOHGGC7iJAQDEi5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@gmod/abortable-promise-cache": "^3.0.1",
-        "@gmod/bgzf-filehandle": "^6.0.9",
-        "@jbrowse/quick-lru": "^7.3.5",
-        "generic-filehandle2": "^2.0.16"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "packages/core/node_modules/vega-util": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1285,41 +1285,41 @@
       "license": "MIT"
     },
     "node_modules/@gmod/bam": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@gmod/bam/-/bam-7.3.3.tgz",
-      "integrity": "sha512-cWSsd+/CpJbLKATfjU2RgeCh1izsv64OiBX5l60guxVcZuFq+waLxS3DW/YsvCTo0TZ8Vzx5mqFDCKb+y1Y9Og==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@gmod/bam/-/bam-8.9.0.tgz",
+      "integrity": "sha512-rH2sz6eVJWS+NlUSe2DQFzNZNlU1iC/+CazBXKzFYbNtUJk6zqdetMQupTJ5RREyjNwvA47rUCzafCruq/Jjvg==",
       "license": "MIT",
       "dependencies": {
-        "@gmod/bgzf-filehandle": "^6.2.0",
+        "@gmod/bgzf-filehandle": "^6.6.0",
+        "@gmod/shared-read-cache": "^1.5.1",
         "@jbrowse/quick-lru": "^7.3.5",
         "crc": "^4.3.2",
-        "generic-filehandle2": "^2.2.0"
+        "generic-filehandle2": "^2.2.1"
       }
     },
     "node_modules/@gmod/bbi": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@gmod/bbi/-/bbi-9.2.1.tgz",
-      "integrity": "sha512-T8whRWIzvx9zFZldCCs90hPPTGTCWiBXEkXpoMhO3rFbEaOyTCxtSpN7ot62TvXjT9EP+H5HwwatzabJSy8uRg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@gmod/bbi/-/bbi-11.1.0.tgz",
+      "integrity": "sha512-DAlT7KF6DWRCWaCb0LTkmtRob3JdNPlWL7geiCOWLBKTZsX0VPfKbsG4xjYhG1mhEckjmIRsO+8etRC2sfZ6HQ==",
       "license": "MIT",
       "dependencies": {
-        "@gmod/abortable-promise-cache": "^3.0.4",
-        "@jbrowse/quick-lru": "^7.3.5",
-        "generic-filehandle2": "^2.1.9"
+        "@gmod/shared-read-cache": "^1.5.1",
+        "generic-filehandle2": "^2.2.1"
       }
     },
     "node_modules/@gmod/bed": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@gmod/bed/-/bed-2.2.6.tgz",
-      "integrity": "sha512-6L2EaYIHts/C3BQ4bcERUH24MPlQ2jpuq+qKWzG7ZWNOLrHx2YplYlXMuVZEiLmmiNShJnH1PFYWNGtM1QaS6Q==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@gmod/bed/-/bed-2.2.10.tgz",
+      "integrity": "sha512-LpoMHyfYuT+fB9ZXTcfMOsDqROORsoNFBUTcfMegh2HSYSctYlBe515njrKgHnzeZ7ioV+5zvRDMcKtFaX9Ppg==",
       "license": "MIT"
     },
     "node_modules/@gmod/bgzf-filehandle": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@gmod/bgzf-filehandle/-/bgzf-filehandle-6.2.0.tgz",
-      "integrity": "sha512-az2V3+hhpEUHBdJsN6SuSHu7rHFqIIssuZFeerRe8fvEcI/qW+BqB3vT5YC0CNU/SqQB8HREeWu8RoLQbmumdw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@gmod/bgzf-filehandle/-/bgzf-filehandle-6.6.0.tgz",
+      "integrity": "sha512-rCKRWfN4KXf4YYH4TeMKKq+56Viu+FX/l2B53uBIx2+ThP9yVbupFMtspteh7Z/lnP6R3vn2kfIytB0wt+bFbA==",
       "license": "MIT",
       "dependencies": {
-        "generic-filehandle2": "^2.1.4",
+        "generic-filehandle2": "^2.2.1",
         "pako-esm2": "^2.0.2"
       }
     },
@@ -1359,6 +1359,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@gmod/shared-read-cache": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@gmod/shared-read-cache/-/shared-read-cache-1.6.0.tgz",
+      "integrity": "sha512-RrkbPdTFcKgtapYTCt8nwP4B/wzFlSLpPC4f5OfNAciC9o/Hxa1oW5qBVLk/4BEV61gp5x3sLjYHIXvMwklHDQ==",
+      "license": "MIT"
     },
     "node_modules/@gmod/vcf": {
       "version": "7.0.9",
@@ -8572,9 +8578,9 @@
       }
     },
     "node_modules/generic-filehandle2": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/generic-filehandle2/-/generic-filehandle2-2.2.0.tgz",
-      "integrity": "sha512-gIE15MYVakEEzWvuNkUnTfjVWzodBi3T6stgRIXpWackW6FhiK5eOBBxif1Kq2wkiiegRGGqaxpv+qUmIzh3Lg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generic-filehandle2/-/generic-filehandle2-2.3.1.tgz",
+      "integrity": "sha512-WuEud2h4xC4H3m9BmULDiicOlP3k+cCSItD5EqgwmoZzG5W97qF1Qda4O4HWLTo27J+yEkOV1FmPd7kolnHEEQ==",
       "license": "MIT"
     },
     "node_modules/get-caller-file": {
@@ -14758,10 +14764,10 @@
       "version": "0.85.0",
       "license": "MIT",
       "dependencies": {
-        "@gmod/bam": "^7.1.19",
-        "@gmod/bbi": "^9.2.0",
-        "@gmod/bed": "^2.1.10",
-        "@gmod/indexedfasta": "^5.0.2",
+        "@gmod/bam": "^8.9.0",
+        "@gmod/bbi": "^11.1.0",
+        "@gmod/bed": "^2.2.10",
+        "@gmod/indexedfasta": "^5.0.10",
         "@gmod/tabix": "3.2.2",
         "@gmod/vcf": "^7.0.0",
         "@types/d3-array": "^3.2.2",
@@ -14778,7 +14784,7 @@
         "d3-format": "^3.1.0",
         "events": "^3.3.0",
         "flatqueue": "^3.0.0",
-        "generic-filehandle2": "^2.0.18",
+        "generic-filehandle2": "^2.3.1",
         "gff-nostream": "^3.0.2",
         "hyparquet": "^1.25.0",
         "internmap": "^2.0.3",
@@ -14795,14 +14801,15 @@
       }
     },
     "packages/core/node_modules/@gmod/indexedfasta": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@gmod/indexedfasta/-/indexedfasta-5.0.7.tgz",
-      "integrity": "sha512-E/BtszY8K4xN6s2IEafpfZ1E8pyWsBx4xEmcMr0SKaBLPzh0VGqEKdmZpH+Sq5Kq7vYVuL8UriFhc6xNwLfXcA==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@gmod/indexedfasta/-/indexedfasta-5.0.10.tgz",
+      "integrity": "sha512-XL5GcrvS9sbJchAWyPVbmrqs2H2SMRiVIBRPWsxlcsodBCg2sx/lkGL2mmDk59F2LQiN2IcN5JlSfYp3GHnotg==",
       "license": "MIT",
       "dependencies": {
-        "@gmod/bgzf-filehandle": "^6.0.18",
+        "@gmod/bgzf-filehandle": "^6.3.2",
+        "@gmod/shared-read-cache": "^1.5.1",
         "@jbrowse/quick-lru": "^7.3.5",
-        "generic-filehandle2": "^2.1.4"
+        "generic-filehandle2": "^2.2.1"
       }
     },
     "packages/core/node_modules/@gmod/tabix": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
     "@gmod/bed": "^2.2.10",
     "@gmod/indexedfasta": "^5.0.10",
     "@gmod/tabix": "3.8.1",
-    "@gmod/vcf": "^7.0.0",
+    "@gmod/vcf": "^7.2.0",
     "@types/d3-array": "^3.2.2",
     "@types/d3-dsv": "^3.0.7",
     "@types/d3-ease": "^3.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,7 +70,7 @@
     "events": "^3.3.0",
     "flatqueue": "^3.0.0",
     "generic-filehandle2": "^2.3.1",
-    "gff-nostream": "^3.0.2",
+    "gff-nostream": "^5.2.1",
     "hyparquet": "^1.25.0",
     "internmap": "^2.0.3",
     "lit": "^3.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,10 +49,10 @@
     "postpack": "node scripts/postpack.mjs"
   },
   "dependencies": {
-    "@gmod/bam": "^7.1.19",
-    "@gmod/bbi": "^9.2.0",
-    "@gmod/bed": "^2.1.10",
-    "@gmod/indexedfasta": "^5.0.2",
+    "@gmod/bam": "^8.9.0",
+    "@gmod/bbi": "^11.1.0",
+    "@gmod/bed": "^2.2.10",
+    "@gmod/indexedfasta": "^5.0.10",
     "@gmod/tabix": "3.2.2",
     "@gmod/vcf": "^7.0.0",
     "@types/d3-array": "^3.2.2",
@@ -69,7 +69,7 @@
     "d3-format": "^3.1.0",
     "events": "^3.3.0",
     "flatqueue": "^3.0.0",
-    "generic-filehandle2": "^2.0.18",
+    "generic-filehandle2": "^2.3.1",
     "gff-nostream": "^3.0.2",
     "hyparquet": "^1.25.0",
     "internmap": "^2.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,7 @@
     "@gmod/bbi": "^11.1.0",
     "@gmod/bed": "^2.2.10",
     "@gmod/indexedfasta": "^5.0.10",
+    "@gmod/shared-read-cache": "^1.6.0",
     "@gmod/tabix": "3.8.1",
     "@gmod/vcf": "^7.2.0",
     "@types/d3-array": "^3.2.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
     "@gmod/bbi": "^11.1.0",
     "@gmod/bed": "^2.2.10",
     "@gmod/indexedfasta": "^5.0.10",
-    "@gmod/tabix": "3.2.2",
+    "@gmod/tabix": "3.8.1",
     "@gmod/vcf": "^7.0.0",
     "@types/d3-array": "^3.2.2",
     "@types/d3-dsv": "^3.0.7",

--- a/packages/core/src/data/formats/bed.js
+++ b/packages/core/src/data/formats/bed.js
@@ -1,4 +1,5 @@
 import { formats as vegaFormats } from "vega-loader";
+import { normalizeGenomicStrand } from "./genomicStrand.js";
 
 const blankLinePattern = /^\s*$/;
 const controlLinePattern = /^\s*(?:browser\b|track\b|#)/;
@@ -41,7 +42,11 @@ export default async function bed(data) {
         }
 
         try {
-            rows.push(parser.parseLine(line));
+            const row = parser.parseLine(line);
+            if ("strand" in row) {
+                row.strand = normalizeGenomicStrand(row.strand);
+            }
+            rows.push(row);
         } catch (error) {
             throw new Error(
                 `Cannot parse BED line ${i + 1}: ${

--- a/packages/core/src/data/formats/bed.test.js
+++ b/packages/core/src/data/formats/bed.test.js
@@ -9,7 +9,7 @@ test("parses BED rows without canonical interval fields", async () => {
             chromEnd: 10,
             name: "featureA",
             score: 5,
-            strand: 1,
+            strand: "+",
         },
     ]);
 });
@@ -26,7 +26,7 @@ chr19\t49302000\t49302300`;
             chrom: "chr19",
             chromStart: 49302000,
             chromEnd: 49302300,
-            strand: 0,
+            strand: null,
         },
     ]);
 });
@@ -41,7 +41,7 @@ test("keeps fallback fieldN names from parser output", async () => {
             chromEnd: 10,
             name: "item",
             score: 7,
-            strand: 1,
+            strand: "+",
             field6: "1",
             field7: "9",
             field8: "255,0,0",
@@ -61,7 +61,7 @@ test("parses BED12 rows with BED12 field names", async () => {
             chromEnd: 10,
             name: "item",
             score: 7,
-            strand: 1,
+            strand: "+",
             thickStart: 1,
             thickEnd: 9,
             itemRgb: "255,0,0",
@@ -78,7 +78,7 @@ test("keeps malformed percent escapes in chromosome names", async () => {
             chrom: "chr1%ZZ",
             chromStart: 0,
             chromEnd: 10,
-            strand: 0,
+            strand: null,
         },
     ]);
 });
@@ -93,7 +93,7 @@ test("skips trailing empty lines at end of input", async () => {
             chromEnd: 10,
             name: "featureA",
             score: 5,
-            strand: 1,
+            strand: "+",
         },
     ]);
 });

--- a/packages/core/src/data/formats/bedpe.js
+++ b/packages/core/src/data/formats/bedpe.js
@@ -1,4 +1,5 @@
 import { formats as vegaFormats } from "vega-loader";
+import { normalizeGenomicStrand } from "./genomicStrand.js";
 
 const blankLinePattern = /^\s*$/;
 const controlLinePattern = /^\s*(?:browser\b|track\b|#)/;
@@ -21,15 +22,6 @@ const requiredColumns = defaultColumns.slice(0, 6);
 const normalizeNone = (/** @type {string} */ value) => value;
 const normalizeStringSentinel = (/** @type {string} */ value) =>
     value == "." ? null : value;
-const normalizeStrand = (/** @type {string} */ value) => {
-    if (value == "+") {
-        return 1;
-    }
-    if (value == "-") {
-        return -1;
-    }
-    return 0;
-};
 const normalizeCoordinate = (/** @type {string} */ value) => {
     if (value == "." || value == "-1" || value == "") {
         return null;
@@ -50,8 +42,8 @@ const columnNormalizers = {
     chrom1: normalizeStringSentinel,
     chrom2: normalizeStringSentinel,
     name: normalizeStringSentinel,
-    strand1: normalizeStrand,
-    strand2: normalizeStrand,
+    strand1: normalizeGenomicStrand,
+    strand2: normalizeGenomicStrand,
     start1: normalizeCoordinate,
     end1: normalizeCoordinate,
     start2: normalizeCoordinate,

--- a/packages/core/src/data/formats/bedpe.test.js
+++ b/packages/core/src/data/formats/bedpe.test.js
@@ -14,8 +14,8 @@ test("parses headerless BEDPE with default positional columns", () => {
             end2: 40,
             name: "eventA",
             score: 5,
-            strand1: 1,
-            strand2: -1,
+            strand1: "+",
+            strand2: "-",
         },
     ]);
 });
@@ -33,8 +33,8 @@ test("keeps optional extra columns as fieldN fallback names", () => {
             end2: 40,
             name: "eventA",
             score: 5,
-            strand1: 1,
-            strand2: -1,
+            strand1: "+",
+            strand2: "-",
             field11: "extra1",
             field12: "extra2",
         },
@@ -91,8 +91,8 @@ test("normalizes unknown sentinels to null", () => {
             end2: 40,
             name: null,
             score: null,
-            strand1: 0,
-            strand2: 0,
+            strand1: null,
+            strand2: null,
         },
     ]);
 });

--- a/packages/core/src/data/formats/genomicStrand.js
+++ b/packages/core/src/data/formats/genomicStrand.js
@@ -1,0 +1,26 @@
+/**
+ * @typedef {"+" | "-" | null} GenomicStrand
+ */
+
+/**
+ * Normalizes parser-native strand values at a known genomic format boundary.
+ *
+ * @param {string | number | null | undefined} strand
+ * @returns {GenomicStrand}
+ */
+export function normalizeGenomicStrand(strand) {
+    if (strand === "+" || strand === 1) {
+        return "+";
+    } else if (strand === "-" || strand === -1) {
+        return "-";
+    } else if (
+        strand === "." ||
+        strand === 0 ||
+        strand === null ||
+        strand === undefined
+    ) {
+        return null;
+    } else {
+        throw new Error(`Unexpected genomic strand: ${JSON.stringify(strand)}`);
+    }
+}

--- a/packages/core/src/data/formats/genomicStrand.test.js
+++ b/packages/core/src/data/formats/genomicStrand.test.js
@@ -1,0 +1,19 @@
+import { expect, test } from "vitest";
+import { normalizeGenomicStrand } from "./genomicStrand.js";
+
+test("normalizes known parser strand domains", () => {
+    expect(normalizeGenomicStrand("+")).toBe("+");
+    expect(normalizeGenomicStrand(1)).toBe("+");
+    expect(normalizeGenomicStrand("-")).toBe("-");
+    expect(normalizeGenomicStrand(-1)).toBe("-");
+    expect(normalizeGenomicStrand(".")).toBeNull();
+    expect(normalizeGenomicStrand(0)).toBeNull();
+    expect(normalizeGenomicStrand(null)).toBeNull();
+    expect(normalizeGenomicStrand(undefined)).toBeNull();
+});
+
+test("rejects unexpected strand values", () => {
+    expect(() =>
+        normalizeGenomicStrand(/** @type {any} */ ("forward"))
+    ).toThrow('Unexpected genomic strand: "forward"');
+});

--- a/packages/core/src/data/sources/lazy/bamSource.js
+++ b/packages/core/src/data/sources/lazy/bamSource.js
@@ -5,6 +5,7 @@ import {
 import { normalizeSingleUrlDescriptor } from "../urlDescriptor.js";
 import { registerBuiltInLazyDataSource } from "./lazyDataSourceRegistry.js";
 import SingleAxisWindowedSource from "./singleAxisWindowedSource.js";
+import { normalizeGenomicStrand } from "../../formats/genomicStrand.js";
 
 export default class BamSource extends SingleAxisWindowedSource {
     /** @type {import("@gmod/bam").BamFile} */
@@ -149,7 +150,7 @@ export function createBamReadDatum(chrom, record) {
         name: record.name,
         cigar: record.CIGAR || "*",
         mapq: record.mq,
-        strand: record.strand === 1 ? "+" : "-",
+        strand: normalizeGenomicStrand(record.strand),
         seq: record.seq,
         qual: record.qual ? Array.from(record.qual) : undefined,
         md: record.getTag("MD"),

--- a/packages/core/src/data/sources/lazy/bamSource.js
+++ b/packages/core/src/data/sources/lazy/bamSource.js
@@ -79,17 +79,21 @@ export default class BamSource extends SingleAxisWindowedSource {
             },
             "BamSource"
         );
-        const [{ BamFile }, { RemoteFile }] = await Promise.all([
-            import("@gmod/bam"),
-            import("generic-filehandle2"),
-        ]);
+        const [{ BamFile }, { RemoteFile }, { gmodChunkCacheBudget }] =
+            await Promise.all([
+                import("@gmod/bam"),
+                import("generic-filehandle2"),
+                import("./gmodChunkCache.js"),
+            ]);
 
         this.#bam = new BamFile({
             bamFilehandle: new RemoteFile(descriptor.url),
             baiFilehandle: new RemoteFile(
                 descriptor.indexUrl ?? descriptor.url + ".bai"
             ),
+            cacheBudget: gmodChunkCacheBudget,
         });
+        this.registerDisposer(() => this.#bam.chunkFeatureCache.clear());
 
         await this.#bam.getHeader();
         const g = this.genome.hasChrPrefix();

--- a/packages/core/src/data/sources/lazy/bamSource.test.js
+++ b/packages/core/src/data/sources/lazy/bamSource.test.js
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import ViewParamRuntime from "../../../paramRuntime/viewParamRuntime.js";
 import BamSource, { createBamReadDatum } from "./bamSource.js";
+import { gmodChunkCacheBudget } from "./gmodChunkCache.js";
 
 /** @type {{ chrom: string, start: number, end: number }[]} */
 const requestedIntervals = [];
+/** @type {Record<string, unknown>[]} */
+const bamConstructorOptions = [];
+const clearChunkFeatureCache = vi.fn();
 
 vi.mock("generic-filehandle2", () => ({
     RemoteFile: class RemoteFile {
@@ -17,6 +21,12 @@ vi.mock("generic-filehandle2", () => ({
 vi.mock("@gmod/bam", () => ({
     BamFile: class BamFile {
         indexToChr = [{ refName: "chr1" }];
+        chunkFeatureCache = { clear: clearChunkFeatureCache };
+
+        /** @param {Record<string, unknown>} options */
+        constructor(options) {
+            bamConstructorOptions.push(options);
+        }
 
         async getHeader() {
             return {};
@@ -130,6 +140,8 @@ function createViewStub(initialWindowSize = 300) {
 describe("BamSource", () => {
     beforeEach(() => {
         requestedIntervals.length = 0;
+        bamConstructorOptions.length = 0;
+        clearChunkFeatureCache.mockClear();
     });
 
     afterEach(() => {
@@ -172,6 +184,24 @@ describe("BamSource", () => {
         expect(requestedIntervals).toEqual([
             { chrom: "chr1", start: 0, end: 300 },
         ]);
+    });
+
+    test("shares the bounded chunk budget and clears its cache on disposal", async () => {
+        const source = new BamSource(
+            {
+                type: "bam",
+                url: "reads.bam",
+            },
+            /** @type {any} */ (createViewStub())
+        );
+
+        await /** @type {any} */ (source).initializedPromise;
+
+        expect(bamConstructorOptions[0].cacheBudget).toBe(gmodChunkCacheBudget);
+
+        source.dispose();
+        source.dispose();
+        expect(clearChunkFeatureCache).toHaveBeenCalledOnce();
     });
 
     test("maps a BAM record to a read-level datum", () => {

--- a/packages/core/src/data/sources/lazy/bamSource.test.js
+++ b/packages/core/src/data/sources/lazy/bamSource.test.js
@@ -273,4 +273,28 @@ describe("BamSource", () => {
             cigar: "*",
         });
     });
+
+    test("maps an unstranded BAM record to null", () => {
+        /** @type {FakeBamRecord} */
+        const record = {
+            start: 50,
+            end: 50,
+            name: "unstranded",
+            CIGAR: "",
+            mq: undefined,
+            strand: 0,
+            seq: "",
+            qual: undefined,
+            flags: 4,
+            getTag: () => undefined,
+            isPaired: () => false,
+            isProperlyPaired: () => false,
+            isDuplicate: () => false,
+            isFailedQc: () => false,
+            isSecondary: () => false,
+            isSupplementary: () => false,
+        };
+
+        expect(createDatum("chr1", record).strand).toBeNull();
+    });
 });

--- a/packages/core/src/data/sources/lazy/bigBedSource.js
+++ b/packages/core/src/data/sources/lazy/bigBedSource.js
@@ -9,6 +9,7 @@ import UrlDescriptorState, {
 } from "../urlDescriptorState.js";
 import { registerBuiltInLazyDataSource } from "./lazyDataSourceRegistry.js";
 import SingleAxisWindowedSource from "./singleAxisWindowedSource.js";
+import { normalizeGenomicStrand } from "../../formats/genomicStrand.js";
 
 export default class BigBedSource extends SingleAxisWindowedSource {
     /**
@@ -138,10 +139,19 @@ export default class BigBedSource extends SingleAxisWindowedSource {
                 parser.parseLine(`${chrom}\t${f.start}\t${f.end}\t${f.rest}`);
         }
 
+        /** @type {BigBedHandle["parseLine"]} */
+        const normalizeParseLine = (chrom, fields) => {
+            const datum = parseLine(chrom, fields);
+            if ("strand" in datum) {
+                datum.strand = normalizeGenomicStrand(datum.strand);
+            }
+            return datum;
+        };
+
         return {
             attachFields: createDescriptorFieldAttacher(descriptor.fields),
             bbi,
-            parseLine,
+            parseLine: normalizeParseLine,
             url: descriptor.url,
         };
     }

--- a/packages/core/src/data/sources/lazy/bigBedSource.test.js
+++ b/packages/core/src/data/sources/lazy/bigBedSource.test.js
@@ -11,6 +11,8 @@ const featuresByUrl = new Map();
 const requestedIntervals = [];
 /** @type {Set<string>} */
 const failingHeaderUrls = new Set();
+/** @type {Map<string, any>} */
+const autoSqlByUrl = new Map();
 
 vi.mock("generic-filehandle2", () => ({
     RemoteFile: class RemoteFile {
@@ -24,14 +26,23 @@ vi.mock("generic-filehandle2", () => ({
 
 vi.mock("@gmod/bed", () => ({
     default: class Bed {
+        /** @param {{ autoSql?: any }} [options] */
+        constructor(options = {}) {
+            this.autoSql = options.autoSql;
+        }
+
         /** @param {string} line */
         parseLine(line) {
-            const [chrom, start, end, name] = line.split("\t");
+            const [chrom, start, end, name, score, strand] = line.split("\t");
             return {
                 chrom,
                 chromStart: Number(start),
                 chromEnd: Number(end),
                 name,
+                ...(score === undefined ? {} : { score: Number(score) }),
+                ...(strand === undefined
+                    ? {}
+                    : { strand: strand == "+" ? 1 : strand == "-" ? -1 : 0 }),
             };
         }
     },
@@ -48,7 +59,9 @@ vi.mock("@gmod/bbi", () => ({
             if (failingHeaderUrls.has(this.url)) {
                 throw new Error("Missing BigBed");
             }
-            return /** @type {{ autoSql: any }} */ ({ autoSql: undefined });
+            return /** @type {{ autoSql: any }} */ ({
+                autoSql: autoSqlByUrl.get(this.url),
+            });
         }
 
         /**
@@ -135,6 +148,7 @@ describe("BigBedSource", () => {
         openedUrls.length = 0;
         requestedIntervals.length = 0;
         failingHeaderUrls.clear();
+        autoSqlByUrl.clear();
         featuresByUrl.clear();
         featuresByUrl.set("https://example.org/spec/features/A.bb", [
             { start: 1, end: 2, rest: "feature A" },
@@ -216,6 +230,75 @@ describe("BigBedSource", () => {
             },
         ]);
         expect(readinessAtCompletion).toEqual([true]);
+    });
+
+    it("normalizes numeric strands from the fallback BED parser", async () => {
+        featuresByUrl.set("https://example.org/spec/fallback.bb", [
+            { start: 1, end: 2, rest: "fallback\t5\t-" },
+        ]);
+        const source = new BigBedSource(
+            {
+                type: "bigbed",
+                debounceMode: "domain",
+                url: "fallback.bb",
+            },
+            /** @type {any} */ (createViewStub())
+        );
+        const collector = new Collector();
+        source.addChild(collector);
+
+        await /** @type {any} */ (source).initializedPromise;
+        await source.loadInterval([0, 100]);
+
+        expect([...collector.getData()]).toEqual([
+            {
+                chrom: "chr1",
+                chromStart: 1,
+                chromEnd: 2,
+                name: "fallback",
+                score: 5,
+                strand: "-",
+            },
+        ]);
+    });
+
+    it("normalizes string strands from the fast AutoSQL parser", async () => {
+        const url = "https://example.org/spec/fast.bb";
+        autoSqlByUrl.set(url, {
+            fields: [
+                { name: "chrom", type: "string", isNumeric: false },
+                { name: "chromStart", type: "uint", isNumeric: true },
+                { name: "chromEnd", type: "uint", isNumeric: true },
+                { name: "name", type: "string", isNumeric: false },
+                { name: "score", type: "uint", isNumeric: true },
+                { name: "strand", type: "char", isNumeric: false },
+            ],
+        });
+        featuresByUrl.set(url, [{ start: 1, end: 2, rest: "fast\t5\t+" }]);
+        const source = new BigBedSource(
+            {
+                type: "bigbed",
+                debounceMode: "domain",
+                url: "fast.bb",
+            },
+            /** @type {any} */ (createViewStub())
+        );
+        const collector = new Collector();
+        source.addChild(collector);
+
+        await /** @type {any} */ (source).initializedPromise;
+        await source.loadInterval([0, 100]);
+
+        expect([...collector.getData()]).toEqual([
+            {
+                chrom: "chr1",
+                chromStart: 1,
+                chromEnd: 2,
+                name: "fast",
+                score: 5,
+                strand: "+",
+            },
+        ]);
     });
 
     it("skips failed template URLs when configured", async () => {

--- a/packages/core/src/data/sources/lazy/gff3Source.js
+++ b/packages/core/src/data/sources/lazy/gff3Source.js
@@ -1,8 +1,9 @@
 import { registerBuiltInLazyDataSource } from "./lazyDataSourceRegistry.js";
 import TabixSource from "./tabixSource.js";
+import { normalizeGenomicStrand } from "../../formats/genomicStrand.js";
 
 /**
- * @extends {TabixSource<import("gff-nostream").GFF3Feature, import("gff-nostream")>}
+ * @extends {TabixSource<import("./gff3Types.js").Gff3FeatureDatum, typeof import("gff-nostream")>}
  */
 export default class Gff3Source extends TabixSource {
     get label() {
@@ -19,13 +20,103 @@ export default class Gff3Source extends TabixSource {
 
     /**
      * @param {string[]} lines
-     * @param {import("gff-nostream")} gff
+     * @param {typeof import("gff-nostream")} gff
      */
     _parseFeatures(lines, gff) {
-        const features = gff.parseStringSync(lines.join("\n"));
-
-        return features;
+        return adaptGff3Features(gff.parseLines(lines));
     }
+}
+
+/**
+ * Adapts parser-native GFF3 features recursively while preserving shared
+ * object identity for legitimate multi-parent relationships.
+ *
+ * @param {import("gff-nostream").GffFeature[]} features
+ * @returns {import("./gff3Types.js").Gff3FeatureDatum[]}
+ */
+export function adaptGff3Features(features) {
+    /** @type {WeakMap<import("gff-nostream").GffFeature, import("./gff3Types.js").Gff3FeatureDatum>} */
+    const adapted = new WeakMap();
+    return adaptFeatureList(features, adapted);
+}
+
+const builtInFields = new Set([
+    "refName",
+    "source",
+    "type",
+    "start",
+    "end",
+    "score",
+    "strand",
+    "phase",
+    "subfeatures",
+]);
+
+/**
+ * @param {import("gff-nostream").GffFeature[]} features
+ * @param {WeakMap<import("gff-nostream").GffFeature, import("./gff3Types.js").Gff3FeatureDatum>} adapted
+ */
+function adaptFeatureList(features, adapted) {
+    /** @type {import("./gff3Types.js").Gff3FeatureDatum[]} */
+    const result = [];
+    const seen = new Set();
+
+    for (const feature of features) {
+        if (!seen.has(feature)) {
+            seen.add(feature);
+            result.push(adaptGff3Feature(feature, adapted));
+        }
+    }
+
+    return result;
+}
+
+/**
+ * @param {import("gff-nostream").GffFeature} feature
+ * @param {WeakMap<import("gff-nostream").GffFeature, import("./gff3Types.js").Gff3FeatureDatum>} adapted
+ * @returns {import("./gff3Types.js").Gff3FeatureDatum}
+ */
+function adaptGff3Feature(feature, adapted) {
+    const cached = adapted.get(feature);
+    if (cached) {
+        return cached;
+    }
+
+    /** @type {import("./gff3Types.js").Gff3FeatureDatum} */
+    const result = {
+        chrom: feature.refName,
+        source: feature.source,
+        type: feature.type,
+        start: feature.start,
+        end: feature.end,
+        score: feature.score,
+        strand: normalizeGenomicStrand(feature.strand),
+        phase: feature.phase,
+        subfeatures: [],
+    };
+    adapted.set(feature, result);
+
+    let chromAttribute;
+    let hasChromAttribute = false;
+    for (const [key, value] of Object.entries(feature)) {
+        if (key == "chrom") {
+            chromAttribute = value;
+            hasChromAttribute = true;
+        } else if (!builtInFields.has(key)) {
+            result[key] = value;
+        }
+    }
+
+    if (hasChromAttribute) {
+        let suffix = 2;
+        while (`chrom${suffix}` in result) {
+            suffix++;
+        }
+        result[`chrom${suffix}`] = chromAttribute;
+    }
+
+    result.subfeatures = adaptFeatureList(feature.subfeatures, adapted);
+    return result;
 }
 
 /**

--- a/packages/core/src/data/sources/lazy/gff3Source.test.js
+++ b/packages/core/src/data/sources/lazy/gff3Source.test.js
@@ -1,0 +1,91 @@
+import { parseLines } from "gff-nostream";
+import { describe, expect, it } from "vitest";
+import { adaptGff3Features } from "./gff3Source.js";
+
+describe("adaptGff3Features", () => {
+    it("adapts coordinates, strands, attributes, and nested features", () => {
+        const features = adaptGff3Features(
+            parseLines([
+                "chr1\tsource\tgene\t101\t200\t.\t+\t.\tID=gene1;Name=Gene;Alias=a,b;start=attributeStart;chrom=attributeChrom;chrom2=existingChrom2",
+                "chr1\tsource\tmRNA\t111\t190\t.\t-\t.\tID=tx1;Parent=gene1;gene_name=Gene",
+                "chr1\tsource\texon\t121\t130\t.\t.\t.\tID=exon1;Parent=tx1;exon_number=1",
+            ])
+        );
+
+        expect(features).toHaveLength(1);
+        expect(features[0]).toMatchObject({
+            chrom: "chr1",
+            source: "source",
+            type: "gene",
+            start: 100,
+            end: 200,
+            strand: "+",
+            id: "gene1",
+            name: "Gene",
+            alias: ["a", "b"],
+            start2: "attributeStart",
+            chrom2: "existingChrom2",
+            chrom3: "attributeChrom",
+        });
+
+        const transcript = features[0].subfeatures[0];
+        expect(transcript).toMatchObject({
+            chrom: "chr1",
+            start: 110,
+            end: 190,
+            strand: "-",
+            id: "tx1",
+            parent: "gene1",
+            gene_name: "Gene",
+        });
+        expect(transcript.subfeatures[0]).toMatchObject({
+            chrom: "chr1",
+            start: 120,
+            end: 130,
+            strand: null,
+            id: "exon1",
+            parent: "tx1",
+            exon_number: "1",
+        });
+        expect("refName" in features[0]).toBe(false);
+    });
+
+    it("preserves multi-parent identity without duplicate attachment", () => {
+        const features = adaptGff3Features(
+            parseLines([
+                "chr1\t.\tgene\t1\t100\t.\t+\t.\tID=gene1",
+                "chr1\t.\tgene\t201\t300\t.\t+\t.\tID=gene2",
+                "chr1\t.\texon\t50\t60\t.\t+\t.\tID=shared;Parent=gene1,gene2",
+                "chr1\t.\texon\t70\t80\t.\t+\t.\tID=once;Parent=gene1,gene1",
+            ])
+        );
+
+        expect(features).toHaveLength(2);
+        expect(features[0].subfeatures).toHaveLength(2);
+        expect(features[1].subfeatures).toHaveLength(1);
+        expect(features[0].subfeatures[0]).toBe(features[1].subfeatures[0]);
+    });
+
+    it("keeps orphan and multi-location features", () => {
+        const features = adaptGff3Features(
+            parseLines([
+                "chr1\t.\tgene\t1\t100\t.\t+\t.\tID=gene1",
+                "chr1\t.\tCDS\t10\t20\t.\t+\t0\tID=cds1;Parent=gene1",
+                "chr1\t.\tCDS\t30\t40\t.\t+\t2\tID=cds1;Parent=gene1",
+                "chr1\t.\texon\t50\t60\t.\t-\t.\tID=orphan;Parent=outside",
+            ])
+        );
+
+        expect(features).toHaveLength(2);
+        expect(features[0].subfeatures).toHaveLength(2);
+        expect(features[0].subfeatures[0]).not.toBe(features[0].subfeatures[1]);
+        expect(features[0].subfeatures.map((feature) => feature.phase)).toEqual(
+            [0, 2]
+        );
+        expect(features[1]).toMatchObject({
+            id: "orphan",
+            parent: "outside",
+            strand: "-",
+        });
+    });
+});

--- a/packages/core/src/data/sources/lazy/gff3Types.d.ts
+++ b/packages/core/src/data/sources/lazy/gff3Types.d.ts
@@ -1,0 +1,15 @@
+export type Gff3Strand = "+" | "-" | null;
+
+/** A GFF3 feature after adaptation to GenomeSpy's public source contract. */
+export interface Gff3FeatureDatum {
+    chrom: string;
+    source: string | null;
+    type: string | null;
+    start: number;
+    end: number;
+    score?: number;
+    strand: Gff3Strand;
+    phase?: number;
+    subfeatures: Gff3FeatureDatum[];
+    [key: string]: unknown;
+}

--- a/packages/core/src/data/sources/lazy/gmodChunkCache.js
+++ b/packages/core/src/data/sources/lazy/gmodChunkCache.js
@@ -1,0 +1,15 @@
+import { SharedBudget } from "@gmod/shared-read-cache";
+
+/** Shared retention ceiling for decompressed BAM and Tabix chunks. */
+export const GMOD_CHUNK_CACHE_BUDGET_BYTES = 1024 * 1024 * 1024;
+
+/**
+ * BAM and Tabix weigh cache entries in decompressed bytes, so they can safely
+ * share one global LRU budget instead of multiplying the per-file default.
+ * Members are weakly held and individual sources clear their caches on
+ * disposal. Reads in flight and each cache's last settled entry may exceed the
+ * retention ceiling, as documented by @gmod/shared-read-cache.
+ */
+export const gmodChunkCacheBudget = new SharedBudget(
+    GMOD_CHUNK_CACHE_BUDGET_BYTES
+);

--- a/packages/core/src/data/sources/lazy/tabixSource.js
+++ b/packages/core/src/data/sources/lazy/tabixSource.js
@@ -115,8 +115,16 @@ export default class TabixSource extends SingleAxisWindowedSource {
             setLoadingStatus: (status, detail) =>
                 this.setLoadingStatus(status, detail),
             loadModules: loadTabixModules,
-            createHandle: (descriptor, { TabixIndexedFile, RemoteFile }) =>
-                this.#createHandle(descriptor, TabixIndexedFile, RemoteFile),
+            createHandle: (
+                descriptor,
+                { TabixIndexedFile, RemoteFile, gmodChunkCacheBudget }
+            ) =>
+                this.#createHandle(
+                    descriptor,
+                    TabixIndexedFile,
+                    RemoteFile,
+                    gmodChunkCacheBudget
+                ),
         });
 
         const addChrPrefix = withoutExprRef(this.params.addChrPrefix);
@@ -139,14 +147,21 @@ export default class TabixSource extends SingleAxisWindowedSource {
      * @param {import("../urlDescriptor.js").UrlDescriptor} descriptor
      * @param {typeof import("@gmod/tabix").TabixIndexedFile} TabixIndexedFile
      * @param {typeof import("generic-filehandle2").RemoteFile} RemoteFile
+     * @param {import("@gmod/shared-read-cache").SharedBudget} gmodChunkCacheBudget
      * @returns {Promise<TabixHandle>}
      */
-    async #createHandle(descriptor, TabixIndexedFile, RemoteFile) {
+    async #createHandle(
+        descriptor,
+        TabixIndexedFile,
+        RemoteFile,
+        gmodChunkCacheBudget
+    ) {
         const tbiIndex = new TabixIndexedFile({
             filehandle: new RemoteFile(descriptor.url),
             tbiFilehandle: new RemoteFile(
                 descriptor.indexUrl ?? descriptor.url + ".tbi"
             ),
+            chunkCacheBudget: gmodChunkCacheBudget,
         });
         const [headerLines, rawReferenceNames] = await Promise.all([
             tbiIndex.getHeaderLines(),
@@ -283,11 +298,13 @@ export default class TabixSource extends SingleAxisWindowedSource {
 }
 
 async function loadTabixModules() {
-    const [{ TabixIndexedFile }, { RemoteFile }] = await Promise.all([
-        import("@gmod/tabix"),
-        import("generic-filehandle2"),
-    ]);
-    return { TabixIndexedFile, RemoteFile };
+    const [{ TabixIndexedFile }, { RemoteFile }, { gmodChunkCacheBudget }] =
+        await Promise.all([
+            import("@gmod/tabix"),
+            import("generic-filehandle2"),
+            import("./gmodChunkCache.js"),
+        ]);
+    return { TabixIndexedFile, RemoteFile, gmodChunkCacheBudget };
 }
 
 /**

--- a/packages/core/src/data/sources/lazy/tabixSource.js
+++ b/packages/core/src/data/sources/lazy/tabixSource.js
@@ -20,8 +20,9 @@ export default class TabixSource extends SingleAxisWindowedSource {
      * @prop {import("@gmod/tabix").TabixIndexedFile} tbiIndex
      * @prop {Record<string, import("../../../spec/channel.js").Scalar>} [fields]
      * @prop {P} parserContext
+     * @prop {Map<string, string>} queryToRawReferenceName
+     * @prop {string[]} rawReferenceNames
      * @prop {string} url
-     * @prop {((refSeq: string) => string) | undefined} renameRefSeqs
      */
 
     /** @type {UrlDescriptorState<TabixHandle>} */
@@ -113,60 +114,52 @@ export default class TabixSource extends SingleAxisWindowedSource {
             clearData: () => this.invalidateData(),
             setLoadingStatus: (status, detail) =>
                 this.setLoadingStatus(status, detail),
-            loadModules: async () => {
-                const { TabixIndexedFile, RemoteFile } =
-                    await loadTabixModules();
-                const addChrPrefix = withoutExprRef(this.params.addChrPrefix);
-
-                const renameRefSeqs =
-                    addChrPrefix === true
-                        ? (/** @type {string} */ refSeq) => "chr" + refSeq
-                        : addChrPrefix
-                          ? (/** @type {string} */ refSeq) =>
-                                addChrPrefix + refSeq
-                          : undefined;
-
-                return { TabixIndexedFile, RemoteFile, renameRefSeqs };
-            },
-            createHandle: (
-                descriptor,
-                { TabixIndexedFile, RemoteFile, renameRefSeqs }
-            ) =>
-                this.#createHandle(
-                    descriptor,
-                    TabixIndexedFile,
-                    RemoteFile,
-                    renameRefSeqs
-                ),
+            loadModules: loadTabixModules,
+            createHandle: (descriptor, { TabixIndexedFile, RemoteFile }) =>
+                this.#createHandle(descriptor, TabixIndexedFile, RemoteFile),
         });
+
+        const addChrPrefix = withoutExprRef(this.params.addChrPrefix);
+        for (const handle of this.#descriptorState.handles) {
+            try {
+                handle.queryToRawReferenceName = createReferenceNameMap(
+                    handle.rawReferenceNames,
+                    addChrPrefix
+                );
+            } catch (error) {
+                throw new Error(
+                    `Cannot map references for Tabix file ${handle.url}: ${/** @type {Error} */ (error).message}`,
+                    { cause: error }
+                );
+            }
+        }
     }
 
     /**
      * @param {import("../urlDescriptor.js").UrlDescriptor} descriptor
      * @param {typeof import("@gmod/tabix").TabixIndexedFile} TabixIndexedFile
      * @param {typeof import("generic-filehandle2").RemoteFile} RemoteFile
-     * @param {((refSeq: string) => string) | undefined} renameRefSeqs
      * @returns {Promise<TabixHandle>}
      */
-    async #createHandle(
-        descriptor,
-        TabixIndexedFile,
-        RemoteFile,
-        renameRefSeqs
-    ) {
+    async #createHandle(descriptor, TabixIndexedFile, RemoteFile) {
         const tbiIndex = new TabixIndexedFile({
             filehandle: new RemoteFile(descriptor.url),
             tbiFilehandle: new RemoteFile(
                 descriptor.indexUrl ?? descriptor.url + ".tbi"
             ),
         });
-        const header = await tbiIndex.getHeader();
+        const [headerLines, rawReferenceNames] = await Promise.all([
+            tbiIndex.getHeaderLines(),
+            tbiIndex.getReferenceSequenceNames(),
+        ]);
+        this.registerDisposer(() => tbiIndex.clearChunkCache());
 
         return {
             tbiIndex,
             fields: descriptor.fields,
-            parserContext: await this._createParser(header, tbiIndex),
-            renameRefSeqs,
+            parserContext: await this._createParser(headerLines.join("\n")),
+            queryToRawReferenceName: new Map(),
+            rawReferenceNames,
             url: descriptor.url,
         };
     }
@@ -186,10 +179,19 @@ export default class TabixSource extends SingleAxisWindowedSource {
                     handles.map(async (handle) => {
                         /** @type {string[]} */
                         const lines = [];
+                        const rawReferenceName =
+                            handle.queryToRawReferenceName.get(
+                                discreteInterval.chrom
+                            );
+
+                        if (!rawReferenceName) {
+                            throw new Error(
+                                `Reference "${discreteInterval.chrom}" is not available in Tabix file ${handle.url}.`
+                            );
+                        }
 
                         await handle.tbiIndex.getLines(
-                            handle.renameRefSeqs?.(discreteInterval.chrom) ??
-                                discreteInterval.chrom,
+                            rawReferenceName,
                             discreteInterval.startPos,
                             discreteInterval.endPos,
                             {
@@ -221,31 +223,11 @@ export default class TabixSource extends SingleAxisWindowedSource {
 
     /**
      * @param {string} header
-     * @param {import("@gmod/tabix").TabixIndexedFile} tbiIndex
      * @protected
      * @returns {Promise<P>}
      */
-    async _createParser(header, tbiIndex) {
+    async _createParser(header) {
         return /** @type {P} */ (undefined);
-    }
-
-    /**
-     * Read a prefix of the Tabix file and decode it as text.
-     *
-     * @param {import("@gmod/tabix").TabixIndexedFile} tbiIndex
-     * @returns {Promise<string>}
-     * @protected
-     */
-    async _readFilePrefix(tbiIndex) {
-        const { maxBlockSize } = await tbiIndex.getMetadata();
-        const tabixIndex = /** @type {any} */ (tbiIndex);
-        const compressedPrefix = await tabixIndex.filehandle.read(
-            maxBlockSize,
-            0
-        );
-        const { unzip } = await import("@gmod/bgzf-filehandle");
-        const bytes = await unzip(compressedPrefix);
-        return new TextDecoder("utf-8").decode(bytes);
     }
 
     /**
@@ -306,4 +288,34 @@ async function loadTabixModules() {
         import("generic-filehandle2"),
     ]);
     return { TabixIndexedFile, RemoteFile };
+}
+
+/**
+ * Builds the mapping from GenomeSpy query names to reference names stored in a
+ * Tabix index. Prefixing is idempotent so files using `1` and `chr1` can be
+ * queried together, while ambiguous names within one file fail immediately.
+ *
+ * @param {string[]} rawReferenceNames
+ * @param {boolean | string} addChrPrefix
+ * @returns {Map<string, string>}
+ */
+export function createReferenceNameMap(rawReferenceNames, addChrPrefix) {
+    const prefix = addChrPrefix === true ? "chr" : addChrPrefix || "";
+    const result = new Map();
+
+    for (const rawName of rawReferenceNames) {
+        const queryName =
+            prefix && !rawName.startsWith(prefix) ? prefix + rawName : rawName;
+        const existing = result.get(queryName);
+
+        if (existing) {
+            throw new Error(
+                `Tabix reference names "${existing}" and "${rawName}" both map to "${queryName}".`
+            );
+        }
+
+        result.set(queryName, rawName);
+    }
+
+    return result;
 }

--- a/packages/core/src/data/sources/lazy/tabixSource.test.js
+++ b/packages/core/src/data/sources/lazy/tabixSource.test.js
@@ -3,6 +3,7 @@ import Collector from "../../collector.js";
 import ViewParamRuntime from "../../../paramRuntime/viewParamRuntime.js";
 import RegexFoldTransform from "../../transforms/regexFold.js";
 import TabixTsvSource from "./tabixTsvSource.js";
+import { gmodChunkCacheBudget } from "./gmodChunkCache.js";
 import { createReferenceNameMap } from "./tabixSource.js";
 
 /** @type {Map<string, string[]>} */
@@ -19,6 +20,10 @@ const headerByUrl = new Map();
 const referenceNamesByUrl = new Map();
 /** @type {Set<string>} */
 const failingHeaderUrls = new Set();
+/** @type {Record<string, unknown>[]} */
+const tabixConstructorOptions = [];
+/** @type {string[]} */
+const clearedChunkCacheUrls = [];
 
 vi.mock("generic-filehandle2", () => ({
     RemoteFile: class RemoteFile {
@@ -31,10 +36,11 @@ vi.mock("generic-filehandle2", () => ({
 
 vi.mock("@gmod/tabix", () => ({
     TabixIndexedFile: class TabixIndexedFile {
-        /** @param {{ filehandle: { url: string }, tbiFilehandle: { url: string } }} options */
+        /** @param {{ filehandle: { url: string }, tbiFilehandle: { url: string }, chunkCacheBudget: unknown }} options */
         constructor(options) {
             this.url = options.filehandle.url;
             this.indexUrl = options.tbiFilehandle.url;
+            tabixConstructorOptions.push(options);
             openedUrls.push(this.url);
             indexUrlByUrl.set(this.url, this.indexUrl);
         }
@@ -53,7 +59,7 @@ vi.mock("@gmod/tabix", () => ({
         }
 
         clearChunkCache() {
-            // No-op in the source adapter mock.
+            clearedChunkCacheUrls.push(this.url);
         }
 
         /**
@@ -144,6 +150,8 @@ describe("TabixSource", () => {
         headerByUrl.clear();
         referenceNamesByUrl.clear();
         failingHeaderUrls.clear();
+        tabixConstructorOptions.length = 0;
+        clearedChunkCacheUrls.length = 0;
         linesByUrl.set("variants/ovarian.vcf.gz", ["chr1\t1\t2\tA"]);
         linesByUrl.set("variants/breast.vcf.gz", ["chr1\t3\t4\tB"]);
     });
@@ -197,6 +205,30 @@ describe("TabixSource", () => {
                 end: 4,
                 value: "B",
             },
+        ]);
+    });
+
+    it("shares the bounded chunk budget and clears caches on disposal", async () => {
+        const source = new TabixTsvSource(
+            /** @type {any} */ ({
+                type: "tabix",
+                debounceMode: "domain",
+                url: ["variants/ovarian.vcf.gz", "variants/breast.vcf.gz"],
+            }),
+            /** @type {any} */ (createViewStub())
+        );
+
+        await /** @type {any} */ (source).initializedPromise;
+
+        expect(
+            tabixConstructorOptions.map((options) => options.chunkCacheBudget)
+        ).toEqual([gmodChunkCacheBudget, gmodChunkCacheBudget]);
+
+        source.dispose();
+        source.dispose();
+        expect(clearedChunkCacheUrls).toEqual([
+            "variants/ovarian.vcf.gz",
+            "variants/breast.vcf.gz",
         ]);
     });
 

--- a/packages/core/src/data/sources/lazy/tabixSource.test.js
+++ b/packages/core/src/data/sources/lazy/tabixSource.test.js
@@ -3,6 +3,7 @@ import Collector from "../../collector.js";
 import ViewParamRuntime from "../../../paramRuntime/viewParamRuntime.js";
 import RegexFoldTransform from "../../transforms/regexFold.js";
 import TabixTsvSource from "./tabixTsvSource.js";
+import { createReferenceNameMap } from "./tabixSource.js";
 
 /** @type {Map<string, string[]>} */
 const linesByUrl = new Map();
@@ -14,6 +15,8 @@ const openedUrls = [];
 const requestedIntervals = [];
 /** @type {Map<string, string>} */
 const headerByUrl = new Map();
+/** @type {Map<string, string[]>} */
+const referenceNamesByUrl = new Map();
 /** @type {Set<string>} */
 const failingHeaderUrls = new Set();
 
@@ -36,11 +39,21 @@ vi.mock("@gmod/tabix", () => ({
             indexUrlByUrl.set(this.url, this.indexUrl);
         }
 
-        async getHeader() {
+        async getHeaderLines() {
             if (failingHeaderUrls.has(this.url)) {
                 throw new Error("Missing Tabix file");
             }
-            return headerByUrl.get(this.url) ?? "#chrom\tstart\tend\tvalue";
+            return (
+                headerByUrl.get(this.url) ?? "#chrom\tstart\tend\tvalue"
+            ).split(/\r?\n/);
+        }
+
+        async getReferenceSequenceNames() {
+            return referenceNamesByUrl.get(this.url) ?? ["chr1"];
+        }
+
+        clearChunkCache() {
+            // No-op in the source adapter mock.
         }
 
         /**
@@ -71,6 +84,7 @@ function createViewStub() {
         "ovarian",
         "breast",
     ]);
+    const setPrefix = paramRuntime.allocateSetter("prefix", false);
 
     const genome = {
         totalSize: 1000,
@@ -100,6 +114,7 @@ function createViewStub() {
 
     return {
         paramRuntime,
+        setPrefix,
         setVisibleCancers,
         loadingStatuses,
         getBaseUrl: () => "",
@@ -127,6 +142,7 @@ describe("TabixSource", () => {
         openedUrls.length = 0;
         requestedIntervals.length = 0;
         headerByUrl.clear();
+        referenceNamesByUrl.clear();
         failingHeaderUrls.clear();
         linesByUrl.set("variants/ovarian.vcf.gz", ["chr1\t1\t2\tA"]);
         linesByUrl.set("variants/breast.vcf.gz", ["chr1\t3\t4\tB"]);
@@ -184,13 +200,68 @@ describe("TabixSource", () => {
         ]);
     });
 
-    it("applies addChrPrefix when querying the Tabix index", async () => {
+    it("maps prefixed assembly queries to raw file references without rewriting rows", async () => {
+        referenceNamesByUrl.set("variants/ovarian.vcf.gz", ["1"]);
+        linesByUrl.set("variants/ovarian.vcf.gz", ["1\t1\t2\tA"]);
+
         const source = new TabixTsvSource(
             /** @type {any} */ ({
                 type: "tabix",
                 debounceMode: "domain",
-                addChrPrefix: "ref-",
-                url: "variants/prefixed.vcf.gz",
+                url: "variants/ovarian.vcf.gz",
+                addChrPrefix: true,
+            }),
+            /** @type {any} */ (createViewStub())
+        );
+        const collector = new Collector();
+        source.addChild(collector);
+
+        await /** @type {any} */ (source).initializedPromise;
+        await source.loadInterval([0, 100]);
+
+        expect(requestedIntervals).toEqual([
+            { chrom: "1", start: 0, end: 100 },
+        ]);
+        expect([...collector.getData()]).toEqual([
+            { chrom: "1", start: 1, end: 2, value: "A" },
+        ]);
+    });
+
+    it("updates query mappings when reactive prefixing changes", async () => {
+        referenceNamesByUrl.set("variants/ovarian.vcf.gz", ["1"]);
+        const view = createViewStub();
+        const source = new TabixTsvSource(
+            /** @type {any} */ ({
+                type: "tabix",
+                debounceMode: "domain",
+                url: "variants/ovarian.vcf.gz",
+                addChrPrefix: { expr: "prefix" },
+            }),
+            /** @type {any} */ (view)
+        );
+
+        await /** @type {any} */ (source).initializedPromise;
+        view.setPrefix(true);
+        await Promise.resolve();
+        await /** @type {any} */ (source).initializedPromise;
+        await source.loadInterval([0, 100]);
+
+        expect(openedUrls).toEqual(["variants/ovarian.vcf.gz"]);
+        expect(requestedIntervals).toEqual([
+            { chrom: "1", start: 0, end: 100 },
+        ]);
+    });
+
+    it("loads files with bare and already-prefixed reference names together", async () => {
+        referenceNamesByUrl.set("variants/ovarian.vcf.gz", ["1"]);
+        referenceNamesByUrl.set("variants/breast.vcf.gz", ["chr1"]);
+
+        const source = new TabixTsvSource(
+            /** @type {any} */ ({
+                type: "tabix",
+                debounceMode: "domain",
+                url: ["variants/ovarian.vcf.gz", "variants/breast.vcf.gz"],
+                addChrPrefix: true,
             }),
             /** @type {any} */ (createViewStub())
         );
@@ -199,8 +270,45 @@ describe("TabixSource", () => {
         await source.loadInterval([0, 100]);
 
         expect(requestedIntervals).toEqual([
-            { chrom: "ref-chr1", start: 0, end: 100 },
+            { chrom: "1", start: 0, end: 100 },
+            { chrom: "chr1", start: 0, end: 100 },
         ]);
+    });
+
+    it("fails when prefixing makes file reference names ambiguous", async () => {
+        referenceNamesByUrl.set("variants/ovarian.vcf.gz", ["1", "chr1"]);
+
+        const source = new TabixTsvSource(
+            /** @type {any} */ ({
+                type: "tabix",
+                debounceMode: "domain",
+                url: "variants/ovarian.vcf.gz",
+                addChrPrefix: true,
+            }),
+            /** @type {any} */ (createViewStub())
+        );
+
+        await expect(
+            /** @type {any} */ (source).initializedPromise
+        ).rejects.toThrow('both map to "chr1"');
+    });
+
+    it("fails clearly for an unavailable query reference", async () => {
+        referenceNamesByUrl.set("variants/ovarian.vcf.gz", ["chr2"]);
+
+        const source = new TabixTsvSource(
+            /** @type {any} */ ({
+                type: "tabix",
+                debounceMode: "domain",
+                url: "variants/ovarian.vcf.gz",
+            }),
+            /** @type {any} */ (createViewStub())
+        );
+
+        await /** @type {any} */ (source).initializedPromise;
+        await expect(source.loadInterval([0, 100])).rejects.toThrow(
+            'Reference "chr1" is not available'
+        );
     });
 
     it("can expand URL templates without attaching fields", async () => {
@@ -231,6 +339,37 @@ describe("TabixSource", () => {
                 start: 5,
                 end: 6,
                 value: "C",
+            },
+        ]);
+    });
+
+    it("uses an uncommented header row reported by the Tabix index", async () => {
+        headerByUrl.set(
+            "variants/ovarian.vcf.gz",
+            "chromosome\tbegin\tfinish\tlabel"
+        );
+        linesByUrl.set("variants/ovarian.vcf.gz", ["chr1\t5\t6\tA"]);
+
+        const source = new TabixTsvSource(
+            /** @type {any} */ ({
+                type: "tabix",
+                debounceMode: "domain",
+                url: "variants/ovarian.vcf.gz",
+            }),
+            /** @type {any} */ (createViewStub())
+        );
+        const collector = new Collector();
+        source.addChild(collector);
+
+        await /** @type {any} */ (source).initializedPromise;
+        await source.loadInterval([0, 100]);
+
+        expect([...collector.getData()]).toEqual([
+            {
+                chromosome: "chr1",
+                begin: 5,
+                finish: 6,
+                label: "A",
             },
         ]);
     });
@@ -412,5 +551,19 @@ describe("TabixSource", () => {
         expect(openedUrls).toEqual([]);
         expect(view.loadingStatuses.at(-1)).toEqual({ status: "complete" });
         expect([...collector.getData()]).toEqual([]);
+    });
+});
+
+describe("createReferenceNameMap", () => {
+    it("adds prefixes idempotently", () => {
+        expect(createReferenceNameMap(["1"], true)).toEqual(
+            new Map([["chr1", "1"]])
+        );
+        expect(createReferenceNameMap(["chr1"], true)).toEqual(
+            new Map([["chr1", "chr1"]])
+        );
+        expect(createReferenceNameMap(["1"], "GRCh38_")).toEqual(
+            new Map([["GRCh38_1", "1"]])
+        );
     });
 });

--- a/packages/core/src/data/sources/lazy/tabixTsvSource.js
+++ b/packages/core/src/data/sources/lazy/tabixTsvSource.js
@@ -111,10 +111,9 @@ export default class TabixTsvSource extends TabixSource {
 
     /**
      * @param {string} header
-     * @param {import("@gmod/tabix").TabixIndexedFile} tbiIndex
      * @returns {Promise<string[]>}
      */
-    async _createParser(header, tbiIndex) {
+    async _createParser(header) {
         const params =
             /** @type {import("../../../spec/data.js").TabixTsvData} */ (
                 this.params
@@ -122,11 +121,7 @@ export default class TabixTsvSource extends TabixSource {
         const columns = withoutExprRef(params.columns);
         let fileColumns = columns ?? extractTabixTsvColumns(header);
 
-        if (!fileColumns?.length) {
-            fileColumns = extractTabixTsvColumnsFromFirstLine(
-                await this._readFilePrefix(tbiIndex)
-            );
-        }
+        fileColumns ??= extractTabixTsvColumnsFromFirstLine(header);
 
         if (!fileColumns?.length) {
             throw new Error(

--- a/packages/core/src/data/sources/urlSource.test.js
+++ b/packages/core/src/data/sources/urlSource.test.js
@@ -97,7 +97,7 @@ test("UrlSource reads BED using format.type bed", async () => {
             chromStart: 0,
             chromEnd: 10,
             name: "feature",
-            strand: 0,
+            strand: null,
         },
     ]);
 });
@@ -127,8 +127,8 @@ test("UrlSource reads BEDPE using format.type bedpe", async () => {
             end2: 40,
             name: "eventA",
             score: 5,
-            strand1: 1,
-            strand2: -1,
+            strand1: "+",
+            strand2: "-",
         },
     ]);
 });

--- a/packages/core/src/spec/data.d.ts
+++ b/packages/core/src/spec/data.d.ts
@@ -651,6 +651,11 @@ export interface TabixTsvData extends TabixData {
     parse?: Parse | null;
 }
 
+/**
+ * Loads tabix-indexed GFF3 features as zero-based, half-open hierarchical
+ * records. Attributes are lowercase top-level fields, child features are in
+ * `subfeatures`, and strand values are `"+"`, `"-"`, or `null`.
+ */
 export interface Gff3Data extends TabixData {
     type: "gff3";
 }

--- a/packages/core/src/spec/data.d.ts
+++ b/packages/core/src/spec/data.d.ts
@@ -22,12 +22,7 @@ import {
 import { ExprRef } from "./parameter.js";
 
 export type ParseValue =
-    | null
-    | string
-    | "string"
-    | "boolean"
-    | "date"
-    | "number";
+    null | string | "string" | "boolean" | "date" | "number";
 
 export interface Parse {
     [field: string]: ParseValue;
@@ -144,21 +139,12 @@ export type DataFormat =
 export type DataFormatType = "json" | "csv" | "tsv" | "dsv" | string;
 
 export type DataSource =
-    | UrlData
-    | InlineData
-    | NamedData
-    | DynamicCallbackData
-    | LazyData;
+    UrlData | InlineData | NamedData | DynamicCallbackData | LazyData;
 
 export type Data = DataSource | Generator;
 
 export type InlineDataset =
-    | number[]
-    | string[]
-    | boolean[]
-    | object[]
-    | string
-    | object;
+    number[] | string[] | boolean[] | object[] | string | object;
 
 export interface DataBase {
     /**
@@ -626,8 +612,10 @@ export interface TabixData extends DebouncedData {
     indexUrl?: IndexUrlSourceRef;
 
     /**
-     * Add a `chr` (boolean) or custom (string) prefix to the chromosome names
-     * in the Tabix file.
+     * Add a `chr` (boolean) or custom (string) prefix when mapping assembly
+     * query names to chromosome names in each Tabix file. Prefixing is
+     * idempotent: an existing matching prefix is not added again. Loaded record
+     * fields retain the names stored in the file.
      *
      * __Default value:__ `false`
      */

--- a/packages/embed-examples/package.json
+++ b/packages/embed-examples/package.json
@@ -15,8 +15,8 @@
     "@genome-spy/core": "^0.85.0",
     "@genome-spy/inspector": "^0.85.0",
     "@genome-spy/react-component": "^0.85.0",
-    "@gmod/indexedfasta": "^2.0.4",
-    "buffer": "^6.0.3",
+    "@gmod/indexedfasta": "^5.0.10",
+    "generic-filehandle2": "^2.3.1",
     "lit": "^3.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/embed-examples/src/dynamicFasta.js
+++ b/packages/embed-examples/src/dynamicFasta.js
@@ -1,13 +1,7 @@
 import { embed } from "@genome-spy/core/minimal";
 
 import { IndexedFasta } from "@gmod/indexedfasta";
-import { RemoteFile } from "generic-filehandle";
-
-import { Buffer } from "buffer";
-
-// Hack needed by @gmod/indexedfasta
-// TODO: Submit a PR to @gmod/indexedfasta to make this unnecessary
-window.Buffer = Buffer;
+import { RemoteFile } from "generic-filehandle2";
 
 // Use IGV's fasta files for testing
 const fasta = new IndexedFasta({

--- a/plans/indexing-and-strands/gmod-upgrades.md
+++ b/plans/indexing-and-strands/gmod-upgrades.md
@@ -218,7 +218,7 @@ and pin the normalized hierarchy through tests described in
 `source-contracts.md`.
 
 Do not add compatibility shims that reconstruct the v3 hierarchy. This is an
-intentional pre-1.0 break.
+intentional GenomeSpy 2.0 break.
 
 The dependency change and the GenomeSpy GFF adapter must be one coherent step:
 v5 changes coordinates, strand representation, attributes, and hierarchy, so
@@ -330,7 +330,7 @@ Documentation and migration: none for the raw-preserving upgrade.
 
 Tentative commit: `build(core): update GMOD VCF parser`
 
-### 5. Upgrade GFF with its v1 adapter
+### 5. Upgrade GFF with its v2 adapter
 
 Outcome: `gff-nostream` 5 and the GFF source adapter land together with the
 normalized public record contract. This closes MB-1 and MB-5 for GFF.
@@ -341,7 +341,7 @@ Affected areas and verification are shared with
 Documentation and migration: record the public hierarchy, coordinate, strand,
 attribute, and collision changes with the adapter.
 
-Tentative commit: `feat(core)!: migrate GFF3 records to the v1 contract`
+Tentative commit: `feat(core)!: migrate GFF3 records to the v2 contract`
 
 ### 6. Modernize the embedded FASTA example
 

--- a/plans/indexing-and-strands/gmod-upgrades.md
+++ b/plans/indexing-and-strands/gmod-upgrades.md
@@ -28,6 +28,7 @@ are recent.
 | `@gmod/indexedfasta` | `^5.0.2` | `5.0.7` | `5.0.10` |
 | `@gmod/tabix` | `3.2.2` | `3.2.2` | `3.8.1` |
 | `@gmod/vcf` | `^7.0.0` | `7.0.9` | `7.2.0` |
+| `@gmod/shared-read-cache` | — | — | `1.6.0` |
 | `gff-nostream` | `^3.0.2` | `3.0.11` | `5.2.1` |
 | `generic-filehandle2` | `^2.0.18` | `2.2.0` | `2.3.1` |
 
@@ -192,12 +193,14 @@ During implementation:
    comparable.
 5. Test disposal/reinitialization so stale handles do not retain cache owners.
 
-**MB-6:** Before aggregate verification, choose one of two explicit outcomes:
-(a) create and pass a bounded shared BAM/Tabix budget with a justified size and
-lifecycle, declaring `@gmod/shared-read-cache` directly; or (b) retain package
-budgets after measuring simultaneous tracks and express acceptance as a
-documented measured bound. Do not assert compliance with an unspecified
-“selected cache budget.”
+**MB-6 resolution:** Core declares `@gmod/shared-read-cache` directly and uses
+one internal 1 GiB budget for all BAM and Tabix chunk caches in the JavaScript
+realm. Both packages weigh these entries in decompressed bytes, so a shared
+budget has consistent units and lets inactive files yield entries to the
+active track. Their three-minute idle eviction remains enabled. Source
+disposal clears the corresponding cache, and the budget holds members weakly.
+The budget bounds settled retained chunks across files; reads in flight and
+each cache's last settled entry can exceed it by design.
 
 The new BGZF worker pool is an optional performance follow-up. If adopted,
 declare `@gmod/bgzf-filehandle` directly, share a bounded pool, verify worker

--- a/plans/indexing-and-strands/gmod-upgrades.md
+++ b/plans/indexing-and-strands/gmod-upgrades.md
@@ -1,0 +1,424 @@
+# GMOD Dependency Upgrades
+
+## Scope
+
+This document covers the dependency and adapter-infrastructure portion of the
+[Genomic Indexing and Strand Contracts](indexing-and-strands-plan.md)
+proposal. It prepares the source layer for the public contracts in
+[Source contracts](source-contracts.md).
+
+The MB identifiers below refer to the merge-blocker register in the
+[master plan](indexing-and-strands-plan.md#incremental-implementation-and-merge-blockers).
+They may remain open during independent package work, but all must be closed
+before merge.
+
+Versions below were current on 2026-08-14. Recheck release notes and the npm
+registry immediately before changing the lockfile, because several releases
+are recent.
+
+## Dependency inventory
+
+### Core
+
+| Package | Current declaration | Current lock resolution | Reviewed target |
+| --- | --- | --- | --- |
+| `@gmod/bam` | `^7.1.19` | `7.3.3` | `8.9.0` |
+| `@gmod/bbi` | `^9.2.0` | `9.2.1` | `11.1.0` |
+| `@gmod/bed` | `^2.1.10` | `2.2.6` | `2.2.10` |
+| `@gmod/indexedfasta` | `^5.0.2` | `5.0.7` | `5.0.10` |
+| `@gmod/tabix` | `3.2.2` | `3.2.2` | `3.8.1` |
+| `@gmod/vcf` | `^7.0.0` | `7.0.9` | `7.2.0` |
+| `gff-nostream` | `^3.0.2` | `3.0.11` | `5.2.1` |
+| `generic-filehandle2` | `^2.0.18` | `2.2.0` | `2.3.1` |
+
+### Embedded examples
+
+`packages/embed-examples` currently declares `@gmod/indexedfasta ^2.0.4`,
+which resolves to 2.1.1 and pulls the legacy `generic-filehandle`/BGZF stack.
+Upgrade it to the same IndexedFASTA 5 line as Core, declare
+`generic-filehandle2`, and remove the `buffer` dependency and global
+`window.Buffer` shim from `src/dynamicFasta.js`.
+
+### Direct-transitive dependency leak
+
+`packages/core/src/data/sources/lazy/tabixSource.js` imports
+`@gmod/bgzf-filehandle` directly even though Core does not declare it. The
+import exists only to decompress a private file-handle prefix. Replace this
+path with the current public Tabix header API. Do not add BGZF as a direct
+dependency unless GenomeSpy deliberately adopts the new worker-pool API.
+
+## Upgrade principles
+
+- Upgrade adapter tests and public package APIs before changing user-visible
+  record shapes where the package allows that separation. When an upgrade
+  necessarily changes the adapter contract, as with `gff-nostream` 5, upgrade
+  the package and adapter atomically.
+- Use public GMOD methods and documented constructor options only.
+- Preserve abort signals, debouncing, URL templates, index URL templates,
+  descriptor-attached fields, file batch boundaries, and active-set readiness.
+- Retain raw parser records until the explicit source-contract adapter step.
+- Keep exact versus caret ranges consistent with repository policy. Initially
+  keep Tabix exact at the reviewed version because its integration is sensitive
+  to minor API changes; revisit only after the new adapter has stabilized.
+- Review bundle output and browser compatibility after each major upgrade.
+
+## Tabix compatibility design
+
+### Removed `renameRefSeqs`
+
+Current `addChrPrefix` is implemented by passing `renameRefSeqs` to
+`TabixIndexedFile`. Modern Tabix removed that option after its implementation
+ceased to participate in the current index path; see the
+[upstream removal](https://github.com/GMOD/tabix-js/commit/85c5fad3a67fc82f7b94aa336a490eab9ac097ce).
+
+Implement chromosome mapping in GenomeSpy instead:
+
+1. Ask each initialized handle for its reference sequence names using the
+   current public Tabix API.
+2. Apply `addChrPrefix` to build an assembly-facing name for each raw file
+   reference.
+3. Build an immutable per-handle map from assembly-facing query name to raw
+   file name.
+4. Convert each discretized GenomeSpy interval to the raw name before calling
+   `getLines()`.
+5. Keep query-name translation separate from emitted record naming until the
+   public `chrom` policy in MB-3 is resolved; retain raw VCF `CHROM` and do not
+   guess generic TSV chromosome columns.
+6. Fail clearly when two raw references map to the same assembly-facing name.
+
+Do not add a fallback that retries arbitrary prefixed/unprefixed forms. The
+initialized reference map is the source of truth and should make failures
+deterministic.
+
+Tests must cover:
+
+- no prefix conversion;
+- `addChrPrefix: true` (`1` -> `chr1`);
+- a custom string prefix;
+- an unknown visible assembly reference;
+- a collision after normalization;
+- multiple files whose raw reference naming differs;
+- a reactive `addChrPrefix` change and handle reload.
+
+**MB-3:** Define `addChrPrefix` behavior for mixed-file naming and decide
+whether it is a query-only mapping or also affects emitted format-aware
+`chrom`. A single blind prefix operation cannot normalize both already-prefixed
+and bare names without an explicit idempotence or rejection rule. Eager parsers
+cannot claim assembly-facing names unless a normalization context is added.
+
+### Public header access
+
+Use the current public Tabix header-lines/header API for VCF, GFF, and Tabix TSV
+initialization. Remove `_readFilePrefix()`, the cast to the private `filehandle`,
+manual BGZF decompression, and the undeclared direct-transitive import.
+
+Verify both kinds of Tabix TSV headers already supported by GenomeSpy:
+
+- a commented column line in the indexed header;
+- a plain first row skipped according to the index metadata.
+
+The latter must not be emitted as a data row.
+
+### Callback interval metadata
+
+Modern Tabix computes zero-based, half-open line intervals according to its
+index format. Capture callback interval metadata only where the public API
+guarantees it and only for format-aware adapters. Do not use it to rewrite
+arbitrary generic Tabix TSV columns.
+
+For VCF, compare callback intervals with the shared eager/lazy VCF interval
+helper. A mismatch should fail a focused test instead of creating different
+contracts between source modes.
+
+Before using callback metadata at runtime, decide whether `TabixSource` carries
+a typed `{ line, fileOffset, start, end }` record to format adapters or keeps
+metadata only as a test oracle. Do not leave an implicit mix of strings and
+record wrappers in the dataflow API. This decision is part of closing MB-1 for
+the Tabix adapter.
+
+### Duplicate chunks
+
+Modern Tabix contains fixes for lines reachable through overlapping chunks.
+Retain GenomeSpy's multi-window and multi-handle ordering checks, and add a
+fixture proving that a physical line is published once when index chunks
+overlap. Do not deduplicate by serialized row value because distinct equal rows
+are valid data.
+
+## BAM and BBI upgrades
+
+### BAM
+
+Keep the existing GenomeSpy record adapter in
+`packages/core/src/data/sources/lazy/bamSource.js`. Verify the v8 constructor,
+index selection, `getRecordsForRange()`, abort behavior, record-coordinate
+methods, flags, tags, CIGAR, sequence, and quality values.
+
+Modern BAM includes overlapping-chunk duplicate fixes. Prefer a small indexed
+integration fixture that proves each physical record is published once without
+applying value-based deduplication; use mocks only for behavior a fixture cannot
+exercise.
+
+### BBI
+
+Upgrade BigWig and BigBed together. Verify:
+
+- `getHeader()` and AutoSQL metadata;
+- `getFeatures()` coordinates and abort signals;
+- BigWig aggregation and multi-file merge ordering;
+- BigBed fast parser creation and fallback parsing;
+- descriptor field attachment and dynamic URL sets.
+
+The BBI major upgrade removed legacy reference-renaming options, but GenomeSpy
+does not currently pass them. Chromosome normalization remains a GenomeSpy
+adapter responsibility where required.
+
+Typed-array or multi-region performance APIs are not part of this migration.
+The existing dataflow consumes objects; adopt a different representation only
+after profiling and a separate design review.
+
+## Cache and worker considerations
+
+Modern BAM and Tabix use `@gmod/shared-read-cache`. GenomeSpy can show several
+tracks and files simultaneously, so independent package defaults may multiply
+memory retention.
+
+During implementation:
+
+1. Inspect the effective default budgets in the selected package versions.
+2. Add a direct `@gmod/shared-read-cache` dependency only if GenomeSpy creates
+   and passes a shared budget.
+3. Prefer one bounded budget per view context or compatible worker context for
+   BAM and Tabix caches that use the same byte-weight semantics.
+4. Do not share budgets with BBI or other caches whose weights are not
+   comparable.
+5. Test disposal/reinitialization so stale handles do not retain cache owners.
+
+**MB-6:** Before aggregate verification, choose one of two explicit outcomes:
+(a) create and pass a bounded shared BAM/Tabix budget with a justified size and
+lifecycle, declaring `@gmod/shared-read-cache` directly; or (b) retain package
+budgets after measuring simultaneous tracks and express acceptance as a
+documented measured bound. Do not assert compliance with an unspecified
+“selected cache budget.”
+
+The new BGZF worker pool is an optional performance follow-up. If adopted,
+declare `@gmod/bgzf-filehandle` directly, share a bounded pool, verify worker
+cleanup, and measure browser bundle/latency changes. It is not required merely
+to complete the dependency upgrades.
+
+## GFF and VCF package integration
+
+### GFF
+
+Upgrade directly to `gff-nostream` 5.2.1 and use `parseLines()` rather than
+joining fetched lines. Review the
+[upstream changelog](https://github.com/GMOD/gff-nostream/blob/main/CHANGELOG.md)
+and pin the normalized hierarchy through tests described in
+`source-contracts.md`.
+
+Do not add compatibility shims that reconstruct the v3 hierarchy. This is an
+intentional pre-1.0 break.
+
+The dependency change and the GenomeSpy GFF adapter must be one coherent step:
+v5 changes coordinates, strand representation, attributes, and hierarchy, so
+it cannot be installed as a behavior-preserving dependency-only commit. Close
+MB-5 as part of that step.
+
+### VCF
+
+Upgrade `@gmod/vcf` while first preserving the current materialized raw record
+shape. Confirm parser construction, header handling, lazy sample
+materialization, INFO array materialization, and breakend ALT preservation.
+Only after that baseline passes should the shared canonical interval fields be
+added.
+
+The reviewed v7 parser exposes non-flag INFO values as arrays. The later
+canonical interval step must close MB-2 rather than assuming scalar `END` or
+`SVTYPE` values.
+
+## Implementation plan
+
+### 1. Record the dependency baseline
+
+Outcome: current source behavior and package versions are captured before any
+lockfile change.
+
+Affected areas:
+
+- `packages/core/package.json`
+- `packages/embed-examples/package.json`
+- lockfile inventory
+- existing source tests
+
+Verification:
+
+- Run focused BED, BEDPE, VCF, BAM, BigBed, BigWig, Tabix, and Tabix TSV tests.
+- Record package resolutions with `npm ls`.
+- Record relevant bundle sizes and focused source line counts.
+
+Documentation and migration: none.
+
+Tentative commit: no commit; this is a verification checkpoint.
+
+### 2. Upgrade independent Core package groups
+
+Outcome: BED, BAM, BBI, and Core IndexedFASTA dependencies use the reviewed
+versions while preserving their existing public record shapes.
+
+Affected areas:
+
+- `packages/core/package.json`
+- root lockfile
+- BED, BAM, BBI, and IndexedFASTA adapters and focused tests
+
+Verification:
+
+- Upgrade and verify each package group independently.
+- Exercise BAM records, both BigBed parser paths, BigWig aggregation, aborts,
+  and IndexedFASTA range semantics.
+- Record dependency-tree and bundle-size changes against the baseline.
+
+Documentation and migration: none unless an observable adapter behavior changes.
+
+Tentative commits: package-scoped `build(core): update ...` commits.
+
+### 3. Upgrade Tabix with its infrastructure adapter
+
+Outcome: Tabix is upgraded to the reviewed version in the same commit in which
+GenomeSpy adopts its public header/reference APIs, owns query-name mapping, and
+removes the undeclared BGZF import. This closes MB-1 for Tabix.
+
+Affected areas:
+
+- `packages/core/src/data/sources/lazy/tabixSource.js`
+- `packages/core/src/data/sources/lazy/tabixSource.test.js`
+- `packages/core/src/data/sources/lazy/tabixTsvSource.js`
+- VCF/GFF lazy parser initialization tests
+- `packages/core/package.json` and the root lockfile
+
+Verification:
+
+- All mapping/header/collision tests listed above pass.
+- Existing multi-file, reactive descriptor, failure, abort, and batch tests
+  remain green.
+
+Documentation and migration: update `addChrPrefix` only if its documented
+observable behavior becomes more precise.
+
+Tentative commit: `refactor(core): modernize Tabix source integration`
+
+### 4. Upgrade VCF while preserving raw records
+
+Outcome: `@gmod/vcf` uses the reviewed version and eager/lazy parsing preserves
+the intentionally raw record materialization. Canonical fields may follow in a
+separate source-contract commit after MB-2 and MB-3 are resolved.
+
+Affected areas:
+
+- `packages/core/package.json`
+- root lockfile
+- eager and lazy VCF adapters, headers, and tests
+
+Verification:
+
+- Parser construction, headers, samples, array-valued INFO fields, ALT/breakend
+  strings, and all other raw fields are pinned by focused tests.
+- No canonical-field algorithm is introduced until MB-2 and MB-3 close.
+
+Documentation and migration: none for the raw-preserving upgrade.
+
+Tentative commit: `build(core): update GMOD VCF parser`
+
+### 5. Upgrade GFF with its v1 adapter
+
+Outcome: `gff-nostream` 5 and the GFF source adapter land together with the
+normalized public record contract. This closes MB-1 and MB-5 for GFF.
+
+Affected areas and verification are shared with
+[the GFF source contract](source-contracts.md#gff3-contract).
+
+Documentation and migration: record the public hierarchy, coordinate, strand,
+attribute, and collision changes with the adapter.
+
+Tentative commit: `feat(core)!: migrate GFF3 records to the v1 contract`
+
+### 6. Modernize the embedded FASTA example
+
+Outcome: the example uses IndexedFASTA 5 and `generic-filehandle2` without a
+global Buffer shim.
+
+Affected areas:
+
+- `packages/embed-examples/package.json`
+- `packages/embed-examples/src/dynamicFasta.js`
+- root lockfile
+
+Verification:
+
+- `npm --workspace @genome-spy/embed-examples run build:smoke`
+- The dynamic FASTA example retrieves and renders sequence in a browser smoke
+  test.
+- `npm ls generic-filehandle buffer @gmod/indexedfasta` confirms the legacy
+  direct stack is gone from this workspace.
+
+Documentation and migration: none; this is an internal example integration.
+
+Tentative commit: `build(embed-examples): update IndexedFASTA integration`
+
+### 7. Verify aggregate behavior
+
+Outcome: dependency upgrades introduce no unreviewed performance, bundle, or
+source-lifecycle regression.
+
+Verification:
+
+- Full unit tests, TypeScript checks, and lint pass.
+- Core and application builds pass.
+- Browser smoke tests load BAM, BigWig, BigBed, Tabix TSV, VCF, GFF3, and
+  IndexedFASTA tracks.
+- Close MB-6 by verifying the selected shared-budget or measured-default cache
+  policy with multiple simultaneous lazy tracks.
+- Aborted and replaced requests do not publish stale data.
+- Compare dependency tree, bundle sizes, source line counts, and diff stats to
+  the baseline.
+
+Documentation and migration: record only user-visible changes in release and
+migration notes.
+
+Tentative commit: `test(core): cover upgraded genomic data adapters`
+
+## Risks and mitigations
+
+- **Very recent releases:** recheck changelogs and use a reviewed lockfile;
+  avoid combining future unreviewed updates with contract debugging.
+- **Silent reference mismatch:** build mappings from actual indexed reference
+  names and fail on collisions/unknown names.
+- **Private API regression:** remove private file-handle access before or with
+  the Tabix upgrade.
+- **Memory growth:** inspect and bound shared cache defaults across concurrent
+  tracks.
+- **Bundle/runtime incompatibility:** build both minimal and full bundles and
+  exercise browser examples, not only Node tests.
+- **Parser-path drift:** assert common public output after BigBed fast and
+  fallback parsing.
+- **Intentional versus accidental breaks:** land dependency compatibility before
+  strand/VCF output changes where practical, while keeping the inseparable GFF
+  package and adapter changes atomic.
+
+## Acceptance criteria
+
+- All direct package versions match the reviewed targets or a newer explicitly
+  reviewed replacement documented in the implementation PR.
+- No workspace relies on legacy `generic-filehandle` or a global Buffer shim
+  for IndexedFASTA.
+- Core has no direct import from an undeclared transitive GMOD package.
+- Tabix header and reference discovery use supported public APIs.
+- `addChrPrefix` has deterministic tested behavior without `renameRefSeqs`.
+- BAM, BBI, Tabix, VCF, GFF, BED, and IndexedFASTA focused tests pass on the
+  selected versions.
+- Multi-file loading, dynamic descriptors, aborts, readiness, and file batch
+  boundaries remain correct.
+- The selected cache ownership/budget policy is documented and verified with
+  simultaneous lazy tracks.
+- Full verification and representative browser smoke checks pass.
+- MB-1, MB-3, and MB-6 are closed before merge; MB-2 and MB-5 are closed in the
+  corresponding source-contract steps.

--- a/plans/indexing-and-strands/gmod-upgrades.md
+++ b/plans/indexing-and-strands/gmod-upgrades.md
@@ -100,11 +100,10 @@ Tests must cover:
 - multiple files whose raw reference naming differs;
 - a reactive `addChrPrefix` change and handle reload.
 
-**MB-3:** Define `addChrPrefix` behavior for mixed-file naming and decide
-whether it is a query-only mapping or also affects emitted format-aware
-`chrom`. A single blind prefix operation cannot normalize both already-prefixed
-and bare names without an explicit idempotence or rejection rule. Eager parsers
-cannot claim assembly-facing names unless a normalization context is added.
+**MB-3 resolution:** `addChrPrefix` is an idempotent query-only mapping. Each
+handle maps the assembly query name to its raw indexed name, allowing bare and
+already-prefixed files to load together. Loaded records retain file-native
+reference names. Collisions within one file fail during initialization.
 
 ### Public header access
 
@@ -310,7 +309,7 @@ Tentative commit: `refactor(core): modernize Tabix source integration`
 
 Outcome: `@gmod/vcf` uses the reviewed version and eager/lazy parsing preserves
 the intentionally raw record materialization. Canonical fields may follow in a
-separate source-contract commit after MB-2 and MB-3 are resolved.
+separate source-contract commit after MB-2 is resolved.
 
 Affected areas:
 
@@ -322,7 +321,7 @@ Verification:
 
 - Parser construction, headers, samples, array-valued INFO fields, ALT/breakend
   strings, and all other raw fields are pinned by focused tests.
-- No canonical-field algorithm is introduced until MB-2 and MB-3 close.
+- No canonical-field algorithm is introduced until MB-2 closes.
 
 Documentation and migration: none for the raw-preserving upgrade.
 

--- a/plans/indexing-and-strands/indexing-and-strands-plan.md
+++ b/plans/indexing-and-strands/indexing-and-strands-plan.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Before GenomeSpy 1.0, standardize the genomic records emitted by built-in data
+For GenomeSpy 2.0, standardize the genomic records emitted by built-in data
 sources. GenomeSpy-owned interval fields use zero-based, half-open coordinates,
 and GenomeSpy-owned strand fields use `"+"`, `"-"`, or `null`. Known formats
 are normalized at the data-source boundary. Generic or custom data remains
@@ -67,7 +67,7 @@ versions, and where a field is accessed in the dataflow.
 - Remove indexing correction from locus encodings and coordinate linearization.
 - Upgrade all direct GMOD packages without regressing lazy loading, chromosome
   naming, multi-file sources, cancellation, or memory use.
-- Publish migration guidance before 1.0 and make documentation changes part of
+- Publish migration guidance for 2.0 and make documentation changes part of
   the acceptance criteria.
 
 ## Non-goals
@@ -103,11 +103,11 @@ describe only the primary record interval.
 ### Deprecate, then remove indexing offsets
 
 Mark `ChromPosDefBase.offset` and
-`LinearizeGenomicCoordinateParams.offset` deprecated immediately. If a public
-prerelease is planned, retain their behavior for that prerelease and emit the
-normal schema/documentation deprecation signal. The final 1.0-bound state
-removes both properties and their implementation. If no prerelease will expose
-the warning, remove them directly and retain the same migration documentation.
+`LinearizeGenomicCoordinateParams.offset` deprecated during 1.x if a release can
+provide a useful migration window. Retain their behavior throughout that
+window. The final 2.0 state removes both properties and their implementation.
+If no 1.x release will expose the warning, remove them directly in 2.0 and
+retain the same migration documentation.
 
 The `linearizeGenomicCoordinate` transform itself remains supported; it maps an
 already-normalized chromosome/position pair into a continuous genome-wide
@@ -131,14 +131,14 @@ each committed state builds and passes its focused tests.
 
 | ID | Status | Finding that must be resolved before merge | Earliest work it blocks |
 | --- | --- | --- | --- |
-| MB-1 | **RESOLVED** | Tabix 3.8.1 landed with its public-API adapter, and `gff-nostream` 5.2.1 landed with the v1 GFF adapter. | — |
+| MB-1 | **RESOLVED** | Tabix 3.8.1 landed with its public-API adapter, and `gff-nostream` 5.2.1 landed with the v2 GFF adapter. | — |
 | MB-2 | **OPEN — MERGE BLOCKER** | Define the exact VCF primary-interval algorithm for current `@gmod/vcf` array-valued INFO fields and Tabix's translocation handling, including malformed `END`/`REF` behavior. | Canonical VCF fields |
 | MB-3 | **RESOLVED** | Emitted `chrom` preserves the file reference name. `addChrPrefix` is an idempotent, query-only per-file mapping and does not rewrite loaded rows. | — |
 | MB-4 | **RESOLVED** | The contract standardizes zero-based, half-open semantics while retaining documented format-specific fields such as BED `chromStart/chromEnd` and BEDPE's two intervals. | — |
 | MB-5 | **RESOLVED** | The GFF adapter reserves `chrom`, moves a colliding attribute to the next free `chromN` field, preserves shared identity across parents, and deduplicates attachment within each parent/path. | — |
 | MB-6 | **RESOLVED** | BAM and Tabix share one internal 1 GiB decompressed-byte retention budget. Their idle eviction remains enabled, source disposal clears caches, and tests verify shared ownership and cleanup. | — |
-| MB-7 | **OPEN — MERGE BLOCKER** | Audit every specification under `examples/` and verify that all examples work. Change only affected specifications or support code; do not treat every asset as requiring conversion. | Final examples acceptance |
-| MB-8 | **OPEN — MERGE BLOCKER** | Complete public output typings, choose the migration-document location/navigation, decide the actual offset deprecation/removal path, and use durable release-specific upstream references. | Final schema and documentation acceptance |
+| MB-7 | **RESOLVED** | Static contract checks and browser verification cover all 215 JSON specifications under `examples/`: 209 Core/Docs specs through `npm run smoke:examples` and six App specs through the App development route. Only the affected GFF3 example required migration. | — |
+| MB-8 | **OPEN — MERGE BLOCKER** | The migration guide now lives at `docs/migration/v2-genomic-data.md` and is in site navigation. Complete public output typings, decide the actual offset deprecation/removal path, add the deferred VCF migration, and use durable release-specific upstream references. | Final schema and documentation acceptance |
 
 The focused plans record the evidence and verification needed to close these
 blockers. Resolving a blocker may refine the corresponding implementation step
@@ -217,7 +217,7 @@ Affected areas and detailed verification are in
 Documentation and migration: replace the legacy GFF object-format description,
 simplify the GENCODE example, and publish an old-to-new field mapping.
 
-Tentative commit: `feat(core)!: migrate GFF3 records to the v1 contract`
+Tentative commit: `feat(core)!: migrate GFF3 records to the v2 contract`
 
 ### 4. Add the bounded VCF primary interval
 
@@ -261,7 +261,7 @@ Tentative commit: `refactor(core)!: remove genomic indexing offsets`
 
 ### 6. Complete docs, examples, and end-to-end verification
 
-Outcome: the repository teaches only the v1 contracts, migration guidance is
+Outcome: the repository teaches only the v2 contracts, migration guidance is
 complete, and every existing example has been audited and works correctly.
 
 Affected areas:
@@ -290,13 +290,13 @@ Verification:
   has been checked and works correctly. Only affected specifications are
   migrated: no affected example retains genomic indexing correction in locus
   encodings or `linearizeGenomicCoordinate`, and its coordinate, strand, GFF,
-  and VCF field references use the v1 contracts.
+  and VCF field references use the v2 contracts.
 - Compare focused line counts and `git diff --stat` before and after; the
   offset and legacy GFF paths should become smaller.
 
 Documentation and migration: this step is the documentation deliverable.
 
-Tentative commit: `docs(core): document v1 genomic data contracts`
+Tentative commit: `docs(core): document v2 genomic data contracts`
 
 ## Alternatives considered
 
@@ -364,7 +364,7 @@ consumers would still receive inconsistent values.
 - Built-in interval sources document and emit zero-based, half-open values in
   their public interval fields, including format-specific field names.
 - BED, BEDPE, BigBed, BAM, and GFF expose symbolic/null strands consistently.
-- GFF3 exposes the documented v1 hierarchy, preserves valid multi-parent
+- GFF3 exposes the documented v2 hierarchy, preserves valid multi-parent
   relationships, and does not attach a feature more than once to the same
   parent/path.
 - Eager and lazy VCF expose identical canonical primary interval semantics and
@@ -377,7 +377,7 @@ consumers would still receive inconsistent values.
 - `addChrPrefix`, multi-file lazy loading, abort handling, and header parsing
   work with the upgraded Tabix package.
 - Every existing specification under `examples/` is audited and verified to
-  work with the v1 contracts. Only affected specifications and supporting code
+  work with the v2 contracts. Only affected specifications and supporting code
   or assets are changed, and no affected example retains a deprecated
   compatibility path.
 - User-facing source, coordinate, transform, and migration documentation is

--- a/plans/indexing-and-strands/indexing-and-strands-plan.md
+++ b/plans/indexing-and-strands/indexing-and-strands-plan.md
@@ -1,0 +1,388 @@
+# Genomic Indexing and Strand Contracts
+
+## Summary
+
+Before GenomeSpy 1.0, standardize the genomic records emitted by built-in data
+sources. GenomeSpy-owned interval fields use zero-based, half-open coordinates,
+and GenomeSpy-owned strand fields use `"+"`, `"-"`, or `null`. Known formats
+are normalized at the data-source boundary. Generic or custom data remains
+unchanged and must be normalized explicitly near the start of the user-authored
+dataflow.
+
+The work also upgrades all GMOD dependencies, migrates GFF3 to
+`gff-nostream` 5, adds canonical primary intervals to VCF records without
+modifying raw VCF fields, removes indexing correction from locus encodings and
+`linearizeGenomicCoordinate`, and updates the user-facing documentation and
+examples.
+
+This proposal addresses:
+
+- [GenomeSpy issue #459: Standardize the representation of strand](https://github.com/genome-spy/genome-spy/issues/459)
+- [GenomeSpy issue #460: Migrate the GFF3 source to gff-nostream v5](https://github.com/genome-spy/genome-spy/issues/460)
+- all direct GMOD dependencies in Core and the older IndexedFASTA integration
+  in `packages/embed-examples`
+
+The detailed designs are split into:
+
+- [Source contracts](source-contracts.md): indexing, strands, GFF3, VCF,
+  explicit user normalization, examples, and documentation.
+- [GMOD upgrades](gmod-upgrades.md): package versions, Tabix compatibility,
+  reference-name mapping, headers, caches, and the embedded FASTA cleanup.
+
+## Problem
+
+GenomeSpy currently exposes a mixture of parser-native and GenomeSpy-native
+representations:
+
+- BAM strands are strings, eager BED and BEDPE strands are numbers, GFF v5
+  strands are numbers, and BigBed can vary by parser path.
+- GFF v3 exposes one-based closed coordinates and a legacy nested hierarchy.
+- VCF exposes raw one-based `POS` and has no canonical GenomeSpy interval.
+- `offset` in a `chrom`/`pos` encoding adjusts only the implicit linearization
+  inserted after user transforms. Earlier formulas, filters, lookups, pileups,
+  and window transforms continue to see the unadjusted coordinate.
+- The explicit `linearizeGenomicCoordinate` transform repeats the same indexing
+  escape hatch even though indexing normalization should be a separate,
+  visible dataflow operation.
+- Current GMOD versions span several generations. A direct upgrade is unsafe
+  because modern Tabix removed `renameRefSeqs`, which currently backs
+  `addChrPrefix`.
+
+These inconsistencies make specifications dependent on file formats, parser
+versions, and where a field is accessed in the dataflow.
+
+## Goals
+
+- Define one public interval-semantics contract for built-in genomic source
+  adapters: documented interval fields are zero-based and half-open. Preserve
+  established format-specific field names unless a source explicitly adds
+  canonical fields.
+- Define one public strand contract: `"+"`, `"-"`, or `null`.
+- Normalize known formats at ingestion, before user transforms.
+- Keep arbitrary/custom data correction explicit in the authored dataflow.
+- Preserve raw VCF fields while adding a clearly bounded canonical primary
+  record interval.
+- Adopt the current GFF object hierarchy and eliminate duplicate feature
+  attachment caused by the legacy representation.
+- Remove indexing correction from locus encodings and coordinate linearization.
+- Upgrade all direct GMOD packages without regressing lazy loading, chromosome
+  naming, multi-file sources, cancellation, or memory use.
+- Publish migration guidance before 1.0 and make documentation changes part of
+  the acceptance criteria.
+
+## Non-goals
+
+- Inferring or rewriting arbitrary coordinate-bearing VCF `INFO`, `FORMAT`,
+  sample, annotation, or breakend fields.
+- Inferring coordinate systems for generic CSV, TSV, JSON, or Tabix TSV data.
+- Changing display-only axis numbering through `scale.numberingOffset`.
+- Changing visual pixel offsets such as `xOffset`, `yOffset`, mark offsets,
+  axis offsets, or stack offsets.
+- Introducing renderer-specific handling for strand or indexing.
+- Providing a universal variant normalization or decomposition system.
+- Migrating downstream specifications outside this repository, or mechanically
+  rewriting raw or vendored example data that already has valid format-native
+  semantics.
+
+## Key decisions
+
+### Source-boundary normalization
+
+Known adapters own the conversion from format semantics to GenomeSpy fields.
+All downstream transforms and encodings can therefore rely on the same values.
+Generic sources do not guess: users add explicit formula or project transforms
+before any transform that consumes the coordinates.
+
+### Canonical fields do not erase raw format data
+
+When a format has valuable raw fields, canonical GenomeSpy fields are added
+alongside them. VCF is the important example: `CHROM`, `POS`, `ALT`, `INFO`,
+`FORMAT`, and samples retain VCF semantics, while `chrom`, `start`, and `end`
+describe only the primary record interval.
+
+### Deprecate, then remove indexing offsets
+
+Mark `ChromPosDefBase.offset` and
+`LinearizeGenomicCoordinateParams.offset` deprecated immediately. If a public
+prerelease is planned, retain their behavior for that prerelease and emit the
+normal schema/documentation deprecation signal. The final 1.0-bound state
+removes both properties and their implementation. If no prerelease will expose
+the warning, remove them directly and retain the same migration documentation.
+
+The `linearizeGenomicCoordinate` transform itself remains supported; it maps an
+already-normalized chromosome/position pair into a continuous genome-wide
+coordinate.
+
+### Symbolic public strands
+
+Use `"+"` and `"-"` because strands are user-facing nominal categories in
+tooltips, legends, expressions, exports, and authored specifications. Use
+`null` for unstranded or unknown values. Parser-native numeric values are
+normalized once during ingestion.
+
+## Incremental implementation and merge blockers
+
+Implementation may proceed as a sequence of independently reviewable commits.
+A merge blocker does not have to be resolved before unrelated earlier work
+starts. However, the branch must not merge until every blocker below has an
+explicit decision, implementation where applicable, and passing verification.
+Dependency upgrades that require adapter changes must remain atomic enough that
+each committed state builds and passes its focused tests.
+
+| ID | Status | Finding that must be resolved before merge | Earliest work it blocks |
+| --- | --- | --- | --- |
+| MB-1 | **OPEN — MERGE BLOCKER** | Sequence dependency upgrades with their required adapters. Modern Tabix APIs cannot be used before upgrading Tabix, and `gff-nostream` 5 cannot be installed as a behavior-preserving dependency-only change. | The affected Tabix and GFF commits |
+| MB-2 | **OPEN — MERGE BLOCKER** | Define the exact VCF primary-interval algorithm for current `@gmod/vcf` array-valued INFO fields and Tabix's translocation handling, including malformed `END`/`REF` behavior. | Canonical VCF fields |
+| MB-3 | **OPEN — MERGE BLOCKER** | Decide whether emitted `chrom` preserves the file reference name or uses an explicitly supplied normalization context. Eager parsers have no assembly context, so “assembly-facing” cannot remain an implicit promise. | GFF/VCF public record contracts |
+| MB-4 | **OPEN — MERGE BLOCKER** | State the interval contract in terms of semantics and documented per-format fields; do not accidentally promise `chrom/start/end` for BED or BEDPE unless duplicate canonical fields are intentionally added. | Final source contract and docs |
+| MB-5 | **OPEN — MERGE BLOCKER** | Define GFF attribute collision behavior for GenomeSpy's `chrom` field and preserve valid multi-parent relationships while preventing accidental duplicate attachment to the same parent/path. | GFF adapter acceptance |
+| MB-6 | **OPEN — MERGE BLOCKER** | Select and verify the BAM/Tabix cache ownership and budget policy, or replace the fixed-budget assertion with a measured acceptance gate. | Aggregate verification |
+| MB-7 | **OPEN — MERGE BLOCKER** | Audit every specification under `examples/` and verify that all examples work. Change only affected specifications or support code; do not treat every asset as requiring conversion. | Final examples acceptance |
+| MB-8 | **OPEN — MERGE BLOCKER** | Complete public output typings, choose the migration-document location/navigation, decide the actual offset deprecation/removal path, and use durable release-specific upstream references. | Final schema and documentation acceptance |
+
+The focused plans record the evidence and verification needed to close these
+blockers. Resolving a blocker may refine the corresponding implementation step
+without forcing all other work to wait.
+
+## Comparable behavior and provenance
+
+The coordinate contract follows the established UCSC distinction between
+zero-based half-open storage and one-based closed display notation; see the
+[UCSC coordinate-counting guide](https://genome-blog.gi.ucsc.edu/blog/2016/12/12/the-ucsc-genome-browser-coordinate-counting-systems/).
+Modern GMOD BAM, BBI, IndexedFASTA, Tabix, and GFF APIs likewise operate on or
+emit zero-based half-open intervals. The GFF hierarchy follows the public
+[`gff-nostream` object format](https://github.com/GMOD/gff-nostream/blob/main/README.md).
+VCF raw-field preservation follows the
+[VCF 4.5 specification](https://samtools.github.io/hts-specs/VCFv4.5.pdf),
+which permits extensible `INFO` and `FORMAT` content and embeds remote breakend
+locations in allele strings.
+
+The proposal adopts documented data semantics only. It does not copy code from
+UCSC, GMOD, samtools/hts-specs, JBrowse, or other projects. The GMOD packages
+used by GenomeSpy are MIT-licensed and compatible with GenomeSpy's MIT license.
+
+## Implementation sequence
+
+### 1. Establish the baseline and upgrade GMOD in coherent groups
+
+Outcome: the baseline is recorded and all required GMOD packages are upgraded
+incrementally. Low-risk packages may land independently. Tabix lands with its
+public-API adapter changes, and GFF lands with its required record adapter, as
+specified in [GMOD upgrades](gmod-upgrades.md).
+
+Affected areas and detailed verification are in [GMOD upgrades](gmod-upgrades.md).
+
+Documentation and migration: document any observable `addChrPrefix` behavior.
+Package groups that preserve the public record shape introduce no coordinate
+contract changes; GFF's package and intentional contract migration land
+together in step 3.
+
+Tentative commits: use the package-group commits specified in
+[GMOD upgrades](gmod-upgrades.md#implementation-plan).
+
+### 2. Standardize source strands
+
+Outcome: BED, BEDPE, BigBed, and BAM expose only `"+"`, `"-"`, or `null` in
+GenomeSpy-owned strand fields. The shared rule is applied to GFF when its v5
+adapter lands in step 3.
+
+Affected areas:
+
+- `packages/core/src/data/formats/bed.js`
+- `packages/core/src/data/formats/bedpe.js`
+- `packages/core/src/data/sources/lazy/bigBedSource.js`
+- `packages/core/src/data/sources/lazy/bamSource.js`
+- a shared source-boundary strand normalizer and adjacent tests
+
+Verification:
+
+- Test forward, reverse, unknown, and missing strands.
+- Exercise both BigBed parser paths and prove identical output.
+- Confirm numeric parser values never reach the public rows.
+
+Documentation and migration: update eager/lazy source field tables, examples,
+and the issue #459 migration note.
+
+Tentative commit: `fix(core)!: standardize genomic strand values`
+
+### 3. Migrate GFF3 to the canonical source contract
+
+Outcome: GFF3 uses `gff-nostream` 5 and emits normalized intervals, symbolic
+strands, flattened attributes, and direct `subfeatures` without accidental
+duplicate attachment to the same parent/path.
+
+Affected areas and detailed verification are in
+[Source contracts](source-contracts.md#gff3-contract).
+
+Documentation and migration: replace the legacy GFF object-format description,
+simplify the GENCODE example, and publish an old-to-new field mapping.
+
+Tentative commit: `feat(core)!: migrate GFF3 records to the v1 contract`
+
+### 4. Add the bounded VCF primary interval
+
+Outcome: eager and lazy VCF records retain their raw fields and additionally
+expose canonical `chrom`, `start`, and `end` for the local primary interval.
+
+Affected areas and detailed verification are in
+[Source contracts](source-contracts.md#vcf-contract).
+
+Documentation and migration: update ClinVar and structural-variant examples;
+state explicitly that arbitrary VCF payload coordinates remain raw.
+
+Tentative commit: `feat(core)!: expose canonical VCF record intervals`
+
+### 5. Retire indexing offsets
+
+Outcome: locus encodings and `linearizeGenomicCoordinate` accept already
+normalized coordinates and no longer perform indexing correction.
+
+Affected areas:
+
+- `packages/core/src/spec/channel.d.ts`
+- `packages/core/src/spec/transform.d.ts`
+- `packages/core/src/view/flowBuilder.js`
+- `packages/core/src/data/transforms/linearizeGenomicCoordinate.js`
+- schema, transform, encoding, and layout tests
+
+Verification:
+
+- Schema/types reject the removed properties in the final state.
+- Implicit and explicit linearization agree for normalized inputs.
+- An explicit correction placed before a filter/pileup affects every downstream
+  consumer, not only rendering.
+- Unrelated display and pixel offsets remain accepted.
+
+Documentation and migration: replace all indexing-offset examples with source
+normalization or explicit early formulas. Clarify that `numberingOffset` changes
+labels, not data.
+
+Tentative commit: `refactor(core)!: remove genomic indexing offsets`
+
+### 6. Complete docs, examples, and end-to-end verification
+
+Outcome: the repository teaches only the v1 contracts, migration guidance is
+complete, and every existing example has been audited and works correctly.
+
+Affected areas:
+
+- `docs/grammar/genomic-coordinates.md`
+- `docs/grammar/transform/linearize-genomic-coordinate.md`
+- `docs/grammar/data/eager.md`
+- `docs/grammar/data/lazy.md`
+- all specifications under `examples/` and only the supporting code or assets
+  that are actually affected, including GFF3, ClinVar, HCC1954 SV/CNV, and
+  ASCAT documentation examples
+- generated schemas and snapshots
+
+Verification:
+
+- Focused source/transform tests pass after every step.
+- `npm test`
+- `npm --workspaces run test:tsc --if-present`
+- `npm run lint`
+- `npm run build && npm run build:docs` when schema-derived docs change.
+- Run `npm run smoke:examples` in addition to focused browser smoke checks
+  for GFF, VCF, BAM, BigBed, and IndexedFASTA. The offline initialization suite
+  alone is insufficient because it skips specifications with absolute HTTP
+  data URLs.
+- A repository-wide audit confirms that every specification under `examples/`
+  has been checked and works correctly. Only affected specifications are
+  migrated: no affected example retains genomic indexing correction in locus
+  encodings or `linearizeGenomicCoordinate`, and its coordinate, strand, GFF,
+  and VCF field references use the v1 contracts.
+- Compare focused line counts and `git diff --stat` before and after; the
+  offset and legacy GFF paths should become smaller.
+
+Documentation and migration: this step is the documentation deliverable.
+
+Tentative commit: `docs(core): document v1 genomic data contracts`
+
+## Alternatives considered
+
+### Keep per-encoding indexing offsets
+
+Rejected because the correction is applied after user transforms and creates
+different meanings for the same field depending on its consumer.
+
+### Normalize arbitrary generic fields automatically
+
+Rejected because field names do not reliably identify coordinate semantics,
+indexing, interval closure, or assembly. Silent guesses would corrupt data.
+
+### Convert every coordinate found in a VCF record
+
+Rejected because VCF extension fields are open-ended. Some values are absolute
+positions, some are relative offsets, some use transcript/protein coordinate
+systems, and breakend mates are embedded in allele strings.
+
+### Leave VCF entirely raw
+
+Rejected because the standard primary interval is sufficiently well defined,
+lazy indexing already depends on it, and forcing every ordinary VCF
+visualization to repeat `POS - 1` would make VCF an avoidable exception. Raw
+fields remain available for full fidelity.
+
+### Normalize strands in renderers
+
+Rejected because transforms, expressions, tooltips, exports, and external
+consumers would still receive inconsistent values.
+
+## Risks
+
+- Major-version GMOD upgrades may change constructor options, returned object
+  shapes, cache behavior, or bundler assumptions. Mitigate with coherent
+  package/adapter groups and focused tests at each increment.
+- `addChrPrefix` may silently stop matching files if reference-name mapping is
+  incomplete. Test query names and the emitted name policy selected in MB-3.
+- A GFF hierarchy regression may duplicate marks. Test object identity/counts
+  per parent/path and a representative rendered feature count.
+- VCF interval rules may be overgeneralized. Limit the contract to the local
+  primary interval and retain every raw field unchanged.
+- Downstream specifications may rely on numeric strands or offsets. Provide
+  concise migration examples and make schema failures direct.
+- Fresh GMOD releases may introduce aggregate cache growth across several
+  tracks. Share or bound caches where supported and test multi-source loading.
+
+## Questions permitted during incremental work
+
+- Will a public prerelease exist between deprecation and removal of indexing
+  offsets? If not, implement direct removal with migration documentation.
+  This closes MB-8 and must be decided before the offset/schema step completes.
+- Should the shared BAM/Tabix cache budget be configurable through public Core
+  configuration in the first change, or remain a documented internal default?
+  The initial implementation should keep this internal unless a concrete user
+  need requires a new API. This closes MB-6 during aggregate verification.
+- Should normalized breakend mate fields be added later? They are deliberately
+  excluded from the primary VCF contract and would require a separate,
+  format-aware proposal.
+
+## Acceptance criteria
+
+- Every direct GMOD dependency and the embedded IndexedFASTA dependency is on
+  the reviewed current release set recorded in `gmod-upgrades.md`.
+- Built-in interval sources document and emit zero-based, half-open values in
+  their public interval fields, including format-specific field names.
+- BED, BEDPE, BigBed, BAM, and GFF expose symbolic/null strands consistently.
+- GFF3 exposes the documented v1 hierarchy, preserves valid multi-parent
+  relationships, and does not attach a feature more than once to the same
+  parent/path.
+- Eager and lazy VCF expose identical canonical primary interval semantics and
+  preserve raw VCF content.
+- Generic data sources perform no inferred indexing conversion; documentation
+  demonstrates an explicit early dataflow correction.
+- Locus encodings and `linearizeGenomicCoordinate` contain no final-state
+  indexing `offset` option.
+- `scale.numberingOffset` and unrelated visual offsets are unchanged.
+- `addChrPrefix`, multi-file lazy loading, abort handling, and header parsing
+  work with the upgraded Tabix package.
+- Every existing specification under `examples/` is audited and verified to
+  work with the v1 contracts. Only affected specifications and supporting code
+  or assets are changed, and no affected example retains a deprecated
+  compatibility path.
+- User-facing source, coordinate, transform, and migration documentation is
+  complete and all embedded examples use the new contracts.
+- Focused tests, full tests, TypeScript checks, lint, builds, docs generation,
+  focused browser checks, and the all-example smoke path pass.
+- Every MB-1 through MB-8 merge blocker is closed and its resolution is visible
+  in the implementation diff, tests, or final documentation as applicable.

--- a/plans/indexing-and-strands/indexing-and-strands-plan.md
+++ b/plans/indexing-and-strands/indexing-and-strands-plan.md
@@ -136,7 +136,7 @@ each committed state builds and passes its focused tests.
 | MB-3 | **RESOLVED** | Emitted `chrom` preserves the file reference name. `addChrPrefix` is an idempotent, query-only per-file mapping and does not rewrite loaded rows. | — |
 | MB-4 | **RESOLVED** | The contract standardizes zero-based, half-open semantics while retaining documented format-specific fields such as BED `chromStart/chromEnd` and BEDPE's two intervals. | — |
 | MB-5 | **RESOLVED** | The GFF adapter reserves `chrom`, moves a colliding attribute to the next free `chromN` field, preserves shared identity across parents, and deduplicates attachment within each parent/path. | — |
-| MB-6 | **OPEN — MERGE BLOCKER** | Select and verify the BAM/Tabix cache ownership and budget policy, or replace the fixed-budget assertion with a measured acceptance gate. | Aggregate verification |
+| MB-6 | **RESOLVED** | BAM and Tabix share one internal 1 GiB decompressed-byte retention budget. Their idle eviction remains enabled, source disposal clears caches, and tests verify shared ownership and cleanup. | — |
 | MB-7 | **OPEN — MERGE BLOCKER** | Audit every specification under `examples/` and verify that all examples work. Change only affected specifications or support code; do not treat every asset as requiring conversion. | Final examples acceptance |
 | MB-8 | **OPEN — MERGE BLOCKER** | Complete public output typings, choose the migration-document location/navigation, decide the actual offset deprecation/removal path, and use durable release-specific upstream references. | Final schema and documentation acceptance |
 

--- a/plans/indexing-and-strands/indexing-and-strands-plan.md
+++ b/plans/indexing-and-strands/indexing-and-strands-plan.md
@@ -131,11 +131,11 @@ each committed state builds and passes its focused tests.
 
 | ID | Status | Finding that must be resolved before merge | Earliest work it blocks |
 | --- | --- | --- | --- |
-| MB-1 | **OPEN — MERGE BLOCKER** | Sequence dependency upgrades with their required adapters. Modern Tabix APIs cannot be used before upgrading Tabix, and `gff-nostream` 5 cannot be installed as a behavior-preserving dependency-only change. | The affected Tabix and GFF commits |
+| MB-1 | **RESOLVED** | Tabix 3.8.1 landed with its public-API adapter, and `gff-nostream` 5.2.1 landed with the v1 GFF adapter. | — |
 | MB-2 | **OPEN — MERGE BLOCKER** | Define the exact VCF primary-interval algorithm for current `@gmod/vcf` array-valued INFO fields and Tabix's translocation handling, including malformed `END`/`REF` behavior. | Canonical VCF fields |
-| MB-3 | **OPEN — MERGE BLOCKER** | Decide whether emitted `chrom` preserves the file reference name or uses an explicitly supplied normalization context. Eager parsers have no assembly context, so “assembly-facing” cannot remain an implicit promise. | GFF/VCF public record contracts |
-| MB-4 | **OPEN — MERGE BLOCKER** | State the interval contract in terms of semantics and documented per-format fields; do not accidentally promise `chrom/start/end` for BED or BEDPE unless duplicate canonical fields are intentionally added. | Final source contract and docs |
-| MB-5 | **OPEN — MERGE BLOCKER** | Define GFF attribute collision behavior for GenomeSpy's `chrom` field and preserve valid multi-parent relationships while preventing accidental duplicate attachment to the same parent/path. | GFF adapter acceptance |
+| MB-3 | **RESOLVED** | Emitted `chrom` preserves the file reference name. `addChrPrefix` is an idempotent, query-only per-file mapping and does not rewrite loaded rows. | — |
+| MB-4 | **RESOLVED** | The contract standardizes zero-based, half-open semantics while retaining documented format-specific fields such as BED `chromStart/chromEnd` and BEDPE's two intervals. | — |
+| MB-5 | **RESOLVED** | The GFF adapter reserves `chrom`, moves a colliding attribute to the next free `chromN` field, preserves shared identity across parents, and deduplicates attachment within each parent/path. | — |
 | MB-6 | **OPEN — MERGE BLOCKER** | Select and verify the BAM/Tabix cache ownership and budget policy, or replace the fixed-budget assertion with a measured acceptance gate. | Aggregate verification |
 | MB-7 | **OPEN — MERGE BLOCKER** | Audit every specification under `examples/` and verify that all examples work. Change only affected specifications or support code; do not treat every asset as requiring conversion. | Final examples acceptance |
 | MB-8 | **OPEN — MERGE BLOCKER** | Complete public output typings, choose the migration-document location/navigation, decide the actual offset deprecation/removal path, and use durable release-specific upstream references. | Final schema and documentation acceptance |

--- a/plans/indexing-and-strands/source-contracts.md
+++ b/plans/indexing-and-strands/source-contracts.md
@@ -29,16 +29,14 @@ A point-like record still has a reference span. For a single reference base,
 `end == start + 1`. Marks may encode only `start` when a visual point is
 desired, but the source contract remains an interval contract.
 
-**MB-3:** Before finalizing GFF and VCF output, decide whether `chrom` preserves
-the file's reference name or accepts an explicit normalization context. Eager
-format parsers have no assembly context, so they cannot implicitly promise an
-assembly-facing name. `addChrPrefix` may remain a query-name mapping without
-rewriting emitted raw records.
+**MB-3 resolution:** `chrom` preserves the reference name stored in the file.
+`addChrPrefix` is an idempotent query-name mapping and does not rewrite emitted
+records. This policy is identical for eager and lazy format adapters.
 
-**MB-4:** Keep the invariant about coordinate semantics separate from field
-naming. BED may continue to expose `chromStart/chromEnd`, and BEDPE may continue
-to expose `start1/end1` and `start2/end2`, provided those documented fields are
-zero-based and half-open.
+**MB-4 resolution:** The invariant applies to coordinate semantics, not one
+mandatory set of field names. BED continues to expose `chromStart/chromEnd`,
+and BEDPE continues to expose `start1/end1` and `start2/end2`; these documented
+fields are zero-based and half-open.
 
 Known source adapters perform format-aware conversion before publishing rows to
 the dataflow. Consequently, formulas, filters, pileups, lookups, windows,
@@ -158,7 +156,7 @@ feature recursively to this public shape:
 
 Specific decisions:
 
-- Rename parser `refName` to canonical `chrom`.
+- Rename parser `refName` to `chrom` without changing the file's reference name.
 - Preserve canonical zero-based, half-open `start` and `end` from v5.
 - Convert numeric parser strand to the symbolic/null contract.
 - Keep `subfeatures` as direct feature objects and normalize them recursively.
@@ -168,16 +166,11 @@ Specific decisions:
   their v5 types.
 - Do not reintroduce `derived_features` or merge multi-location records in the
   adapter.
-- Apply the reference-name policy selected in MB-3; preserve parser-native
-  reference information only if a separately named raw field is needed and
-  documented.
 
-**MB-5:** The adapter-created `chrom` field is not one of `gff-nostream`'s
-parser-native collision targets. Decide how an input attribute named `chrom`
-is renamed or preserved before assigning the canonical field. Also distinguish
-accidental duplicate attachment from valid GFF features with multiple parents:
-the adapter must preserve each declared parent relationship while avoiding
-duplicate attachment to the same parent/path.
+**MB-5 resolution:** Reserve adapter-created `chrom`. Rename an attribute named
+`chrom` to the next free numeric field (`chrom2`, `chrom3`, and so on). Preserve
+the same adapted feature object under each declared parent, while deduplicating
+repeated attachment to the same parent/path.
 
 The exact output fixture becomes a deliberate public contract and should be
 captured by focused snapshots after the adapter design stabilizes.
@@ -209,7 +202,7 @@ parser type after `refName` and numeric strand have been adapted.
   same parent/path.
 - Test attribute arrays, singleton attributes, and collisions with built-in
   property names.
-- Test the MB-3 reference-name policy with a bare-reference file.
+- Test raw reference-name preservation with a bare-reference file.
 - Add a stable snapshot for the normalized hierarchy.
 - Render a representative GENCODE interval and assert the expected mark/SVG
   count so object duplication cannot return unnoticed.
@@ -225,7 +218,7 @@ the raw parser materialization and adds only these GenomeSpy-owned fields:
 {
     CHROM, POS, ID, REF, ALT, QUAL, FILTER, INFO, SAMPLES,
     // ...other raw parser fields...
-    chrom, // reference name under the policy selected in MB-3
+    chrom, // same reference name as raw CHROM
     start, // zero-based inclusive local start
     end,   // zero-based exclusive local end
 }
@@ -248,8 +241,7 @@ Raw fields remain untouched:
 Create one shared helper used by eager `format.type: "vcf"` and lazy
 `data.lazy.type: "vcf"`:
 
-1. `chrom` follows the reference-name policy selected in MB-3 while raw `CHROM`
-   remains unchanged.
+1. `chrom` equals raw `CHROM`; the raw field remains unchanged.
 2. `start` is `POS - 1`.
 3. Compute `end` from the exact algorithm selected in MB-2.
 
@@ -288,7 +280,8 @@ reviewing the public contract.
 - Assert raw `POS`, `INFO`, `ALT`, and sample objects are unchanged.
 - Assert eager and lazy parsing produce identical canonical fields.
 - Assert breakend mate coordinates and confidence intervals are not rewritten.
-- Test the MB-3 reference-name policy separately from raw `CHROM` preservation.
+- Test that `chrom` equals raw `CHROM` even when a lazy query uses
+  `addChrPrefix` mapping.
 - Update ClinVar to encode canonical fields without an encoding offset.
 - Audit HCC1954 structural-variant formulas so local and mate endpoints declare
   explicitly whether they consume canonical or raw values.

--- a/plans/indexing-and-strands/source-contracts.md
+++ b/plans/indexing-and-strands/source-contracts.md
@@ -178,9 +178,9 @@ captured by focused snapshots after the adapter design stabilizes.
 Define an explicit GenomeSpy GFF datum type rather than reusing the upstream
 parser type after `refName` and numeric strand have been adapted.
 
-### Legacy-to-v1 mapping
+### GenomeSpy 1.x-to-v2 mapping
 
-| Legacy GFF3 field/path | v1 field/path |
+| GenomeSpy 1.x GFF3 field/path | GenomeSpy 2.0 field/path |
 | --- | --- |
 | `seq_id` | `chrom` |
 | `start` with encoding offset | canonical `start` |
@@ -381,15 +381,16 @@ initialization suite is insufficient because it skips specifications with
 absolute HTTP data URLs. Do not treat the known list as exhaustive or presume
 that every example needs an edit.
 
-Add a v1 migration section with old/new snippets for encoding offsets, explicit
+Add a v2 migration section with old/new snippets for encoding offsets, explicit
 custom-data correction, numeric strands, GFF hierarchy fields, and canonical
 versus raw VCF fields.
 
 **MB-8:** Select a concrete migration document path and add it to
 `zensical.toml`. Decide whether the offsets receive an observable prerelease
-deprecation or are removed directly for 1.0; document the chosen path in types,
-schema-derived docs, and the migration page. Replace mutable upstream `main`
-links used as compatibility evidence with release-tagged or commit-pinned links.
+deprecation during 1.x or are removed directly in 2.0; document the chosen path
+in types, schema-derived docs, and the migration page. Replace mutable upstream
+`main` links used as compatibility evidence with release-tagged or commit-pinned
+links.
 
 Regenerate schema artifacts from `.d.ts` sources. Do not edit generated schema
 descriptions directly.

--- a/plans/indexing-and-strands/source-contracts.md
+++ b/plans/indexing-and-strands/source-contracts.md
@@ -1,0 +1,423 @@
+# Source Contracts
+
+## Scope
+
+This document specifies the user-visible coordinate, strand, GFF3, and VCF
+contracts for the [Genomic Indexing and Strand Contracts](indexing-and-strands-plan.md)
+proposal. Dependency and Tabix mechanics are covered separately in
+[GMOD upgrades](gmod-upgrades.md).
+
+The MB identifiers below refer to the merge-blocker register in the
+[master plan](indexing-and-strands-plan.md#incremental-implementation-and-merge-blockers).
+They may remain open while independent upgrade work proceeds, but each must be
+closed before merge.
+
+## General coordinate contract
+
+GenomeSpy-owned genomic intervals use zero-based, half-open semantics. Sources
+keep their established documented field names unless their format-specific
+contract explicitly adds canonical fields. For sources that expose the
+canonical interval shape, it is:
+
+```text
+chrom: chromosome or contig reference name under the source's documented policy
+start: zero-based inclusive start
+end:   zero-based exclusive end
+```
+
+A point-like record still has a reference span. For a single reference base,
+`end == start + 1`. Marks may encode only `start` when a visual point is
+desired, but the source contract remains an interval contract.
+
+**MB-3:** Before finalizing GFF and VCF output, decide whether `chrom` preserves
+the file's reference name or accepts an explicit normalization context. Eager
+format parsers have no assembly context, so they cannot implicitly promise an
+assembly-facing name. `addChrPrefix` may remain a query-name mapping without
+rewriting emitted raw records.
+
+**MB-4:** Keep the invariant about coordinate semantics separate from field
+naming. BED may continue to expose `chromStart/chromEnd`, and BEDPE may continue
+to expose `start1/end1` and `start2/end2`, provided those documented fields are
+zero-based and half-open.
+
+Known source adapters perform format-aware conversion before publishing rows to
+the dataflow. Consequently, formulas, filters, pileups, lookups, windows,
+encodings, tooltips, and exports observe the same values.
+
+Generic CSV, TSV, JSON, and Tabix TSV records are not interpreted. Authors
+derive canonical fields explicitly near the beginning of the dataflow:
+
+```json
+{
+  "transform": [
+    {
+      "type": "formula",
+      "expr": "datum.rawStart - 1",
+      "as": "start"
+    },
+    {
+      "type": "formula",
+      "expr": "datum.rawEnd",
+      "as": "end"
+    }
+  ]
+}
+```
+
+For a one-based closed interval, subtract one only from the start. Its inclusive
+end has the same numeric value as the corresponding zero-based exclusive end.
+Keep raw fields when their original representation is useful; downstream
+transforms should refer consistently to the derived canonical fields.
+
+## Per-format coordinate status
+
+| Format/source | Input or library semantics | GenomeSpy action |
+| --- | --- | --- |
+| BAM | GMOD records are zero-based, half-open | Preserve `chrom/start/end` |
+| BED | BED is zero-based, half-open | Preserve BED coordinate fields |
+| BEDPE | BEDPE interval columns are zero-based, half-open | Preserve both intervals |
+| BigWig | BBI features are zero-based, half-open | Preserve `chrom/start/end` |
+| BigBed | BBI/BED features are zero-based, half-open | Preserve coordinates |
+| Indexed FASTA | Query API is zero-based, half-open | Preserve query/result positions |
+| WIG | Source notation is one-based closed | Continue converting during parsing |
+| GFF3 | Text format is one-based closed | Let GFF v5/parser adapter emit canonical intervals |
+| VCF | Raw `POS` is one-based; record span is format-aware | Add canonical primary `chrom/start/end`, retain raw fields |
+| Generic Tabix TSV | Determined by its index configuration and row schema | Do not rewrite row fields; require explicit transforms |
+
+The Tabix query API uses zero-based, half-open query windows internally. That
+does not prove that arbitrary columns in a generic row have the same semantics.
+
+## Strand contract
+
+GenomeSpy-owned strand fields use:
+
+```ts
+type Strand = "+" | "-" | null;
+```
+
+Normalize parser-native values at ingestion:
+
+| Input | Output |
+| --- | --- |
+| `"+"` or `1` | `"+"` |
+| `"-"` or `-1` | `"-"` |
+| `.`, `0`, missing, or format-defined unstranded value | `null` |
+
+Use one shared helper for these known parser domains so BED, BEDPE, BigBed,
+BAM, and GFF cannot drift. Validate unexpected values at the format boundary;
+do not silently reinterpret arbitrary strings.
+
+BEDPE applies the rule independently to `strand1` and `strand2`. GFF applies it
+recursively to every object in `subfeatures`. BigBed normalizes both the fast
+AutoSQL parser and fallback `@gmod/bed` parser results after parsing, which
+ensures the selected parser path does not affect public data.
+
+### Strand migration
+
+Specifications comparing numeric strands migrate as follows:
+
+```text
+datum.strand == 1   -> datum.strand == "+"
+datum.strand == -1  -> datum.strand == "-"
+datum.strand == 0   -> datum.strand == null
+```
+
+Update scale domains, preferred orders, conditional encodings, tooltip labels,
+and tests together.
+
+## GFF3 contract
+
+### Current problem
+
+`packages/core/src/data/sources/lazy/gff3Source.js` uses `gff-nostream` 3 and
+parses Tabix slices by joining lines into a new string. The legacy objects use
+`seq_id`, one-based closed coordinates, string strands, nested
+`child_features` arrays, and attributes under `attributes`. Specifications need
+repeated flatten/project operations, and the legacy grouping can attach the
+same biological feature more than once.
+
+### New record shape
+
+Use `gff-nostream` 5 `parseLines()` for each Tabix slice. Adapt each returned
+feature recursively to this public shape:
+
+```js
+{
+    chrom,
+    start,
+    end,
+    strand,
+    source,
+    type,
+    score,
+    phase,
+    subfeatures,
+    // parser-flattened GFF attributes
+}
+```
+
+Specific decisions:
+
+- Rename parser `refName` to canonical `chrom`.
+- Preserve canonical zero-based, half-open `start` and `end` from v5.
+- Convert numeric parser strand to the symbolic/null contract.
+- Keep `subfeatures` as direct feature objects and normalize them recursively.
+- Preserve v5's documented flattened attribute behavior, including its
+  collision naming. Do not reconstruct the v3 `attributes` container.
+- Preserve nullable `source` and `type`, and optional `score` and `phase`, with
+  their v5 types.
+- Do not reintroduce `derived_features` or merge multi-location records in the
+  adapter.
+- Apply the reference-name policy selected in MB-3; preserve parser-native
+  reference information only if a separately named raw field is needed and
+  documented.
+
+**MB-5:** The adapter-created `chrom` field is not one of `gff-nostream`'s
+parser-native collision targets. Decide how an input attribute named `chrom`
+is renamed or preserved before assigning the canonical field. Also distinguish
+accidental duplicate attachment from valid GFF features with multiple parents:
+the adapter must preserve each declared parent relationship while avoiding
+duplicate attachment to the same parent/path.
+
+The exact output fixture becomes a deliberate public contract and should be
+captured by focused snapshots after the adapter design stabilizes.
+
+Define an explicit GenomeSpy GFF datum type rather than reusing the upstream
+parser type after `refName` and numeric strand have been adapted.
+
+### Legacy-to-v1 mapping
+
+| Legacy GFF3 field/path | v1 field/path |
+| --- | --- |
+| `seq_id` | `chrom` |
+| `start` with encoding offset | canonical `start` |
+| `end` | canonical exclusive `end` |
+| string `strand` | `"+"`, `"-"`, or `null` |
+| `child_features` nested arrays | `subfeatures` objects |
+| `attributes.ID[0]` | flattened `id` field |
+| `attributes.*` | lowercase flattened fields; singleton values become scalars and repeated values remain arrays |
+| repeated initial `flatten` | removed |
+
+### GFF3 verification
+
+- Add a synthetic gene -> transcript -> exon fixture with exact coordinate,
+  attribute, and strand assertions.
+- Test an orphan child whose parent is outside the fetched Tabix slice; it must
+  remain available as a top-level feature.
+- Test multi-location and multi-parent features. Assert that every declared
+  relationship is preserved and that no segment is attached repeatedly to the
+  same parent/path.
+- Test attribute arrays, singleton attributes, and collisions with built-in
+  property names.
+- Test the MB-3 reference-name policy with a bare-reference file.
+- Add a stable snapshot for the normalized hierarchy.
+- Render a representative GENCODE interval and assert the expected mark/SVG
+  count so object duplication cannot return unnoticed.
+
+## VCF contract
+
+### Boundary of normalization
+
+VCF is extensible and cannot be normalized recursively. The source preserves
+the raw parser materialization and adds only these GenomeSpy-owned fields:
+
+```js
+{
+    CHROM, POS, ID, REF, ALT, QUAL, FILTER, INFO, SAMPLES,
+    // ...other raw parser fields...
+    chrom, // reference name under the policy selected in MB-3
+    start, // zero-based inclusive local start
+    end,   // zero-based exclusive local end
+}
+```
+
+`chrom/start/end` describe the primary local reference interval, not every
+coordinate contained by the VCF record.
+
+Raw fields remain untouched:
+
+- `POS` stays one-based.
+- `INFO.END` retains VCF semantics. Its numeric value normally equals the
+  canonical exclusive `end`; do not decrement it in place.
+- Breakend mate positions embedded in `ALT` stay raw.
+- Arbitrary `INFO`, `FORMAT`, sample, `ANN`, and `CSQ` values stay raw.
+- Relative fields such as `CIPOS` and `CIEND` stay relative offsets.
+
+### Primary interval computation
+
+Create one shared helper used by eager `format.type: "vcf"` and lazy
+`data.lazy.type: "vcf"`:
+
+1. `chrom` follows the reference-name policy selected in MB-3 while raw `CHROM`
+   remains unchanged.
+2. `start` is `POS - 1`.
+3. Compute `end` from the exact algorithm selected in MB-2.
+
+**MB-2:** Current `@gmod/vcf` materializes non-flag INFO values as arrays, so
+`INFO.END` and `INFO.SVTYPE` must not be treated as scalars. Current Tabix
+interval logic also treats `SVTYPE=TRA` as a one-base local interval before
+considering `END`; other records use a valid `END` or fall back to
+`start + REF.length`. Decide whether the public helper adopts those semantics
+exactly, then specify failure behavior for invalid or missing `POS`, `END`, and
+`REF`. Eager and lazy parsing must use the same decision.
+
+Validate the helper against the interval semantics used by the upgraded Tabix
+library. Do not use field-name heuristics such as `POS2` or recursively scan
+annotations. A later normalized mate-breakpoint API requires a separate,
+format-aware design.
+
+For multi-allelic or structural records, the canonical interval is the record's
+local reference span. It is not a promise of one normalized interval per ALT
+allele.
+
+Update `packages/core/src/data/formats/vcfTypes.d.ts` to include the canonical
+fields without weakening the types of preserved raw fields.
+
+### Collision behavior
+
+The GMOD parser currently uses uppercase standard fields and nests INFO/sample
+data, so lowercase `chrom/start/end` form a distinct GenomeSpy namespace.
+Fail fast during development if an upgraded parser starts producing conflicting
+top-level lowercase fields; do not silently overwrite parser data without
+reviewing the public contract.
+
+### VCF verification
+
+- Test SNVs, insertions, deletions, symbolic alleles with `END`, multi-allelic
+  records, and breakends.
+- Assert raw `POS`, `INFO`, `ALT`, and sample objects are unchanged.
+- Assert eager and lazy parsing produce identical canonical fields.
+- Assert breakend mate coordinates and confidence intervals are not rewritten.
+- Test the MB-3 reference-name policy separately from raw `CHROM` preservation.
+- Update ClinVar to encode canonical fields without an encoding offset.
+- Audit HCC1954 structural-variant formulas so local and mate endpoints declare
+  explicitly whether they consume canonical or raw values.
+
+## Indexing-offset retirement
+
+### Encoding offset
+
+`ChromPosDefBase.offset` is currently copied by
+`packages/core/src/view/flowBuilder.js` into an implicit
+`LinearizeGenomicCoordinate` appended after user transforms. It therefore
+changes final linearization but not earlier access to the same position field.
+Remove it from:
+
+- `packages/core/src/spec/channel.d.ts`
+- implicit transform construction in `packages/core/src/view/flowBuilder.js`
+- generated schemas and schema-derived documentation
+
+The current user documentation is also internally inconsistent: the type docs
+say the offset is subtracted, while `docs/grammar/genomic-coordinates.md`
+describes addition and shows a negative value. Migration removes that ambiguity
+rather than choosing another implicit sign convention.
+
+### Transform offset
+
+Remove `LinearizeGenomicCoordinateParams.offset` and the subtraction code in
+`packages/core/src/data/transforms/linearizeGenomicCoordinate.js`. The transform
+continues to accept `chrom`, one or more `pos` fields, corresponding `as`
+fields, and a locus-scale channel.
+
+Indexing correction is a preceding explicit transform, not a mode of
+linearization. This ordering makes corrected values available to every later
+consumer.
+
+### Unaffected offsets
+
+Do not change:
+
+- `scale.numberingOffset`, which controls labels and tick selection without
+  modifying data;
+- mark `xOffset`, `x2Offset`, `yOffset`, and `y2Offset`;
+- axis, title, legend, stroke-dash, stack, and layout offsets.
+
+Use precise terminology in docs so searches for the removed coordinate option
+do not imply that unrelated offset features are deprecated.
+
+## User-facing documentation
+
+Documentation is an acceptance requirement, not deferred cleanup.
+
+### Genomic coordinates
+
+Update `docs/grammar/genomic-coordinates.md` to:
+
+- define the source/dataflow zero-based half-open invariant;
+- remove locus-encoding offset guidance;
+- demonstrate explicit normalization before other transforms;
+- distinguish data normalization from `scale.numberingOffset`;
+- link to source-specific exceptions and raw-field behavior.
+
+### Coordinate linearization
+
+Update `docs/grammar/transform/linearize-genomic-coordinate.md` to state that
+inputs must already be canonical and to show normalization preceding explicit
+linearization.
+
+### Source pages
+
+Update `docs/grammar/data/eager.md` and `docs/grammar/data/lazy.md` with concise
+returned-field contracts for WIG, BED, BEDPE, BigWig, BigBed, BAM, GFF3, VCF,
+IndexedFASTA, and generic Tabix TSV.
+
+For VCF, use explicit wording: canonical fields describe the primary local
+record interval; all other VCF contents preserve raw semantics.
+
+For GFF, document the exact hierarchy, coordinate contract, strand contract,
+attribute behavior, and slice/orphan behavior needed to use the source.
+
+### Examples and migration page
+
+Update the known affected specifications:
+
+- `examples/docs/examples/genomic-data/gff3-gene-annotations.json`
+- `examples/docs/examples/genomic-data/clinvar-variants.json`
+- `examples/docs/examples/genomic-data/hcc1954-sv-cnv.json`
+- `examples/docs/examples/genomic-data/ASCAT.json`
+- `examples/docs/examples/genomic-data/ASCAT-algorithm.json`
+- their pages under `docs/examples/genomic-data/`
+
+In addition, audit every existing specification under `examples/`, not only the
+known files above, and verify that all examples work correctly. Migrate only
+uses affected by the new coordinate, strand, GFF, VCF, or offset contracts and
+change supporting code or assets only when necessary. This includes imported
+and private/example variants that may not be embedded in the documentation.
+Use repository-wide searches plus `npm run smoke:examples`; the offline
+initialization suite is insufficient because it skips specifications with
+absolute HTTP data URLs. Do not treat the known list as exhaustive or presume
+that every example needs an edit.
+
+Add a v1 migration section with old/new snippets for encoding offsets, explicit
+custom-data correction, numeric strands, GFF hierarchy fields, and canonical
+versus raw VCF fields.
+
+**MB-8:** Select a concrete migration document path and add it to
+`zensical.toml`. Decide whether the offsets receive an observable prerelease
+deprecation or are removed directly for 1.0; document the chosen path in types,
+schema-derived docs, and the migration page. Replace mutable upstream `main`
+links used as compatibility evidence with release-tagged or commit-pinned links.
+
+Regenerate schema artifacts from `.d.ts` sources. Do not edit generated schema
+descriptions directly.
+
+## Acceptance criteria
+
+- The general coordinate and strand contracts are stated once and linked from
+  every format-specific page.
+- Known adapters normalize before any user-authored transform.
+- Generic/custom records are unchanged and have a documented explicit
+  normalization pattern.
+- GFF and VCF fulfill their bounded contracts and do not claim broader
+  normalization.
+- Encoding and transform indexing offsets are absent from the final schema.
+- Every affected in-repository example uses canonical fields without hidden
+  coordinate adjustment.
+- Every existing specification under `examples/` has been audited and verified
+  to work. Only affected specifications and supporting code or assets are
+  migrated; no affected example depends on indexing offsets, numeric source
+  strands, the legacy GFF hierarchy, or raw VCF `POS` for its primary genomic
+  placement.
+- Documentation contains no remaining recommendation to correct genomic
+  indexing in a locus encoding or during linearization.
+- MB-2, MB-3, MB-4, MB-5, MB-7, and MB-8 are closed before merge.

--- a/zensical.toml
+++ b/zensical.toml
@@ -8,6 +8,7 @@ extra_css = ["stylesheets/extra.css"]
 nav = [
     "index.md",
     "getting-started.md",
+    { "Migration to GenomeSpy 2.0" = "migration/v2-genomic-data.md" },
     { "Visualization Grammar" = [
         "grammar/index.md",
         { "Data Input" = [


### PR DESCRIPTION
GenomeSpy 1.x intentionally preserves and documents its current GMOD-backed record formats. This draft prepares the breaking GenomeSpy 2.0 migration and is opened now so the planned resolution of the related issues is visible. It must not merge before the v2.0 development window.

- Standardize public strand values as `"+"`, `"-"`, or `null`.
- Migrate GFF3 records to the `gff-nostream` v5 hierarchy and coordinate model.
- Upgrade the related GMOD integrations and bound shared lazy-source caches.
- Update affected examples, tests, schemas, and migration documentation.

Still in progress:

- Define and implement canonical VCF primary intervals.
- Decide and implement the indexing-offset removal path.
- Complete public output typings and v2.0 migration documentation.
- Run the final full verification matrix.

Closes #459
Closes #460
