### PR TITLE
feat(core): make minimal renderers opt-in

### DIFF
--- a/docs/api/embedding.md
+++ b/docs/api/embedding.md
@@ -12,10 +12,13 @@ entry points for importing the `embed` function:
 `@genome-spy/core` is the default entry point. It includes the standard
 GenomeSpy runtime and the built-in data source and format registrations.
 
-`@genome-spy/core/minimal` provides the same `embed` API without the built-in
-loaders. Import the data source and format modules you need explicitly:
+`@genome-spy/core/minimal` provides the same `embed` API without built-in
+renderers or optional data loaders. Import at least one live renderer and any
+data source or format modules you need explicitly:
 
 ```js
+import "@genome-spy/core/rendering/webgl.js";
+import "@genome-spy/core/rendering/canvas.js";
 import { embed } from "@genome-spy/core/minimal";
 import "@genome-spy/core/data/formats/parquet.js";
 import "@genome-spy/core/data/sources/lazy/bigBedSource.js";
@@ -26,6 +29,13 @@ const spec = {
 
 const api = await embed(document.body, spec);
 ```
+
+The `webgl.js` import enables WebGL2. The `canvas.js` import enables Canvas2D
+as a live renderer and as a fallback for raster export and hybrid SVG
+rasterization. Import `@genome-spy/core/rendering/svg.js` when using SVG export
+or analysis. You can omit any renderer capability the host application does
+not use; Core reports the required import if an unavailable capability is
+requested.
 
 ## API object
 

--- a/docs/api/runtime-state.md
+++ b/docs/api/runtime-state.md
@@ -118,6 +118,8 @@ The default and full entry points register both binary readers. With the
 host uses:
 
 ```js
+import "@genome-spy/core/rendering/webgl.js";
+import "@genome-spy/core/rendering/canvas.js";
 import { embed } from "@genome-spy/core/minimal";
 import "@genome-spy/core/data/formats/arrow.js";
 import "@genome-spy/core/data/formats/parquet.js";

--- a/packages/core/docs/architecture/rendering.md
+++ b/packages/core/docs/architecture/rendering.md
@@ -57,13 +57,17 @@ Modular rendering implementations live under `src/rendering/`:
   delegates, batching, picking, and rasterization.
 - `webgpu/` is the development-only Core adapter for the separate WebGPU
   renderer package.
-- `renderingBackend.js` selects the live surface and exposes rendering, export,
-  and optional picking capabilities.
+- `renderingModuleRegistry.js` holds opt-in loaders without importing renderer
+  implementations.
+- `renderingBackend.js` selects a registered live surface and exposes
+  rendering, export, and optional picking capabilities.
 
-`renderingBackend.js` dynamically imports WebGL when `webgl` is selected or
-when `auto` makes its WebGL-first attempt. Explicit Canvas2D and WebGPU
-selection does not initialize WebGL. If automatic WebGL initialization fails,
-Core falls back to Canvas2D; an explicit WebGL failure is reported.
+The full entrypoint registers dynamically imported WebGL, Canvas2D, and SVG
+modules. The minimal entrypoint registers none of them; applications enable
+only the capabilities they use through public side-effect imports. Automatic
+selection tries registered WebGL first and then registered Canvas2D. Explicit
+Canvas2D and WebGPU selection does not initialize WebGL. An explicit WebGL
+failure is reported.
 
 Semantic marks remain under `src/marks/`. They own configuration, encoders,
 data, facet semantics, and rendering revisions. WebGL's private adapter owns one
@@ -77,7 +81,8 @@ selective rasterization capability and may fall through to detached Canvas2D.
 Run selection, image placeholders, cropping, and document ordering remain
 SVG-owned. Export never initializes an unselected GPU backend.
 
-The ESM build preserves these dynamic boundaries. UMD is a compatibility
+The ESM build preserves these dynamic boundaries. Its minimal entry chunk and
+complete chunk graph exclude unregistered renderers. UMD is a compatibility
 artifact and inlines dynamic modules because its format cannot emit runtime
 chunks.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,9 @@
     ".": "./src/index.js",
     "./minimal": "./src/minimal.js",
     "./full": "./src/full.js",
+    "./rendering/canvas.js": "./src/rendering/registerCanvas.js",
+    "./rendering/svg.js": "./src/rendering/registerSvg.js",
+    "./rendering/webgl.js": "./src/rendering/registerWebGL.js",
     "./browser": {
       "import": "./dist/bundle/index.es.js",
       "default": "./dist/bundle/index.js"

--- a/packages/core/scripts/verifyMinimalBundle.mjs
+++ b/packages/core/scripts/verifyMinimalBundle.mjs
@@ -33,6 +33,11 @@ const optionalRenderingDirectories = [
 ];
 const webGlRenderingDirectory = "src/rendering/webgl/";
 const webGpuRenderingDirectory = "src/rendering/webgpu/";
+const rendererRegistrationSources = [
+    "src/rendering/registerCanvas.js",
+    "src/rendering/registerSvg.js",
+    "src/rendering/registerWebGL.js",
+];
 
 const tempDir = fs.mkdtempSync(
     path.join(os.tmpdir(), "genome-spy-minimal-bundle-")
@@ -49,7 +54,6 @@ try {
         minimalOutDir
     );
     const minimalSources = readStaticEntrySources(minimalOutput, "minimal.js");
-    verifyNoStaticWebGLSources(minimalSources, "Minimal bundle");
 
     for (const forbidden of forbiddenSources) {
         if (minimalSources.some((source) => source.endsWith(forbidden))) {
@@ -59,14 +63,10 @@ try {
         }
     }
 
-    for (const forbidden of optionalRenderingDirectories) {
-        if (minimalSources.some((source) => source.includes(forbidden))) {
-            throw new Error(
-                `Minimal bundle should not include ${forbidden}, but it does.`
-            );
-        }
-    }
-    verifyDynamicWebGLChunk(minimalOutput, "minimal.js");
+    verifyNoOptionalRendererSources(
+        readAllOutputSources(minimalOutput),
+        "Minimal bundle"
+    );
 
     const productionOutput = await buildEntry(
         "index.js",
@@ -99,7 +99,19 @@ try {
             `Production bundle should not include ${webGpuRenderingDirectory}, but it does.`
         );
     }
-    verifyDynamicWebGLChunk(productionOutput, "index.js");
+    verifyDynamicRendererChunks(productionOutput, "index.js", {
+        name: "WebGL",
+        directory: webGlRenderingDirectory,
+        isImplementationSource: isWebGLImplementationSource,
+    });
+    verifyDynamicRendererChunks(productionOutput, "index.js", {
+        name: "Canvas2D",
+        directory: "src/rendering/canvas2d/",
+    });
+    verifyDynamicRendererChunks(productionOutput, "index.js", {
+        name: "SVG",
+        directory: "src/rendering/svg/",
+    });
 
     console.log("Minimal bundle verification passed.");
 } finally {
@@ -171,8 +183,9 @@ function verifyNoStaticWebGLSources(sources, owner) {
 /**
  * @param {Array<import("rollup").OutputChunk | import("rollup").OutputAsset>} output
  * @param {string} entry
+ * @param {{name: string, directory: string, isImplementationSource?: (source: string) => boolean}} options
  */
-function verifyDynamicWebGLChunk(output, entry) {
+function verifyDynamicRendererChunks(output, entry, options) {
     const chunks = output.filter((item) => item.type == "chunk");
     const chunksByFileName = new Map(
         chunks.map((chunk) => [chunk.fileName, chunk])
@@ -215,39 +228,69 @@ function verifyDynamicWebGLChunk(output, entry) {
 
     visit(entryChunk, false);
 
-    const webGlChunks = chunks.filter((chunk) =>
+    const isImplementationSource =
+        options.isImplementationSource ??
+        ((source) => normalizeSource(source).includes(options.directory));
+    const rendererChunks = chunks.filter((chunk) =>
         Object.keys(chunk.modules)
             .map(normalizeSource)
-            .some(isWebGLImplementationSource)
+            .some(isImplementationSource)
     );
-    if (!webGlChunks.length) {
-        throw new Error(`Build for ${entry} did not contain a WebGL chunk.`);
+    if (!rendererChunks.length) {
+        throw new Error(
+            `Build for ${entry} did not contain a ${options.name} chunk.`
+        );
     }
 
-    const factoryChunk = webGlChunks.find((chunk) =>
+    const factoryChunk = rendererChunks.find((chunk) =>
         Object.keys(chunk.modules)
             .map(normalizeSource)
-            .some((source) =>
-                source.endsWith(webGlRenderingDirectory + "index.js")
-            )
+            .some((source) => source.endsWith(options.directory + "index.js"))
     );
     if (!factoryChunk) {
         throw new Error(
-            `Build for ${entry} did not contain ${webGlRenderingDirectory}index.js.`
+            `Build for ${entry} did not contain ${options.directory}index.js.`
         );
     }
     if (!dynamicallyReachable.has(factoryChunk.fileName)) {
         throw new Error(
-            `WebGL factory chunk ${factoryChunk.fileName} is not dynamically reachable from the production entry.`
+            `${options.name} factory chunk ${factoryChunk.fileName} is not dynamically reachable from ${entry}.`
         );
     }
 
-    const unreachableChunk = webGlChunks.find(
+    const unreachableChunk = rendererChunks.find(
         (chunk) => !dynamicallyReachable.has(chunk.fileName)
     );
     if (unreachableChunk) {
         throw new Error(
-            `WebGL implementation chunk ${unreachableChunk.fileName} is not behind a dynamic import.`
+            `${options.name} implementation chunk ${unreachableChunk.fileName} is not behind a dynamic import.`
+        );
+    }
+}
+
+/**
+ * @param {string[]} sources
+ * @param {string} owner
+ */
+function verifyNoOptionalRendererSources(sources, owner) {
+    const forbiddenDirectories = [
+        ...optionalRenderingDirectories,
+        webGlRenderingDirectory,
+        webGpuRenderingDirectory,
+    ];
+    const source = sources.find(
+        (source) =>
+            forbiddenDirectories.some((directory) =>
+                source.includes(directory)
+            ) ||
+            rendererRegistrationSources.some((registration) =>
+                source.endsWith(registration)
+            ) ||
+            isWebGLImplementationSource(source)
+    );
+    if (source) {
+        throw new Error(
+            `${owner} should not include optional renderer sources, but includes ${source}.`
         );
     }
 }

--- a/packages/core/scripts/verifyMinimalBundle.mjs
+++ b/packages/core/scripts/verifyMinimalBundle.mjs
@@ -275,7 +275,6 @@ function verifyDynamicRendererChunks(output, entry, options) {
 function verifyNoOptionalRendererSources(sources, owner) {
     const forbiddenDirectories = [
         ...optionalRenderingDirectories,
-        webGlRenderingDirectory,
         webGpuRenderingDirectory,
     ];
     const source = sources.find(

--- a/packages/core/src/genomeSpy.js
+++ b/packages/core/src/genomeSpy.js
@@ -12,5 +12,8 @@ import "./data/formats/wig.js";
 import "./data/formats/vcf.js";
 // These side-effect imports make the default runtime fat for convenience.
 import "./data/sources/lazy/registerBuiltInLazySources.js";
+import "./rendering/registerCanvas.js";
+import "./rendering/registerSvg.js";
+import "./rendering/registerWebGL.js";
 
 export { default } from "./genomeSpyBase.js";

--- a/packages/core/src/genomeSpyBase.js
+++ b/packages/core/src/genomeSpyBase.js
@@ -26,6 +26,7 @@ import { invalidatePrefix } from "./utils/propertyCacher.js";
 import { VIEW_ROOT_NAME, ViewFactory } from "./view/viewFactory.js";
 import InteractionController from "./genomeSpy/interactionController.js";
 import { createRenderingBackend } from "./rendering/renderingBackend.js";
+import { renderingModules } from "./rendering/renderingModuleRegistry.js";
 import {
     exportRasterUsingBackend,
     rasterizeSvgRunsUsingBackend,
@@ -791,8 +792,7 @@ export default class GenomeSpy {
         const background = getExportBackground(this.spec, options);
 
         try {
-            const { createSvgExport } =
-                await import("./rendering/svg/index.js");
+            const { createSvgExport } = await loadSvgRenderer();
             const { svg, warnings, rasterized } = await createSvgExport({
                 viewRoot: this.viewRoot,
                 rasterizeSvgRuns: (rasterOptions) =>
@@ -830,7 +830,7 @@ export default class GenomeSpy {
         const logicalWidth = options.logicalWidth ?? canvasSize.width;
         const logicalHeight = options.logicalHeight ?? canvasSize.height;
         try {
-            const svgModule = await import("./rendering/svg/index.js");
+            const svgModule = await loadSvgRenderer();
             return svgModule.analyzeSvgExport({
                 viewRoot: this.viewRoot,
                 logicalWidth,
@@ -908,6 +908,16 @@ export default class GenomeSpy {
         });
         return resolutions;
     }
+}
+
+async function loadSvgRenderer() {
+    const loader = renderingModules.svgRenderer;
+    if (!loader) {
+        throw new Error(
+            'SVG export is not registered. Import "@genome-spy/core/rendering/svg.js" when using "@genome-spy/core/minimal".'
+        );
+    }
+    return loader();
 }
 
 /**

--- a/packages/core/src/genomeSpyCanvasLive.test.js
+++ b/packages/core/src/genomeSpyCanvasLive.test.js
@@ -4,6 +4,9 @@ import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("./styles/genome-spy.css.js", () => ({ default: "" }));
 
+import "./rendering/registerCanvas.js";
+import "./rendering/registerSvg.js";
+import "./rendering/registerWebGL.js";
 import GenomeSpy from "./genomeSpyBase.js";
 
 /** @type {ReturnType<typeof createContext>[]} */

--- a/packages/core/src/minimal.js
+++ b/packages/core/src/minimal.js
@@ -1,14 +1,14 @@
 /**
  * Lean GenomeSpy core entry point.
  *
- * Use this entry when you want the `embed` API without the default built-in
- * optional eager and lazy format registrations. Core axis lazy sources remain
- * available.
+ * Use this entry when you want the `embed` API without the default renderer,
+ * eager format, and lazy data-source registrations. Core axis lazy sources
+ * remain available.
  */
 import { html } from "lit";
 
-// Lean core entry point: shares the embed API, but skips optional eager and
-// lazy format registrations.
+// Lean core entry point: shares the embed API, but skips optional renderer,
+// eager format, and lazy data-source registrations.
 import GenomeSpy from "./genomeSpyBase.js";
 import icon from "./img/bowtie.svg";
 import favIcon from "./img/genomespy-favicon.svg";

--- a/packages/core/src/rendering/README.md
+++ b/packages/core/src/rendering/README.md
@@ -6,7 +6,9 @@ graph and expose only the capabilities needed by shared orchestration.
 
 ## Directory layout
 
-- `renderingBackend.js` dynamically selects the live backend and exposes its
+- `renderingModuleRegistry.js` holds the renderer loaders enabled by the active
+  package entrypoint or explicit opt-in imports.
+- `renderingBackend.js` selects a registered live backend and exposes its
   surface, coordinator, raster operations, and optional picking capability.
 - `canvasSizeHelper.js` provides backend-neutral logical and physical surface
   sizing.
@@ -31,8 +33,9 @@ immediate layer must not import Canvas2D, SVG, WebGL, or WebGPU code. There is
 intentionally no universal low-level drawing interface shared by every
 renderer.
 
-`renderingBackend.js` is the only static caller of renderer factories. WebGL,
-Canvas2D, and SVG enter through dynamic imports. Keep all TWGL and GLSL imports
+The `register*.js` modules are the only static bridge to renderer factories.
+Their dynamic imports keep WebGL, Canvas2D, and SVG out of the minimal entrypoint
+unless explicitly enabled. Keep all TWGL and GLSL imports
 under `webgl/`; adding one elsewhere would pull the temporary renderer back
 into the synchronous ESM graph.
 

--- a/packages/core/src/rendering/canvas2d/README.md
+++ b/packages/core/src/rendering/canvas2d/README.md
@@ -1,10 +1,11 @@
 # Canvas2D renderer
 
 This directory contains GenomeSpy Core's compatibility renderer for browsers
-and virtual desktops where WebGL2 is unavailable. The subsystem is dynamically
-imported after backend selection, so normal WebGL rendering does not include it
-in the synchronous ESM entry bundle. The single-file UMD distribution still
-inlines optional modules.
+and virtual desktops where WebGL2 is unavailable. `../registerCanvas.js`
+registers its dynamically imported live and raster capabilities. Normal WebGL
+rendering does not include it in the synchronous ESM entry bundle, while the
+minimal entrypoint omits it entirely unless explicitly enabled. The single-file
+UMD distribution still inlines optional modules.
 
 ## Architecture
 

--- a/packages/core/src/rendering/rasterization.js
+++ b/packages/core/src/rendering/rasterization.js
@@ -1,3 +1,5 @@
+import { renderingModules } from "./renderingModuleRegistry.js";
+
 /**
  * Signals that a raster backend could not be initialized or does not support
  * the requested operation. Rendering errors must use their original type so
@@ -30,9 +32,13 @@ export async function exportRasterUsingBackend(backend, options) {
         }
     }
 
+    if (!renderingModules.canvasRasterExport) {
+        throw unavailableRasterExportError();
+    }
+
     let canvasModule;
     try {
-        canvasModule = await import("./canvas2d/rasterExport.js");
+        canvasModule = await renderingModules.canvasRasterExport();
     } catch (error) {
         throw unavailableRasterExportError(error);
     }
@@ -70,16 +76,21 @@ export async function rasterizeSvgRunsUsingBackend(backend, options) {
         }
     }
 
+    if (!renderingModules.canvasSvgRasterizer) {
+        throw new RasterizationUnavailableError(
+            'No raster backend supports selective SVG rasterization. Import "@genome-spy/core/rendering/canvas.js" to enable the Canvas2D fallback.'
+        );
+    }
+
     let canvasModule;
     try {
-        canvasModule = await import("./canvas2d/svgRasterizer.js");
+        canvasModule = await renderingModules.canvasSvgRasterizer();
     } catch (error) {
         throw new RasterizationUnavailableError(
             "No raster backend supports selective SVG rasterization.",
             { cause: error }
         );
     }
-
     const rasterizeSvgRuns = canvasModule.createCanvas2DSvgRasterizer();
     await rasterizeSvgRuns(options);
 }
@@ -87,7 +98,7 @@ export async function rasterizeSvgRunsUsingBackend(backend, options) {
 /** @param {unknown} cause */
 function unavailableRasterExportError(cause) {
     return new RasterizationUnavailableError(
-        "Raster export is unsupported because no raster rendering backend is available.",
+        'Raster export is unsupported because no raster rendering backend is available. Import "@genome-spy/core/rendering/canvas.js" to enable the Canvas2D fallback.',
         { cause }
     );
 }

--- a/packages/core/src/rendering/rasterization.test.js
+++ b/packages/core/src/rendering/rasterization.test.js
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
     canvasExportRaster: vi.fn(),
@@ -8,25 +8,29 @@ const mocks = vi.hoisted(() => ({
     createCanvas2DSvgRasterizer: vi.fn(),
 }));
 
-vi.mock("./canvas2d/rasterExport.js", () => ({
-    exportRaster: mocks.canvasExportRaster,
-}));
-
-vi.mock("./canvas2d/svgRasterizer.js", () => ({
-    createCanvas2DSvgRasterizer: mocks.createCanvas2DSvgRasterizer,
-}));
-
 import {
     exportRasterUsingBackend,
     RasterizationUnavailableError,
     rasterizeSvgRunsUsingBackend,
 } from "./rasterization.js";
+import { renderingModules } from "./renderingModuleRegistry.js";
 
 beforeEach(() => {
     vi.resetAllMocks();
     mocks.createCanvas2DSvgRasterizer.mockReturnValue(
         mocks.canvasRasterizeSvgRuns
     );
+    renderingModules.canvasRasterExport = async () => ({
+        exportRaster: mocks.canvasExportRaster,
+    });
+    renderingModules.canvasSvgRasterizer = async () => ({
+        createCanvas2DSvgRasterizer: mocks.createCanvas2DSvgRasterizer,
+    });
+});
+
+afterEach(() => {
+    delete renderingModules.canvasRasterExport;
+    delete renderingModules.canvasSvgRasterizer;
 });
 
 describe("raster capability routing", () => {
@@ -82,15 +86,11 @@ describe("raster capability routing", () => {
     });
 
     test("rejects explicitly when no full-raster backend is available", async () => {
-        mocks.canvasExportRaster.mockRejectedValue(
-            new RasterizationUnavailableError("No Canvas2D")
-        );
+        delete renderingModules.canvasRasterExport;
 
         await expect(
             exportRasterUsingBackend(createBackend(), createExportOptions())
-        ).rejects.toThrow(
-            "Raster export is unsupported because no raster rendering backend is available."
-        );
+        ).rejects.toThrow("@genome-spy/core/rendering/canvas.js");
     });
 
     test("prefers the selected backend for selective SVG rasterization", async () => {

--- a/packages/core/src/rendering/registerCanvas.js
+++ b/packages/core/src/rendering/registerCanvas.js
@@ -1,0 +1,12 @@
+import { renderingModules } from "./renderingModuleRegistry.js";
+
+renderingModules.canvasBackend = async (options) => {
+    const { createCanvas2DRenderingBackend } =
+        await import("./canvas2d/index.js");
+    return createCanvas2DRenderingBackend(options);
+};
+
+renderingModules.canvasRasterExport = () =>
+    import("./canvas2d/rasterExport.js");
+renderingModules.canvasSvgRasterizer = () =>
+    import("./canvas2d/svgRasterizer.js");

--- a/packages/core/src/rendering/registerSvg.js
+++ b/packages/core/src/rendering/registerSvg.js
@@ -1,0 +1,3 @@
+import { renderingModules } from "./renderingModuleRegistry.js";
+
+renderingModules.svgRenderer = () => import("./svg/index.js");

--- a/packages/core/src/rendering/registerWebGL.js
+++ b/packages/core/src/rendering/registerWebGL.js
@@ -1,0 +1,6 @@
+import { renderingModules } from "./renderingModuleRegistry.js";
+
+renderingModules.webglBackend = async (options) => {
+    const { createWebGLRenderingBackend } = await import("./webgl/index.js");
+    return createWebGLRenderingBackend(options);
+};

--- a/packages/core/src/rendering/renderingBackend.js
+++ b/packages/core/src/rendering/renderingBackend.js
@@ -1,4 +1,5 @@
 import { warnOnce } from "../utils/warning.js";
+import { renderingModules } from "./renderingModuleRegistry.js";
 
 /**
  * @typedef {object} RenderingSurface
@@ -66,45 +67,47 @@ import { warnOnce } from "../utils/warning.js";
  */
 export async function createRenderingBackend(options) {
     if (options.renderer == "canvas") {
-        return createCanvas2DBackend(options);
+        if (!renderingModules.canvasBackend) {
+            throw rendererNotRegisteredError("canvas");
+        }
+        return renderingModules.canvasBackend(options);
     } else if (options.renderer == "webgpu" && import.meta.env.DEV) {
         return createWebGpuBackend(options);
     } else if (options.renderer != "auto" && options.renderer != "webgl") {
         throw new Error("Unknown renderer: " + options.renderer);
     }
 
+    const webGlFactory = renderingModules.webglBackend;
+    const canvasFactory = renderingModules.canvasBackend;
+    if (!webGlFactory) {
+        if (options.renderer == "webgl") {
+            throw rendererNotRegisteredError("webgl");
+        } else if (canvasFactory) {
+            return canvasFactory(options);
+        }
+        throw new Error(
+            'No rendering backend is registered. Import "@genome-spy/core/rendering/webgl.js" or "@genome-spy/core/rendering/canvas.js" when using "@genome-spy/core/minimal".'
+        );
+    }
+
     try {
-        return await createWebGLBackend(options);
+        return await webGlFactory(options);
     } catch (error) {
         if (options.renderer == "webgl") {
             throw error;
+        } else if (!canvasFactory) {
+            throw new Error(
+                'WebGL2 initialization failed and the Canvas2D fallback is not registered. Import "@genome-spy/core/rendering/canvas.js" when using "@genome-spy/core/minimal".',
+                { cause: error }
+            );
         }
 
-        const backend = await createCanvas2DBackend(options);
+        const backend = await canvasFactory(options);
         warnOnce(
             "WebGL2 is unavailable. Using the Canvas2D compatibility renderer."
         );
         return backend;
     }
-}
-
-/**
- * @param {RenderingBackendOptions} options
- * @returns {Promise<RenderingBackend>}
- */
-async function createWebGLBackend(options) {
-    const { createWebGLRenderingBackend } = await import("./webgl/index.js");
-    return createWebGLRenderingBackend(options);
-}
-
-/**
- * @param {RenderingBackendOptions} options
- * @returns {Promise<RenderingBackend>}
- */
-async function createCanvas2DBackend(options) {
-    const { createCanvas2DRenderingBackend } =
-        await import("./canvas2d/index.js");
-    return createCanvas2DRenderingBackend(options);
 }
 
 /**
@@ -117,4 +120,11 @@ async function createWebGpuBackend(options) {
         /* @vite-ignore */ modulePath
     );
     return createWebGpuRenderingBackend(options);
+}
+
+/** @param {"canvas" | "webgl"} renderer */
+function rendererNotRegisteredError(renderer) {
+    return new Error(
+        `The "${renderer}" rendering backend is not registered. Import "@genome-spy/core/rendering/${renderer}.js" when using "@genome-spy/core/minimal".`
+    );
 }

--- a/packages/core/src/rendering/renderingBackend.test.js
+++ b/packages/core/src/rendering/renderingBackend.test.js
@@ -1,20 +1,12 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
     createWebGLRenderingBackend: vi.fn(),
     createCanvas2DRenderingBackend: vi.fn(),
     createWebGpuRenderingBackend: vi.fn(),
     warnOnce: vi.fn(),
-}));
-
-vi.mock("./webgl/index.js", () => ({
-    createWebGLRenderingBackend: mocks.createWebGLRenderingBackend,
-}));
-
-vi.mock("./canvas2d/index.js", () => ({
-    createCanvas2DRenderingBackend: mocks.createCanvas2DRenderingBackend,
 }));
 
 vi.mock("./webgpu/index.js", () => ({
@@ -26,6 +18,7 @@ vi.mock("../utils/warning.js", () => ({
 }));
 
 import { createRenderingBackend } from "./renderingBackend.js";
+import { renderingModules } from "./renderingModuleRegistry.js";
 
 const baseOptions = {
     renderer: /** @type {const} */ ("auto"),
@@ -38,6 +31,15 @@ const baseOptions = {
 describe("createRenderingBackend", () => {
     beforeEach(() => {
         vi.resetAllMocks();
+        renderingModules.webglBackend = async (options) =>
+            mocks.createWebGLRenderingBackend(options);
+        renderingModules.canvasBackend = async (options) =>
+            mocks.createCanvas2DRenderingBackend(options);
+    });
+
+    afterEach(() => {
+        delete renderingModules.canvasBackend;
+        delete renderingModules.webglBackend;
     });
 
     test("loads WebGL without loading Canvas2D when WebGL is available", async () => {
@@ -140,5 +142,52 @@ describe("createRenderingBackend", () => {
             })
         ).rejects.toBe(failure);
         expect(mocks.createCanvas2DRenderingBackend).not.toHaveBeenCalled();
+    });
+
+    test("explains how to enable the missing automatic fallback", async () => {
+        delete renderingModules.canvasBackend;
+        mocks.createWebGLRenderingBackend.mockRejectedValue(
+            new Error("No WebGL2")
+        );
+
+        await expect(
+            createRenderingBackend({
+                ...baseOptions,
+                container: document.createElement("div"),
+            })
+        ).rejects.toThrow("@genome-spy/core/rendering/canvas.js");
+    });
+
+    test("uses the registered Canvas2D backend when auto has no WebGL", async () => {
+        delete renderingModules.webglBackend;
+        const canvasBackend = /** @type {any} */ ({ surface: {} });
+        mocks.createCanvas2DRenderingBackend.mockReturnValue(canvasBackend);
+
+        await expect(
+            createRenderingBackend({
+                ...baseOptions,
+                container: document.createElement("div"),
+            })
+        ).resolves.toBe(canvasBackend);
+        expect(mocks.createWebGLRenderingBackend).not.toHaveBeenCalled();
+    });
+
+    test("explains how to register a missing renderer", async () => {
+        delete renderingModules.webglBackend;
+        delete renderingModules.canvasBackend;
+
+        await expect(
+            createRenderingBackend({
+                ...baseOptions,
+                container: document.createElement("div"),
+            })
+        ).rejects.toThrow("@genome-spy/core/rendering/webgl.js");
+        await expect(
+            createRenderingBackend({
+                ...baseOptions,
+                renderer: "canvas",
+                container: document.createElement("div"),
+            })
+        ).rejects.toThrow("@genome-spy/core/rendering/canvas.js");
     });
 });

--- a/packages/core/src/rendering/renderingModuleRegistry.js
+++ b/packages/core/src/rendering/renderingModuleRegistry.js
@@ -1,0 +1,13 @@
+/**
+ * @typedef {(options: import("./renderingBackend.js").RenderingBackendOptions) => Promise<import("./renderingBackend.js").RenderingBackend>} RenderingBackendFactory
+ * @typedef {() => Promise<typeof import("./svg/index.js")>} SvgRendererLoader
+ * @typedef {object} RenderingModules
+ * @prop {RenderingBackendFactory} [canvasBackend]
+ * @prop {RenderingBackendFactory} [webglBackend]
+ * @prop {() => Promise<{exportRaster: typeof import("./canvas2d/rasterExport.js").exportRaster}>} [canvasRasterExport]
+ * @prop {() => Promise<{createCanvas2DSvgRasterizer: typeof import("./canvas2d/svgRasterizer.js").createCanvas2DSvgRasterizer}>} [canvasSvgRasterizer]
+ * @prop {SvgRendererLoader} [svgRenderer]
+ */
+
+/** @type {RenderingModules} */
+export const renderingModules = {};

--- a/packages/core/src/rendering/svg/README.md
+++ b/packages/core/src/rendering/svg/README.md
@@ -1,8 +1,9 @@
 # SVG export
 
-This directory contains GenomeSpy Core's vector export implementation. The
-subsystem is dynamically imported by `GenomeSpy.exportSvg()` so normal WebGL
-rendering does not include it in the main bundle.
+This directory contains GenomeSpy Core's vector export implementation.
+`../registerSvg.js` registers the dynamically imported subsystem, so normal
+rendering does not include it in the main bundle and the minimal entrypoint can
+omit it entirely.
 
 ## Architecture
 

--- a/packages/core/src/rendering/webgl/README.md
+++ b/packages/core/src/rendering/webgl/README.md
@@ -4,7 +4,8 @@ This directory contains GenomeSpy Core's legacy WebGL2 renderer. It remains a
 production backend during the transition to WebGPU with Canvas2D fallback, but
 it is intentionally isolated so it can eventually be deleted as one module.
 
-The implementation is dynamically imported by `../renderingBackend.js`.
+The implementation is registered by `../registerWebGL.js` and dynamically
+imported only when selected.
 Shared Core modules must not import TWGL, GLSL, `WebGLHelper`, WebGL mark
 delegates, or renderer resource types. The compatibility UMD bundle still
 inlines dynamic modules because its format cannot emit runtime chunks.
@@ -27,8 +28,9 @@ initialize another renderer.
 
 ## Initialization and lifetime
 
-When `webgl` is selected, `renderingBackend.js` dynamically imports this
-directory's `index.js`. The entry point creates one `WebGLHelper` and one
+When `webgl` is selected, `renderingBackend.js` invokes the factory registered
+by `../registerWebGL.js`, which dynamically imports this directory's `index.js`.
+The entry point creates one `WebGLHelper` and one
 `WebGLRendererResources` for the lifetime of the backend. The helper creates
 the canvas, WebGL2 context, picking framebuffer, size observer, and global GL
 state; the resource owner registers itself as the helper's resource finalizer.

--- a/packages/embed-examples/src/brushLinkingApi.js
+++ b/packages/embed-examples/src/brushLinkingApi.js
@@ -1,6 +1,5 @@
 import { embed, intervalSelection } from "@genome-spy/core/minimal";
 import "@genome-spy/core/rendering/webgl.js";
-import "@genome-spy/core/rendering/canvas.js";
 
 /**
  * @typedef {import("@genome-spy/core/types/selectionTypes.js").IntervalSelection} IntervalSelection

--- a/packages/embed-examples/src/brushLinkingApi.js
+++ b/packages/embed-examples/src/brushLinkingApi.js
@@ -1,4 +1,6 @@
 import { embed, intervalSelection } from "@genome-spy/core/minimal";
+import "@genome-spy/core/rendering/webgl.js";
+import "@genome-spy/core/rendering/canvas.js";
 
 /**
  * @typedef {import("@genome-spy/core/types/selectionTypes.js").IntervalSelection} IntervalSelection

--- a/packages/embed-examples/src/dynamicFasta.js
+++ b/packages/embed-examples/src/dynamicFasta.js
@@ -1,4 +1,6 @@
 import { embed } from "@genome-spy/core/minimal";
+import "@genome-spy/core/rendering/webgl.js";
+import "@genome-spy/core/rendering/canvas.js";
 
 import { IndexedFasta } from "@gmod/indexedfasta";
 import { RemoteFile } from "generic-filehandle";

--- a/packages/embed-examples/src/dynamicFasta.js
+++ b/packages/embed-examples/src/dynamicFasta.js
@@ -1,6 +1,5 @@
 import { embed } from "@genome-spy/core/minimal";
 import "@genome-spy/core/rendering/webgl.js";
-import "@genome-spy/core/rendering/canvas.js";
 
 import { IndexedFasta } from "@gmod/indexedfasta";
 import { RemoteFile } from "generic-filehandle";

--- a/packages/embed-examples/src/dynamicNamedData.js
+++ b/packages/embed-examples/src/dynamicNamedData.js
@@ -1,4 +1,6 @@
 import { embed } from "@genome-spy/core/minimal";
+import "@genome-spy/core/rendering/webgl.js";
+import "@genome-spy/core/rendering/canvas.js";
 
 /** @type {import("@genome-spy/core/spec/root.js").RootSpec} */
 const spec = {

--- a/packages/embed-examples/src/dynamicNamedData.js
+++ b/packages/embed-examples/src/dynamicNamedData.js
@@ -1,6 +1,5 @@
 import { embed } from "@genome-spy/core/minimal";
 import "@genome-spy/core/rendering/webgl.js";
-import "@genome-spy/core/rendering/canvas.js";
 
 /** @type {import("@genome-spy/core/spec/root.js").RootSpec} */
 const spec = {

--- a/packages/embed-examples/src/inspectorOverlay.js
+++ b/packages/embed-examples/src/inspectorOverlay.js
@@ -1,4 +1,6 @@
 import { embed } from "@genome-spy/core/minimal";
+import "@genome-spy/core/rendering/webgl.js";
+import "@genome-spy/core/rendering/canvas.js";
 import { attachInspectorOverlay } from "@genome-spy/inspector";
 
 /** @type {import("@genome-spy/core/spec/root.js").RootSpec} */

--- a/packages/embed-examples/src/inspectorOverlay.js
+++ b/packages/embed-examples/src/inspectorOverlay.js
@@ -1,6 +1,5 @@
 import { embed } from "@genome-spy/core/minimal";
 import "@genome-spy/core/rendering/webgl.js";
-import "@genome-spy/core/rendering/canvas.js";
 import { attachInspectorOverlay } from "@genome-spy/inspector";
 
 /** @type {import("@genome-spy/core/spec/root.js").RootSpec} */

--- a/packages/embed-examples/src/linkedEmbeds.js
+++ b/packages/embed-examples/src/linkedEmbeds.js
@@ -1,6 +1,5 @@
 import { embed } from "@genome-spy/core/minimal";
 import "@genome-spy/core/rendering/webgl.js";
-import "@genome-spy/core/rendering/canvas.js";
 import { html, render } from "lit";
 
 /**

--- a/packages/embed-examples/src/linkedEmbeds.js
+++ b/packages/embed-examples/src/linkedEmbeds.js
@@ -1,4 +1,6 @@
 import { embed } from "@genome-spy/core/minimal";
+import "@genome-spy/core/rendering/webgl.js";
+import "@genome-spy/core/rendering/canvas.js";
 import { html, render } from "lit";
 
 /**

--- a/packages/embed-examples/src/multipleDynamicSources.js
+++ b/packages/embed-examples/src/multipleDynamicSources.js
@@ -1,4 +1,6 @@
 import { embed } from "@genome-spy/core/minimal";
+import "@genome-spy/core/rendering/webgl.js";
+import "@genome-spy/core/rendering/canvas.js";
 
 /** @type {import("@genome-spy/core/spec/root.js").RootSpec} */
 const spec = {

--- a/packages/embed-examples/src/multipleDynamicSources.js
+++ b/packages/embed-examples/src/multipleDynamicSources.js
@@ -1,6 +1,5 @@
 import { embed } from "@genome-spy/core/minimal";
 import "@genome-spy/core/rendering/webgl.js";
-import "@genome-spy/core/rendering/canvas.js";
 
 /** @type {import("@genome-spy/core/spec/root.js").RootSpec} */
 const spec = {

--- a/packages/embed-examples/src/namedDataForm.js
+++ b/packages/embed-examples/src/namedDataForm.js
@@ -1,4 +1,6 @@
 import { embed } from "@genome-spy/core/minimal";
+import "@genome-spy/core/rendering/webgl.js";
+import "@genome-spy/core/rendering/canvas.js";
 
 const getFormData = () =>
     ["A", "B"].map((x) => ({

--- a/packages/embed-examples/src/namedDataForm.js
+++ b/packages/embed-examples/src/namedDataForm.js
@@ -1,6 +1,5 @@
 import { embed } from "@genome-spy/core/minimal";
 import "@genome-spy/core/rendering/webgl.js";
-import "@genome-spy/core/rendering/canvas.js";
 
 const getFormData = () =>
     ["A", "B"].map((x) => ({

--- a/packages/embed-examples/src/paramApi.js
+++ b/packages/embed-examples/src/paramApi.js
@@ -1,6 +1,5 @@
 import { embed, intervalSelection } from "@genome-spy/core/minimal";
 import "@genome-spy/core/rendering/webgl.js";
-import "@genome-spy/core/rendering/canvas.js";
 import { html, render } from "lit";
 
 /** @type {import("@genome-spy/core/spec/root.js").RootSpec} */

--- a/packages/embed-examples/src/paramApi.js
+++ b/packages/embed-examples/src/paramApi.js
@@ -1,4 +1,6 @@
 import { embed, intervalSelection } from "@genome-spy/core/minimal";
+import "@genome-spy/core/rendering/webgl.js";
+import "@genome-spy/core/rendering/canvas.js";
 import { html, render } from "lit";
 
 /** @type {import("@genome-spy/core/spec/root.js").RootSpec} */

--- a/packages/embed-examples/src/scaleApi.js
+++ b/packages/embed-examples/src/scaleApi.js
@@ -1,6 +1,5 @@
 import { embed } from "@genome-spy/core/minimal";
 import "@genome-spy/core/rendering/webgl.js";
-import "@genome-spy/core/rendering/canvas.js";
 import { html, render } from "lit";
 
 /** @type {import("@genome-spy/core/spec/root.js").RootSpec} */

--- a/packages/embed-examples/src/scaleApi.js
+++ b/packages/embed-examples/src/scaleApi.js
@@ -1,4 +1,6 @@
 import { embed } from "@genome-spy/core/minimal";
+import "@genome-spy/core/rendering/webgl.js";
+import "@genome-spy/core/rendering/canvas.js";
 import { html, render } from "lit";
 
 /** @type {import("@genome-spy/core/spec/root.js").RootSpec} */

--- a/packages/embed-examples/src/viewMutationApi.js
+++ b/packages/embed-examples/src/viewMutationApi.js
@@ -1,4 +1,6 @@
 import { embed } from "@genome-spy/core/minimal";
+import "@genome-spy/core/rendering/webgl.js";
+import "@genome-spy/core/rendering/canvas.js";
 import { html, render } from "lit";
 
 /*

--- a/packages/embed-examples/src/viewMutationApi.js
+++ b/packages/embed-examples/src/viewMutationApi.js
@@ -1,6 +1,5 @@
 import { embed } from "@genome-spy/core/minimal";
 import "@genome-spy/core/rendering/webgl.js";
-import "@genome-spy/core/rendering/canvas.js";
 import { html, render } from "lit";
 
 /*


### PR DESCRIPTION
The minimal entrypoint still shipped Canvas2D, SVG, and WebGL chunks even when an embedding application never used them. This keeps the default entrypoint convenient while making renderer capabilities explicit and removable for larger host applications.

## Changes

- Add public side-effect opt-ins for WebGL, Canvas2D, and SVG.
- Keep all three renderers registered by the default and full entrypoints.
- Route live rendering and Canvas raster fallbacks through a small internal loader table.
- Report the exact import needed when a minimal consumer requests an unavailable capability.
- Update minimal-based examples, public usage docs, and the ESM bundle verifier.

## Minimal ESM output graph

| | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Uncompressed | 1,082.43 kB | 820.77 kB | 261.66 kB (24.2%) |
| Gzip | 356.05 kB | 277.67 kB | 78.38 kB (22.0%) |

The default ESM build still emits WebGL, Canvas2D, and SVG as dynamically reachable chunks.

## Verification

- `npm test -- --reporter=agent` — 433 files, 3,601 tests passed.
- `npm run lint`
- `npm --workspace @genome-spy/core run verify:bundle:minimal`
- Focused live Canvas, backend routing, and rasterization tests — 20 tests passed.
- Core TypeScript checking reaches the existing `gff-nostream` `GFF3Feature` declaration error.
- The embed-examples smoke build resolves the new opt-ins, then reaches the existing unresolved `generic-filehandle` import in `dynamicFasta.js`.

_Posted by Codex (AI agent) at the user's request._