### PR TITLE
Feat/displace2d

### DIFF
--- a/packages/core/src/data/transforms/displace2d.js
+++ b/packages/core/src/data/transforms/displace2d.js
@@ -1,0 +1,288 @@
+import { BEHAVIOR_COLLECTS, BEHAVIOR_MODIFIES } from "../flowNode.js";
+import {
+    activateExprRefProps,
+    isExprRef,
+} from "../../paramRuntime/paramUtils.js";
+import { field } from "../../utils/field.js";
+import Transform from "./transform.js";
+import { solveDisplacement } from "./displace2dSolver.js";
+
+/**
+ * @typedef {object} PlacementProps
+ * @prop {number} width
+ * @prop {number} height
+ * @prop {number} xPositionFactor
+ * @prop {number} yPositionFactor
+ * @prop {[number, number] | undefined} xExtent
+ * @prop {[number, number] | undefined} yExtent
+ */
+
+/**
+ * Computes non-overlapping placements for a two-dimensional batch.
+ */
+export default class Displace2DTransform extends Transform {
+    #placementBootstrapped = false;
+    #bootstrapReplayPending = false;
+
+    /** @type {import("../flowNode.js").Datum[]} */
+    #data = [];
+
+    /** @type {PlacementProps} */
+    #placementProps;
+
+    get behavior() {
+        return BEHAVIOR_COLLECTS | BEHAVIOR_MODIFIES;
+    }
+
+    /**
+     * @param {import("../../spec/transform.js").Displace2DParams} params
+     * @param {import("../flowNode.js").ParamRuntimeProvider} paramRuntimeProvider
+     */
+    constructor(params, paramRuntimeProvider) {
+        super(params, paramRuntimeProvider);
+
+        const as = params.as ?? ["xDisplacement", "yDisplacement"];
+        if (
+            !Array.isArray(as) ||
+            as.length != 2 ||
+            typeof as[0] != "string" ||
+            typeof as[1] != "string" ||
+            as[0] == as[1]
+        ) {
+            throw new Error(
+                "displace2d as must contain two distinct output field names."
+            );
+        }
+        this.as = as;
+        this.xAccessor = field(params.x);
+        this.yAccessor = field(params.y);
+
+        this.width = typeof params.width == "number" ? params.width : 0;
+        this.height = typeof params.height == "number" ? params.height : 0;
+        this.xPositionFactor = isExprRef(params.xPositionFactor)
+            ? 1
+            : (params.xPositionFactor ?? 1);
+        this.yPositionFactor = isExprRef(params.yPositionFactor)
+            ? 1
+            : (params.yPositionFactor ?? 1);
+        this.xExtent = isExprRef(params.xExtent) ? undefined : params.xExtent;
+        this.yExtent = isExprRef(params.yExtent) ? undefined : params.yExtent;
+
+        this.widthAccessor =
+            typeof params.width == "string"
+                ? field(params.width)
+                : () => this.width;
+        this.heightAccessor =
+            typeof params.height == "string"
+                ? field(params.height)
+                : () => this.height;
+
+        const placementProps = {
+            width: typeof params.width == "string" ? this.width : params.width,
+            height:
+                typeof params.height == "string" ? this.height : params.height,
+            xPositionFactor: params.xPositionFactor ?? 1,
+            yPositionFactor: params.yPositionFactor ?? 1,
+            xExtent: params.xExtent,
+            yExtent: params.yExtent,
+        };
+        const hasReactiveProps = Object.values(placementProps).some(isExprRef);
+        this.#placementBootstrapped = !hasReactiveProps;
+
+        const placementChanged = () => {
+            if (!this.#placementBootstrapped || this.disposed) {
+                return;
+            }
+
+            if (
+                this.#refreshPlacementParameters() &&
+                this.completed &&
+                !this.#bootstrapReplayPending
+            ) {
+                this.repropagate();
+            }
+        };
+
+        this.#placementProps = hasReactiveProps
+            ? /** @type {any} */ (
+                  activateExprRefProps(
+                      this.paramRuntime,
+                      placementProps,
+                      placementChanged,
+                      (disposer) => this.registerDisposer(disposer),
+                      { batchMode: "whenPropagated" }
+                  )
+              )
+            : /** @type {any} */ (placementProps);
+
+        if (this.#placementBootstrapped) {
+            this.#refreshPlacementParameters();
+        }
+    }
+
+    complete() {
+        const data = this.#data;
+
+        if (!this.#placementBootstrapped) {
+            for (const datum of data) {
+                datum[this.as[0]] = 0;
+                datum[this.as[1]] = 0;
+                this._propagate(datum);
+            }
+            super.complete();
+            data.length = 0;
+
+            this.#refreshPlacementParameters();
+            this.#placementBootstrapped = true;
+            this.#bootstrapReplayPending = true;
+            queueMicrotask(() => {
+                this.#bootstrapReplayPending = false;
+                if (!this.disposed) {
+                    this.#refreshPlacementParameters();
+                    this.repropagate();
+                }
+            });
+            return;
+        }
+
+        const count = data.length;
+        const xPositions = new Array(count);
+        const yPositions = new Array(count);
+        const widths = new Array(count);
+        const heights = new Array(count);
+
+        for (let i = 0; i < count; i++) {
+            const datum = data[i];
+            xPositions[i] = this.xAccessor(datum) * this.xPositionFactor;
+            yPositions[i] = this.yAccessor(datum) * this.yPositionFactor;
+            widths[i] = this.widthAccessor(datum);
+            heights[i] = this.heightAccessor(datum);
+        }
+
+        const displacements = solveDisplacement(
+            xPositions,
+            yPositions,
+            widths,
+            heights,
+            scaleExtent(this.xExtent, this.xPositionFactor),
+            scaleExtent(this.yExtent, this.yPositionFactor)
+        );
+
+        for (let i = 0; i < count; i++) {
+            data[i][this.as[0]] = displacements.x[i];
+            data[i][this.as[1]] = displacements.y[i];
+            this._propagate(data[i]);
+        }
+
+        super.complete();
+        data.length = 0;
+    }
+
+    #refreshPlacementParameters() {
+        const props = this.#placementProps;
+        validatePlacementParameters(props);
+
+        const placementChanged =
+            props.width != this.width ||
+            props.height != this.height ||
+            props.xPositionFactor != this.xPositionFactor ||
+            props.yPositionFactor != this.yPositionFactor ||
+            !equalExtent(props.xExtent, this.xExtent) ||
+            !equalExtent(props.yExtent, this.yExtent);
+
+        this.width = props.width;
+        this.height = props.height;
+        this.xPositionFactor = props.xPositionFactor;
+        this.yPositionFactor = props.yPositionFactor;
+        this.xExtent = copyExtent(props.xExtent);
+        this.yExtent = copyExtent(props.yExtent);
+
+        return placementChanged;
+    }
+
+    reset() {
+        super.reset();
+        this.#data.length = 0;
+    }
+
+    /**
+     * @param {import("../flowNode.js").Datum} datum
+     */
+    handle(datum) {
+        this.#data.push(datum);
+    }
+}
+
+/**
+ * @param {PlacementProps} props
+ */
+function validatePlacementParameters(props) {
+    if (
+        !Number.isFinite(props.xPositionFactor) ||
+        !Number.isFinite(props.yPositionFactor)
+    ) {
+        throw new Error("displace2d position factors must be finite numbers.");
+    }
+    if (
+        !Number.isFinite(props.width) ||
+        !Number.isFinite(props.height) ||
+        props.width < 0 ||
+        props.height < 0
+    ) {
+        throw new Error(
+            "displace2d scalar dimensions must be finite non-negative numbers."
+        );
+    }
+    validateExtent(props.xExtent, "xExtent");
+    validateExtent(props.yExtent, "yExtent");
+}
+
+/**
+ * @param {[number, number] | undefined} extent
+ * @param {string} name
+ */
+function validateExtent(extent, name) {
+    if (
+        extent !== undefined &&
+        (!Array.isArray(extent) ||
+            extent.length != 2 ||
+            !Number.isFinite(extent[0]) ||
+            !Number.isFinite(extent[1]) ||
+            extent[0] > extent[1])
+    ) {
+        throw new Error(
+            `displace2d ${name} must contain finite ascending bounds.`
+        );
+    }
+}
+
+/**
+ * @param {[number, number] | undefined} extent
+ * @param {number} factor
+ * @returns {[number, number] | undefined}
+ */
+function scaleExtent(extent, factor) {
+    if (!extent) {
+        return undefined;
+    }
+
+    const first = extent[0] * factor;
+    const second = extent[1] * factor;
+    return [Math.min(first, second), Math.max(first, second)];
+}
+
+/**
+ * @param {[number, number] | undefined} first
+ * @param {[number, number] | undefined} second
+ */
+function equalExtent(first, second) {
+    return first?.[0] == second?.[0] && first?.[1] == second?.[1];
+}
+
+/**
+ * @param {[number, number] | undefined} extent
+ * @returns {[number, number] | undefined}
+ */
+function copyExtent(extent) {
+    return extent ? [extent[0], extent[1]] : undefined;
+}

--- a/packages/core/src/data/transforms/displace2d.test.js
+++ b/packages/core/src/data/transforms/displace2d.test.js
@@ -1,0 +1,391 @@
+import { describe, expect, test, vi } from "vitest";
+import Rectangle from "../../view/layout/rectangle.js";
+import { createAndInitialize, renderToLayout } from "../../view/testUtils.js";
+import UnitView from "../../view/unitView.js";
+import Collector from "../collector.js";
+import Displace2DTransform from "./displace2d.js";
+import createTransform from "./transformFactory.js";
+
+/**
+ * @param {Record<string, any>[]} data
+ * @param {Partial<import("../../spec/transform.js").Displace2DParams>} [overrides]
+ */
+function createFlow(data, overrides = {}) {
+    const source = new Collector();
+    const transform = new Displace2DTransform(
+        {
+            type: "displace2d",
+            x: "x",
+            y: "y",
+            width: 10,
+            height: 10,
+            xPositionFactor: 100,
+            yPositionFactor: 100,
+            as: ["dx", "dy"],
+            ...overrides,
+        },
+        /** @type {any} */ ({})
+    );
+    const output = new Collector();
+    source.addChild(transform);
+    transform.addChild(output);
+
+    for (const datum of data) {
+        source.handle(datum);
+    }
+    source.complete();
+
+    return { output, source, transform };
+}
+
+describe("Displace2DTransform", () => {
+    test("uses unit factors and displacement field defaults", () => {
+        const transform = new Displace2DTransform(
+            {
+                type: "displace2d",
+                x: "x",
+                y: "y",
+                width: 10,
+                height: 10,
+            },
+            /** @type {any} */ ({})
+        );
+        const output = new Collector();
+        transform.addChild(output);
+        transform.handle({ x: 0, y: 0 });
+        transform.complete();
+
+        expect(transform.xPositionFactor).toBe(1);
+        expect(transform.yPositionFactor).toBe(1);
+        expect([...output.getData()]).toEqual([
+            { x: 0, y: 0, xDisplacement: 0, yDisplacement: 0 },
+        ]);
+    });
+
+    test("reacts to zoom without affecting the data-driven domain", async () => {
+        /** @type {import("../../spec/view.js").UnitSpec} */
+        const spec = {
+            width: 200,
+            height: 100,
+            data: {
+                values: [
+                    { x: 100, y: 0 },
+                    { x: 11, y: 0 },
+                    { x: 10, y: 0 },
+                ],
+            },
+            transform: [
+                {
+                    type: "collect",
+                    sort: { field: "x", order: "ascending" },
+                },
+                {
+                    type: "displace2d",
+                    x: "x",
+                    y: "y",
+                    width: 20,
+                    height: 20,
+                    xPositionFactor: {
+                        expr: "width * (scale('x', 1) - scale('x', 0))",
+                    },
+                    xExtent: [9.5, 100.5],
+                    as: ["dx", "dy"],
+                },
+            ],
+            mark: "point",
+            encoding: {
+                x: {
+                    field: "x",
+                    type: "quantitative",
+                    scale: { zoom: true },
+                },
+                y: { field: "y", type: "quantitative" },
+                xOffset: { field: "dx", type: "quantitative", scale: null },
+                yOffset: { field: "dy", type: "quantitative", scale: null },
+            },
+        };
+        const view = await createAndInitialize(spec, UnitView);
+        renderToLayout(view, Rectangle.create(0, 0, 200, 100));
+
+        const resolution = view.getScaleResolution("x");
+        const initialDomain = resolution.getScale().domain();
+        expect(initialDomain[0]).toBeLessThanOrEqual(10);
+        expect(initialDomain[1]).toBeGreaterThanOrEqual(100);
+
+        const initialPlacement = [...view.flowHandle.collector.getData()];
+        expect(initialPlacement.map((datum) => datum.x)).toEqual([10, 11, 100]);
+        expect(
+            initialPlacement.some((datum) => datum.dx != 0 || datum.dy != 0)
+        ).toBe(true);
+
+        const zoomPromise = resolution.zoomTo([0, 10], false);
+        await view.paramRuntime.whenPropagated();
+        await Promise.resolve();
+        const zoomedPlacement = [...view.flowHandle.collector.getData()];
+        expect(zoomedPlacement.map(({ dx, dy }) => [dx, dy])).toEqual([
+            [0, 0],
+            [0, 0],
+            [0, 0],
+        ]);
+        expect(zoomedPlacement[0]).not.toBe(initialPlacement[0]);
+        await zoomPromise;
+    });
+
+    test("preserves input order and emits signed pixel offsets", () => {
+        const input = [
+            { x: 0, y: 0 },
+            { x: 0, y: 0 },
+        ];
+        const { output } = createFlow(input);
+        const placed = [...output.getData()];
+
+        expect(placed.map(({ dx, dy }) => [dx, dy])).toEqual([
+            [0, 0],
+            [0, -10],
+        ]);
+        expect(placed[0]).toBe(input[0]);
+        expect(placed[1]).toBe(input[1]);
+    });
+
+    test("reads collision dimensions from fields", () => {
+        const { output } = createFlow(
+            [
+                { x: 0, y: 0, width: 20, height: 10 },
+                { x: 0, y: 0, width: 20, height: 10 },
+            ],
+            { width: "width", height: "height" }
+        );
+
+        expect([...output.getData()].map(({ dx, dy }) => [dx, dy])).toEqual([
+            [0, 0],
+            [0, -10],
+        ]);
+    });
+
+    test("scales and normalizes source-coordinate extents", () => {
+        const positive = createFlow([{ x: 1.2, y: 0.5 }], {
+            width: 20,
+            height: 20,
+            xExtent: [0, 1],
+            yExtent: [0, 1],
+        });
+        const negative = createFlow([{ x: 1.2, y: 0.5 }], {
+            width: 20,
+            height: 20,
+            xPositionFactor: -100,
+            xExtent: [0, 1],
+            yExtent: [0, 1],
+        });
+
+        expect([...positive.output.getData()][0]).toMatchObject({
+            dx: -30,
+            dy: 0,
+        });
+        expect([...negative.output.getData()][0]).toMatchObject({
+            dx: 30,
+            dy: 0,
+        });
+    });
+
+    test("coalesces reactive placement changes into one replay", async () => {
+        const values = {
+            width: 20,
+            height: 20,
+            xFactor: 100,
+            yFactor: 100,
+            xExtent: /** @type {[number, number] | undefined} */ ([0, 1]),
+            yExtent: /** @type {[number, number] | undefined} */ ([0, 1]),
+        };
+        /** @type {Map<string, () => void>} */
+        const listeners = new Map();
+        const paramRuntime = {
+            watchExpression: (
+                /** @type {keyof typeof values} */ expression,
+                /** @type {() => void} */ callback,
+                /** @type {{ registerDisposer: (disposer: () => void) => void }} */ options
+            ) => {
+                listeners.set(expression, callback);
+                options.registerDisposer(() => undefined);
+                return () => values[expression];
+            },
+        };
+        const source = new Collector();
+        const transform = new Displace2DTransform(
+            {
+                type: "displace2d",
+                x: "x",
+                y: "y",
+                width: { expr: "width" },
+                height: { expr: "height" },
+                xPositionFactor: { expr: "xFactor" },
+                yPositionFactor: { expr: "yFactor" },
+                xExtent: { expr: "xExtent" },
+                yExtent: { expr: "yExtent" },
+                as: ["dx", "dy"],
+            },
+            /** @type {any} */ ({ paramRuntime })
+        );
+        const output = new Collector();
+        source.addChild(transform);
+        transform.addChild(output);
+        source.handle({ x: 0.5, y: 0.5 });
+        source.handle({ x: 0.5, y: 0.5 });
+
+        const repropagate = vi.spyOn(source, "repropagate");
+        source.complete();
+        expect([...output.getData()].map(({ dx, dy }) => [dx, dy])).toEqual([
+            [0, 0],
+            [0, 0],
+        ]);
+
+        await Promise.resolve();
+        expect(repropagate).toHaveBeenCalledOnce();
+        expect([...output.getData()].map(({ dx, dy }) => [dx, dy])).toEqual([
+            [0, 0],
+            [0, -20],
+        ]);
+        repropagate.mockClear();
+
+        values.width = 10;
+        values.height = 10;
+        values.xFactor = -100;
+        values.yFactor = -100;
+        values.xExtent = undefined;
+        values.yExtent = undefined;
+        listeners.forEach((listener) => listener());
+
+        await Promise.resolve();
+        expect(repropagate).toHaveBeenCalledOnce();
+        expect([...output.getData()].map(({ dx, dy }) => [dx, dy])).toEqual([
+            [0, 0],
+            [0, -10],
+        ]);
+    });
+
+    test("clears a disabled reactive extent instead of retaining scaled bounds", async () => {
+        let extent = /** @type {[number, number] | undefined} */ ([0, 1]);
+        /** @type {() => void} */
+        let listener;
+        const paramRuntime = {
+            watchExpression: (
+                /** @type {string} */ expression,
+                /** @type {() => void} */ callback
+            ) => {
+                expect(expression).toBe("extent");
+                listener = callback;
+                return () => extent;
+            },
+        };
+        const source = new Collector();
+        const transform = new Displace2DTransform(
+            {
+                type: "displace2d",
+                x: "x",
+                y: "y",
+                width: 20,
+                height: 20,
+                xPositionFactor: 100,
+                yPositionFactor: 100,
+                xExtent: { expr: "extent" },
+                as: ["dx", "dy"],
+            },
+            /** @type {any} */ ({ paramRuntime })
+        );
+        const output = new Collector();
+        source.addChild(transform);
+        transform.addChild(output);
+        source.handle({ x: 1.2, y: 0.5 });
+        source.complete();
+        await Promise.resolve();
+
+        expect([...output.getData()][0].dx).toBe(-30);
+
+        extent = undefined;
+        listener();
+        await Promise.resolve();
+
+        expect([...output.getData()][0].dx).toBe(0);
+    });
+
+    test("cancels the deferred bootstrap replay after disposal", async () => {
+        /** @type {() => void} */
+        let listener;
+        const disposer = vi.fn();
+        const paramRuntime = {
+            watchExpression: (
+                /** @type {string} */ expression,
+                /** @type {() => void} */ callback,
+                /** @type {{ registerDisposer: (disposer: () => void) => void }} */ options
+            ) => {
+                expect(expression).toBe("factor");
+                listener = callback;
+                options.registerDisposer(disposer);
+                return () => 100;
+            },
+        };
+        const source = new Collector();
+        const transform = new Displace2DTransform(
+            {
+                type: "displace2d",
+                x: "x",
+                y: "y",
+                width: 10,
+                height: 10,
+                xPositionFactor: { expr: "factor" },
+            },
+            /** @type {any} */ ({ paramRuntime })
+        );
+        const output = new Collector();
+        source.addChild(transform);
+        transform.addChild(output);
+        source.handle({ x: 0, y: 0 });
+
+        const repropagate = vi.spyOn(source, "repropagate");
+        source.complete();
+        transform.dispose();
+        listener();
+        await Promise.resolve();
+
+        expect(repropagate).not.toHaveBeenCalled();
+        expect(disposer).toHaveBeenCalledOnce();
+    });
+
+    test("rejects invalid parameters and field values", () => {
+        expect(() =>
+            createFlow([{ x: 0, y: 0 }], {
+                xPositionFactor: Infinity,
+            })
+        ).toThrow("position factors");
+        expect(() =>
+            createFlow([{ x: 0, y: 0, width: -1 }], {
+                width: "width",
+            })
+        ).toThrow("dimensions");
+        expect(
+            () =>
+                new Displace2DTransform(
+                    /** @type {any} */ ({
+                        type: "displace2d",
+                        x: "x",
+                        y: "y",
+                        width: 10,
+                        height: 10,
+                        as: ["offset", "offset"],
+                    }),
+                    /** @type {any} */ ({})
+                )
+        ).toThrow("distinct output field names");
+    });
+
+    test("is available through the transform factory", () => {
+        expect(
+            createTransform({
+                type: "displace2d",
+                x: "x",
+                y: "y",
+                width: 10,
+                height: 10,
+            })
+        ).toBeInstanceOf(Displace2DTransform);
+    });
+});

--- a/packages/core/src/data/transforms/displace2dSolver.js
+++ b/packages/core/src/data/transforms/displace2dSolver.js
@@ -1,0 +1,289 @@
+const LONG_AXIS_RINGS = 2;
+const SHORT_AXIS_RINGS = 8;
+const CANDIDATE_OFFSETS = createCandidateOffsets();
+
+/**
+ * @typedef {object} Displacement2D
+ * @prop {number[]} x Signed horizontal offsets.
+ * @prop {number[]} y Signed vertical offsets.
+ */
+
+/**
+ * Places axis-aligned rectangles without overlap using stable input order.
+ *
+ * Candidates form a small bounded strip around each original center.
+ * Rectangles that exhaust the bounded search are placed in a non-overlapping
+ * row to the right of all original and previously placed rectangles.
+ *
+ * @param {number[]} xPositions Original horizontal centers.
+ * @param {number[]} yPositions Original vertical centers.
+ * @param {number[]} widths Full collision widths.
+ * @param {number[]} heights Full collision heights.
+ * @param {[number, number]} [xExtent] Preferred horizontal outer bounds.
+ * @param {[number, number]} [yExtent] Preferred vertical outer bounds.
+ * @param {Displacement2D} [output] Reusable output arrays.
+ * @returns {Displacement2D} The output arrays.
+ */
+export function solveDisplacement(
+    xPositions,
+    yPositions,
+    widths,
+    heights,
+    xExtent,
+    yExtent,
+    output = { x: [], y: [] }
+) {
+    const count = xPositions.length;
+    if (
+        yPositions.length != count ||
+        widths.length != count ||
+        heights.length != count
+    ) {
+        throw new Error(
+            "displace2d positions and dimensions must have the same number of values."
+        );
+    }
+    validateExtent(xExtent, "xExtent");
+    validateExtent(yExtent, "yExtent");
+
+    const xDisplacements = output.x;
+    const yDisplacements = output.y;
+    xDisplacements.length = count;
+    yDisplacements.length = count;
+
+    let overflowCursor = xExtent?.[1] ?? -Infinity;
+    let cellSize = 1;
+
+    for (let i = 0; i < count; i++) {
+        const x = xPositions[i];
+        const y = yPositions[i];
+        const width = widths[i];
+        const height = heights[i];
+
+        if (!Number.isFinite(x) || !Number.isFinite(y)) {
+            throw new Error("displace2d positions must be finite numbers.");
+        } else if (
+            !Number.isFinite(width) ||
+            !Number.isFinite(height) ||
+            width < 0 ||
+            height < 0
+        ) {
+            throw new Error(
+                "displace2d dimensions must be finite non-negative numbers."
+            );
+        }
+
+        overflowCursor = Math.max(overflowCursor, x + width / 2);
+        // The largest dimension limits each rectangle to at most four cells,
+        // keeping grid storage linear in the number of rectangles.
+        cellSize = Math.max(cellSize, width, height);
+    }
+
+    /** @type {Map<number, Map<number, number[]>>} */
+    const grid = new Map();
+
+    /**
+     * @param {number} index
+     * @param {number} candidateX
+     * @param {number} candidateY
+     */
+    const isAvailable = (index, candidateX, candidateY) => {
+        const width = widths[index];
+        const height = heights[index];
+
+        if (
+            !fitsExtent(candidateX, width, xExtent) ||
+            !fitsExtent(candidateY, height, yExtent)
+        ) {
+            return false;
+        }
+
+        if (width == 0 || height == 0) {
+            return true;
+        }
+
+        const minCellX = Math.floor((candidateX - width / 2) / cellSize);
+        const maxCellX = Math.floor((candidateX + width / 2) / cellSize);
+        const minCellY = Math.floor((candidateY - height / 2) / cellSize);
+        const maxCellY = Math.floor((candidateY + height / 2) / cellSize);
+
+        for (let cellX = minCellX; cellX <= maxCellX; cellX++) {
+            const column = grid.get(cellX);
+            if (!column) {
+                continue;
+            }
+
+            for (let cellY = minCellY; cellY <= maxCellY; cellY++) {
+                const occupants = column.get(cellY);
+                if (!occupants) {
+                    continue;
+                }
+
+                for (const j of occupants) {
+                    const otherX = xPositions[j] + xDisplacements[j];
+                    const otherY = yPositions[j] + yDisplacements[j];
+                    if (
+                        Math.abs(candidateX - otherX) * 2 < width + widths[j] &&
+                        Math.abs(candidateY - otherY) * 2 < height + heights[j]
+                    ) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    };
+
+    for (let i = 0; i < count; i++) {
+        const x = xPositions[i];
+        const y = yPositions[i];
+        const width = widths[i];
+        const height = heights[i];
+        const preferredX = clampToExtent(x, width, xExtent);
+        const preferredY = clampToExtent(y, height, yExtent);
+
+        let placed = false;
+        if (isAvailable(i, x, y)) {
+            xDisplacements[i] = 0;
+            yDisplacements[i] = 0;
+            placed = true;
+        } else if (
+            (preferredX != x || preferredY != y) &&
+            isAvailable(i, preferredX, preferredY)
+        ) {
+            xDisplacements[i] = preferredX - x;
+            yDisplacements[i] = preferredY - y;
+            placed = true;
+        }
+
+        for (const [dx, dy] of CANDIDATE_OFFSETS) {
+            if (placed) {
+                break;
+            }
+
+            const candidateX =
+                preferredX + (width >= height ? dx * width : dy * width);
+            const candidateY =
+                preferredY + (width >= height ? dy * height : dx * height);
+            if (isAvailable(i, candidateX, candidateY)) {
+                xDisplacements[i] = candidateX - x;
+                yDisplacements[i] = candidateY - y;
+                placed = true;
+            }
+        }
+
+        if (!placed) {
+            const overflowX = overflowCursor + width / 2;
+            const overflowY = clampToExtent(y, height, yExtent);
+            xDisplacements[i] = overflowX - x;
+            yDisplacements[i] = overflowY - y;
+        }
+
+        overflowCursor = Math.max(
+            overflowCursor,
+            x + xDisplacements[i] + width / 2
+        );
+
+        if (width > 0 && height > 0) {
+            const placedX = x + xDisplacements[i];
+            const placedY = y + yDisplacements[i];
+            const minCellX = Math.floor((placedX - width / 2) / cellSize);
+            const maxCellX = Math.floor((placedX + width / 2) / cellSize);
+            const minCellY = Math.floor((placedY - height / 2) / cellSize);
+            const maxCellY = Math.floor((placedY + height / 2) / cellSize);
+
+            for (let cellX = minCellX; cellX <= maxCellX; cellX++) {
+                let column = grid.get(cellX);
+                if (!column) {
+                    column = new Map();
+                    grid.set(cellX, column);
+                }
+
+                for (let cellY = minCellY; cellY <= maxCellY; cellY++) {
+                    let occupants = column.get(cellY);
+                    if (!occupants) {
+                        occupants = [];
+                        column.set(cellY, occupants);
+                    }
+                    occupants.push(i);
+                }
+            }
+        }
+    }
+
+    return output;
+}
+
+/**
+ * Generates a bounded strip along the cheaper displacement axis.
+ *
+ * @returns {[number, number][]}
+ */
+function createCandidateOffsets() {
+    /** @type {[number, number][]} */
+    const offsets = [];
+
+    for (let ring = 1; ring <= SHORT_AXIS_RINGS; ring++) {
+        offsets.push([0, -ring], [0, ring]);
+    }
+
+    for (let column = 1; column <= LONG_AXIS_RINGS; column++) {
+        offsets.push([column, 0], [-column, 0]);
+        for (let ring = 1; ring <= SHORT_AXIS_RINGS; ring++) {
+            offsets.push(
+                [column, -ring],
+                [column, ring],
+                [-column, -ring],
+                [-column, ring]
+            );
+        }
+    }
+
+    return offsets;
+}
+
+/**
+ * @param {number} center
+ * @param {number} size
+ * @param {[number, number] | undefined} extent
+ */
+function fitsExtent(center, size, extent) {
+    return (
+        !extent ||
+        (center - size / 2 >= extent[0] && center + size / 2 <= extent[1])
+    );
+}
+
+/**
+ * @param {number} center
+ * @param {number} size
+ * @param {[number, number] | undefined} extent
+ */
+function clampToExtent(center, size, extent) {
+    if (!extent || size > extent[1] - extent[0]) {
+        return center;
+    }
+
+    return Math.max(
+        extent[0] + size / 2,
+        Math.min(extent[1] - size / 2, center)
+    );
+}
+
+/**
+ * @param {[number, number] | undefined} extent
+ * @param {string} name
+ */
+function validateExtent(extent, name) {
+    if (
+        extent &&
+        (!Number.isFinite(extent[0]) ||
+            !Number.isFinite(extent[1]) ||
+            extent[0] > extent[1])
+    ) {
+        throw new Error(
+            `displace2d ${name} must contain finite ascending bounds.`
+        );
+    }
+}

--- a/packages/core/src/data/transforms/displace2dSolver.test.js
+++ b/packages/core/src/data/transforms/displace2dSolver.test.js
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "vitest";
+import { solveDisplacement } from "./displace2dSolver.js";
+
+/**
+ * @param {number[]} xPositions
+ * @param {number[]} yPositions
+ * @param {number[]} widths
+ * @param {number[]} heights
+ * @param {{ x: number[], y: number[] }} displacements
+ */
+function expectNoOverlap(
+    xPositions,
+    yPositions,
+    widths,
+    heights,
+    displacements
+) {
+    for (let i = 0; i < xPositions.length; i++) {
+        for (let j = 0; j < i; j++) {
+            const overlap =
+                widths[i] > 0 &&
+                heights[i] > 0 &&
+                widths[j] > 0 &&
+                heights[j] > 0 &&
+                Math.abs(
+                    xPositions[i] +
+                        displacements.x[i] -
+                        (xPositions[j] + displacements.x[j])
+                ) *
+                    2 <
+                    widths[i] + widths[j] &&
+                Math.abs(
+                    yPositions[i] +
+                        displacements.y[i] -
+                        (yPositions[j] + displacements.y[j])
+                ) *
+                    2 <
+                    heights[i] + heights[j];
+
+            expect(overlap).toBe(false);
+        }
+    }
+}
+
+describe("solveDisplacement", () => {
+    test("keeps already separated rectangles in place", () => {
+        expect(
+            solveDisplacement([0, 10, 20], [0, 10, 0], [4, 6, 4], [4, 6, 4])
+        ).toEqual({ x: [0, 0, 0], y: [0, 0, 0] });
+    });
+
+    test("deterministically separates coincident variable-size rectangles", () => {
+        const xPositions = [0, 0, 0, 0];
+        const yPositions = [0, 0, 0, 0];
+        const widths = [8, 4, 6, 2];
+        const heights = [2, 6, 4, 8];
+        const first = solveDisplacement(
+            xPositions,
+            yPositions,
+            widths,
+            heights
+        );
+        const second = solveDisplacement(
+            xPositions,
+            yPositions,
+            widths,
+            heights
+        );
+
+        expect(first).toEqual(second);
+        expectNoOverlap(xPositions, yPositions, widths, heights, first);
+    });
+
+    test("allows touching edges and empty collision rectangles", () => {
+        expect(
+            solveDisplacement([0, 10, 0], [0, 0, 0], [10, 10, 0], [10, 10, 10])
+        ).toEqual({ x: [0, 0, 0], y: [0, 0, 0] });
+    });
+
+    test("clamps edge items into feasible preferred extents", () => {
+        const displacements = solveDisplacement(
+            [-10, 5, 20],
+            [5, 5, 5],
+            [2, 2, 2],
+            [2, 2, 2],
+            [0, 10],
+            [0, 10]
+        );
+
+        expect(displacements).toEqual({ x: [11, 0, -11], y: [0, 0, 0] });
+        expectNoOverlap(
+            [-10, 5, 20],
+            [5, 5, 5],
+            [2, 2, 2],
+            [2, 2, 2],
+            displacements
+        );
+    });
+
+    test("uses a right-side overflow row after exhausting local candidates", () => {
+        const count = 86;
+        const xPositions = Array(count).fill(0);
+        const yPositions = Array(count).fill(0);
+        const widths = Array(count).fill(2);
+        const heights = Array(count).fill(2);
+        const displacements = solveDisplacement(
+            xPositions,
+            yPositions,
+            widths,
+            heights
+        );
+
+        const lastLeft =
+            xPositions.at(-1) + displacements.x.at(-1) - widths.at(-1) / 2;
+        const previousRight = Math.max(
+            ...xPositions
+                .slice(0, -1)
+                .map((x, i) => x + displacements.x[i] + widths[i] / 2)
+        );
+
+        expect(lastLeft).toBe(previousRight);
+        expect(displacements.y.at(-1)).toBe(0);
+        expectNoOverlap(xPositions, yPositions, widths, heights, displacements);
+    });
+
+    test("overflows an oversized rectangle without dropping it", () => {
+        const displacements = solveDisplacement(
+            [5],
+            [5],
+            [12],
+            [12],
+            [0, 10],
+            [0, 10]
+        );
+
+        expect(displacements).toEqual({ x: [12], y: [0] });
+    });
+
+    test("optionally reuses output arrays", () => {
+        const output = { x: [NaN], y: [NaN] };
+
+        expect(
+            solveDisplacement([0], [0], [2], [2], undefined, undefined, output)
+        ).toBe(output);
+        expect(output).toEqual({ x: [0], y: [0] });
+    });
+
+    test.each([
+        [[NaN], [0], [1], [1], "positions"],
+        [[0], [0], [Infinity], [1], "dimensions"],
+        [[0], [0], [1], [-1], "dimensions"],
+        [[0, 1], [0], [1, 1], [1, 1], "same number"],
+    ])(
+        "rejects invalid rectangle input %#",
+        (xPositions, yPositions, widths, heights, message) => {
+            expect(() =>
+                solveDisplacement(xPositions, yPositions, widths, heights)
+            ).toThrow(message);
+        }
+    );
+
+    test.each([
+        ["xExtent", [NaN, 1], undefined],
+        ["xExtent", [1, 0], undefined],
+        ["yExtent", undefined, [0, Infinity]],
+    ])("rejects invalid %s", (name, xExtent, yExtent) => {
+        expect(() =>
+            solveDisplacement([0], [0], [1], [1], xExtent, yExtent)
+        ).toThrow(name);
+    });
+});

--- a/packages/core/src/data/transforms/transformFactory.js
+++ b/packages/core/src/data/transforms/transformFactory.js
@@ -4,6 +4,7 @@ import CoordinateLookupTransform from "./coordinateLookup.js";
 import CrossTransform from "./cross.js";
 import CoverageTransform from "./coverage.js";
 import Displace1DTransform from "./displace1d.js";
+import Displace2DTransform from "./displace2d.js";
 import FilterScoredLabelsTransform from "./filterScoredLabels.js";
 import AxisLabelLayoutTransform from "./axisLabelLayout.js";
 import FilterTransform from "./filter.js";
@@ -40,6 +41,7 @@ export const transforms = {
     collect: Collector,
     coverage: CoverageTransform,
     displace1d: Displace1DTransform,
+    displace2d: Displace2DTransform,
     axisLabelLayout: AxisLabelLayoutTransform,
     filterScoredLabels: FilterScoredLabelsTransform,
     filter: FilterTransform,

--- a/packages/core/src/spec/schema.test.js
+++ b/packages/core/src/spec/schema.test.js
@@ -314,6 +314,36 @@ describe("generated core schema", () => {
         );
     });
 
+    test("accepts two-dimensional displacement transform parameters", () => {
+        const validate = createCoreValidator();
+        const spec = {
+            data: { values: [{ x: 1, y: 2, width: 20 }] },
+            transform: [
+                {
+                    type: "displace2d",
+                    x: "x",
+                    y: "y",
+                    width: "width",
+                    height: { expr: "fontSize" },
+                    xPositionFactor: { expr: "width / 10" },
+                    yExtent: [0, 100],
+                    as: ["dx", "dy"],
+                },
+            ],
+            mark: "point",
+            encoding: {
+                x: { field: "x", type: "quantitative" },
+                y: { field: "y", type: "quantitative" },
+                xOffset: { field: "dx", type: "quantitative", scale: null },
+                yOffset: { field: "dy", type: "quantitative", scale: null },
+            },
+        };
+
+        expect(validate(spec), JSON.stringify(validate.errors, null, 2)).toBe(
+            true
+        );
+    });
+
     test("includes shared lookup options in concrete transform schemas", () => {
         const schema = createCoreSchema();
         const lookupParams =

--- a/packages/core/src/spec/transform.d.ts
+++ b/packages/core/src/spec/transform.d.ts
@@ -1106,6 +1106,76 @@ export interface Displace1DParams extends TransformParamsBase {
     as?: string;
 }
 
+/**
+ * Places generic axis-aligned rectangles in stable input order. Every input row
+ * receives signed pixel offsets; earlier rows have placement priority.
+ */
+export interface Displace2DParams extends TransformParamsBase {
+    type: "displace2d";
+
+    /** Field containing the original horizontal rectangle center. */
+    x: Field;
+
+    /** Field containing the original vertical rectangle center. */
+    y: Field;
+
+    /**
+     * Full collision width in logical pixels, including any desired spacing. A
+     * number is shared by all rows, a field supplies per-row values, and an
+     * expression supplies a reactive scalar shared by all rows. Values must be
+     * non-negative.
+     */
+    width: number | Field | ExprRef;
+
+    /**
+     * Full collision height in logical pixels, including any desired spacing.
+     * A number is shared by all rows, a field supplies per-row values, and an
+     * expression supplies a reactive scalar shared by all rows. Values must be
+     * non-negative.
+     */
+    height: number | Field | ExprRef;
+
+    /**
+     * Multiplier that converts horizontal positions to logical pixels. An
+     * expression can react to scale or layout changes. Negative factors are
+     * valid. Nonlinear scales require pixel positions derived upstream.
+     *
+     * __Default value:__ `1`
+     */
+    xPositionFactor?: number | ExprRef;
+
+    /**
+     * Multiplier that converts vertical positions to logical pixels. An
+     * expression can react to scale or layout changes. Negative factors are
+     * valid. Nonlinear scales require pixel positions derived upstream.
+     *
+     * __Default value:__ `1`
+     */
+    yPositionFactor?: number | ExprRef;
+
+    /**
+     * Preferred horizontal outer bounds in the original coordinate system.
+     * Rectangles that exhaust the bounded local search remain non-overlapping
+     * and extend beyond these bounds in a deterministic overflow row. An
+     * expression may evaluate to `undefined` to disable the bounds.
+     */
+    xExtent?: [number, number] | ExprRef;
+
+    /**
+     * Preferred vertical outer bounds in the original coordinate system. An
+     * expression may evaluate to `undefined` to disable the bounds.
+     */
+    yExtent?: [number, number] | ExprRef;
+
+    /**
+     * Output fields for signed horizontal and vertical pixel displacements.
+     * Positive values move right and down, respectively.
+     *
+     * __Default value:__ `["xDisplacement", "yDisplacement"]`
+     */
+    as?: [string, string];
+}
+
 export interface FlattenCompressedExonsParams extends TransformParamsBase {
     type: "flattenCompressedExons";
 
@@ -1139,6 +1209,7 @@ export type TransformParams =
     | CoordinateLookupParams
     | CrossParams
     | Displace1DParams
+    | Displace2DParams
     | FlattenDelimitedParams
     | FormulaParams
     | LookupParams

--- a/plans/displace2d/displace2d-plan.md
+++ b/plans/displace2d/displace2d-plan.md
@@ -499,6 +499,36 @@ example, either reference the stable upstream asset or add a small derived
 fixture with verified provenance and license; do not add the 1.8 MB Arrow file
 to GenomeSpy merely for convenience.
 
+### Initial solver evidence (2026-08-27)
+
+The first direct rectangle scan confirmed correctness but missed the latency
+budget: the broad 2,000-item synthetic fixture reached a 236 ms Node p95. A
+solver-local uniform grid reduced the same direct candidate checks to about
+1.4 ms p95, justifying that single acceleration structure. No alternative
+collision index remains in the implementation.
+
+Candidate comparison on the airway volcano fixture rejected a nine-position
+neighborhood because 15 of 32 labels used overflow. A bounded strip aligned
+with each rectangle's short axis was the smallest tested sequence that passed
+the initial quality gates. It tests at most 84 displaced candidates, preserves
+the original center as the first candidate, and uses the right-side row after
+exhaustion. With temporary dimensions of eight pixels per character plus eight
+pixels of horizontal spacing and an 18-pixel height, the top-32 airway fixture
+had zero overflow, 82.7 px mean displacement, and 146.9 px p95 displacement.
+Repeat these quality measurements with actual `measureText` output during
+transform integration.
+
+Headless Chromium 145 on an Apple M5 MacBook Pro with 32 GB memory measured the
+final clustered synthetic fixture after ten warm-ups and across 50 solves:
+
+- 100 rectangles: 0.2 ms median and 0.3 ms p95;
+- 500 rectangles: 2.2 ms median and 2.4 ms p95;
+- 2,000 rectangles: 10.7 ms median and 11.0 ms p95.
+
+The temporary benchmark scripts were deleted after recording these results.
+Milestone 1 still requires the real browser airway fixture, interaction-churn
+trace, and visual inspection before the algorithm review gate is complete.
+
 ## Commit and delivery strategy
 
 Commit frequently on `feat/displace2d`, but keep every commit focused,

--- a/plans/displace2d/displace2d-plan.md
+++ b/plans/displace2d/displace2d-plan.md
@@ -42,6 +42,9 @@ Temporary reference checkouts used while preparing this plan:
   commit `7c5792254f0d`, and
   [ggwordcloud](https://github.com/lepennec/ggwordcloud) commit `13544e593f54`
   under `/private/tmp/displace2d-related-work/repos`
+- [genome-spy-python](https://github.com/genome-spy/genome-spy-python) commit
+  `1e97fa3d9102` at
+  `/private/tmp/displace2d-related-work/repos/genome-spy-python`
 
 Research PDFs downloaded under `/private/tmp/displace2d-related-work/papers`:
 
@@ -54,6 +57,17 @@ Research PDFs downloaded under `/private/tmp/displace2d-related-work/papers`:
 
 The D3-Labeler paper link no longer responded, but its MIT-licensed repository
 contains the described simulated-annealing implementation and objective terms.
+
+The exact 12,000-row Arrow table used by genome-spy-python's public airway MA
+and volcano examples is available temporarily at
+`/private/tmp/displace2d-related-work/airway-differential-expression.arrow`.
+Its stable published source is the
+[content-addressed Arrow asset](https://genomespy.app/genome-spy-python/_static/generated/arrow/b4b5bf13778d0f9fe586ee61ef1114aca7b70a15060c39a07a17d566fa06935d.arrow)
+embedded in the pasted specifications. The underlying counts originate from
+the Himes et al. airway experiment, GEO accession
+[GSE52778](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE52778), as
+distributed by Bioconductor's `airway` experiment-data package. Re-verify the
+dataset license before committing any copied or derived data to this repository.
 
 ## Related-work conclusions
 
@@ -420,15 +434,70 @@ Record quality alongside runtime using the following metrics:
 - fraction of rows whose original position remains unchanged;
 - number of materially changed offsets at each step of the zoom trace.
 
-Before selecting the production candidate sequence, choose the canonical
-annotation example and commit its deterministic fixture and quality thresholds
-to this plan. The selection gate is invalid until those thresholds exist. At a
-minimum, an already non-overlapping fixture must remain completely unchanged,
-a fixture constructed so the bounded local candidates can resolve it must have
-zero overflow, and infeasible or search-exhausted fixtures must preserve all
-rows without overlaps. For the canonical dense fixture, set explicit maximum
-overflow and displacement thresholds before comparing implementations; do not
-derive the thresholds from whichever implementation happens to win.
+The canonical fixture and initial thresholds below must be committed before
+selecting the production candidate sequence. At a minimum, an already
+non-overlapping fixture must remain completely unchanged, a fixture constructed
+so the bounded local candidates can resolve it must have zero overflow, and
+infeasible or search-exhausted fixtures must preserve all rows without overlaps.
+Do not derive or relax dense-fixture thresholds to favor whichever
+implementation happens to win.
+
+## Canonical airway fixtures
+
+Use genome-spy-python's
+[airway volcano plot](https://genomespy.app/genome-spy-python/gallery/airway_volcano_plot.html)
+as the primary end-to-end fixture. Its existing labels and leader rules already
+share pixel offsets, exactly matching the proposed output contract. Use the
+[airway MA plot](https://genomespy.app/genome-spy-python/gallery/airway_ma_plot.html)
+as a secondary integration fixture: replace its precomputed data-domain label
+endpoints with pixel displacements while keeping the original data positions as
+leader-line anchors.
+
+The published plots contain only three labels each, which is useful for checking
+composition but too sparse to evaluate automatic placement. Derive deterministic
+annotation subsets from the same 12,000-row table:
+
+1. Sort by `neglog10_pvalue` descending and `ensgene` ascending.
+2. Assign `row_number` and select the first N rows.
+3. Use `gene_symbol` when present and `ensgene` otherwise. The first 32 rows
+   contain label strings from 4 to 15 characters, providing realistic variable
+   widths without another data source.
+4. Obtain label width with `measureText`, derive height explicitly from the text
+   mark's font metrics, and include the desired spacing in both dimensions.
+5. Preserve the selected order through the collector immediately before
+   `displace2d`. Use the same offsets for text and leader-rule endpoints.
+
+Fixture roles and initial gates:
+
+- **Volcano composition:** the original three curated labels must retain all
+  rows, produce leader lines from the original data points, and remain stable
+  through the recorded zoom trace.
+- **Volcano quality:** the top 32 labels at the gallery's 760 by 420 logical-pixel
+  size must have zero overlap and zero overflow initially. Mean displacement
+  must be at most 100 px and p95 at most 200 px.
+- **MA regression:** use the top 16 labels to verify negative or positive scale
+  factors, pixel-offset output, and leader anchors after replacing data-domain
+  label endpoints. Require zero initial overflow.
+- **Performance:** use the top 100, 500, and 2,000 rows from the same ordering in
+  the 1,000 by 800 solver benchmark defined above. The 500- and 2,000-label
+  variants are intentional saturation tests; their overflow counts are reported
+  but are not visual-quality gates.
+- **Interaction churn:** use a deterministic 20-step twofold zoom around the
+  center and then reverse it. A material change is an offset delta greater than
+  4 px between steps. For the 32-label volcano fixture, the median changed
+  fraction must be at most 10% and p95 at most 35%.
+
+These are initial review thresholds, fixed before solver comparison. Change one
+only at the algorithm review gate with a recorded fixture-based rationale, not
+to favor an implementation already written. The 12,000 background points remain
+rendering load but are not collision obstacles in the first contract. The
+selected annotation rectangles avoid one another, and leader lines preserve
+association with their original points.
+
+For local research, use the downloaded Arrow file. Before committing a permanent
+example, either reference the stable upstream asset or add a small derived
+fixture with verified provenance and license; do not add the 1.8 MB Arrow file
+to GenomeSpy merely for convenience.
 
 ## Commit and delivery strategy
 
@@ -504,6 +573,7 @@ Affected areas and downstream consumers:
   results and reproduction command are recorded unless it proves valuable as a
   small permanent regression benchmark; do not build a benchmark framework.
 - Representative scatterplot and genomic annotation fixtures.
+- The 3-, 16-, 32-, 100-, 500-, and 2,000-label airway subsets defined above.
 - This plan's algorithm decision, API question, and recorded measurements.
 - No changes under the `displace1d` implementation, tests, types, or docs.
 
@@ -569,9 +639,9 @@ Tentative commit: `feat(core): add two-dimensional displacement transform`
 
 ### 3. User-facing example, documentation, and integration
 
-Intended outcome: demonstrate a realistic interactive scatterplot with moved
-text annotations and verify the complete contract across renderers and
-interactions.
+Intended outcome: demonstrate the interactive airway volcano plot with moved
+text annotations, retain the airway MA plot as a secondary regression, and
+verify the complete contract across renderers and interactions.
 
 Affected areas and downstream consumers:
 
@@ -611,8 +681,9 @@ documentation, provenance, and code-size tradeoff.
 
 ## Final integration acceptance criteria
 
-- A documented `displace2d` spec labels a dense interactive scatterplot and
-  visibly recomputes during zoom, pan, and resize without blocking interaction.
+- A documented `displace2d` spec labels the airway volcano fixture and visibly
+  recomputes during zoom, pan, and resize without blocking interaction. The MA
+  regression confirms conversion from data-domain endpoints to pixel offsets.
 - The solver and transform meet the accepted performance and churn thresholds
   on the recorded fixtures.
 - Every row is preserved and receives deterministic x and y offsets. Output
@@ -671,24 +742,20 @@ documentation, provenance, and code-size tradeoff.
 
 ## Unresolved questions
 
-1. Which existing or new scatterplot is the canonical first use case, and what
-   real annotation counts, overflow fraction, and normalized displacement
-   should set the final benchmark thresholds? Freeze these before selecting the
-   candidate sequence.
-2. Does a small finite candidate sequence meet the placement-quality fixture,
+1. Does a small finite candidate sequence meet the placement-quality fixture,
    or is a fixed-budget rectangular-ring sequence justified? The right-side
    overflow row is already the termination rule. Resolve the candidate sequence
    inside the solver and keep its controls out of the first public API.
-3. Are separate x/y position factors and extents clearer than paired parameters?
+2. Are separate x/y position factors and extents clearer than paired parameters?
    Prefer the form that most closely preserves `displace1d` semantics and keeps
    expression-backed replay straightforward.
-4. Does stable input and search order provide acceptable temporal coherence?
+3. Does stable input and search order provide acceptable temporal coherence?
    Previous-frame state remains deferred unless the interaction trace proves it
    is needed.
-5. Does the direct rectangle scan meet the performance budget? Only if it fails,
+4. Does the direct rectangle scan meet the performance budget? Only if it fails,
    which single acceleration structure fixes the measured bottleneck with the
    least code and memory?
-6. Does the canonical example remain useful when only annotation rectangles
-   avoid one another? If avoiding anchor points is essential, revise the generic
-   solver input contract at the first review gate rather than adding mark or
-   renderer coupling.
+5. Does visual review of the 32-label airway fixture confirm that background
+   points can remain non-obstacles? If not, revise the generic solver input
+   contract at the first review gate rather than adding mark or renderer
+   coupling.

--- a/plans/displace2d/displace2d-plan.md
+++ b/plans/displace2d/displace2d-plan.md
@@ -1,0 +1,427 @@
+# Two-dimensional annotation displacement
+
+## Status
+
+Proposed. This plan is a temporary implementation artifact and must be
+reconciled and retired before the pull request is merged.
+
+## Motivation
+
+Dense two-dimensional plots need annotation placement that remains legible
+during zooming, panning, resizing, and data updates. GenomeSpy already has a
+`displace1d` transform for ordered, one-dimensional items. A new `displace2d`
+transform should extend the same dataflow-oriented pattern to axis-aligned
+rectangular annotations without coupling the dataflow to marks or a retained
+scene graph.
+
+The main inspirations are:
+
+- [ggrepel](https://ggrepel.slowkow.com/), which repels label boxes from other
+  labels, data points, and plot edges and pulls labels toward their anchors.
+- [ggrepel's related-work survey](https://ggrepel.slowkow.com/articles/related-work),
+  particularly Vega's occupancy-bitmap label placement and the contrasting
+  force, simulated-annealing, greedy, and spiral approaches.
+- [Vega's label transform](https://vega.github.io/vega/docs/transforms/label/),
+  which greedily tests prioritized candidate anchors against compact occupancy
+  bitmaps and explicitly represents labels that cannot be placed.
+
+Temporary reference checkouts used while preparing this plan:
+
+- Vega commit
+  [`79aa7d9`](https://github.com/vega/vega/tree/79aa7d9de7b09604c5f881a09fd528d2b561d12f/packages/vega-label)
+  at `/private/tmp/genome-spy-vega-reference`
+- ggrepel commit
+  [`458aa50`](https://github.com/slowkow/ggrepel/tree/458aa50c14c2d4df8792fff1478aca1ba3b3615f)
+  at `/private/tmp/genome-spy-ggrepel-reference`
+
+## Goals
+
+1. Provide a public transform named `displace2d`, following the existing
+   `displace1d` naming and dataflow conventions.
+2. Keep interaction smooth. Recomputing placement on scale-domain or layout
+   changes must have a deterministic, bounded cost suitable for interactive
+   zoom and pan.
+3. Keep the implementation modular and self-contained: a pure placement solver,
+   a thin dataflow adapter, and no dependency from transforms to views, marks,
+   Canvas, WebGL, SVG, or DOM geometry.
+4. Support heterogeneous axis-aligned annotation rectangles, padding, preferred
+   plot bounds, stable priority order, and explicit handling of items that
+   cannot be placed.
+5. Produce pixel-space x and y displacements that work with GenomeSpy's existing
+   `xOffset`, `yOffset`, `x2Offset`, and `y2Offset` channels. Preserve the
+   original anchor fields so layered leader lines can connect anchors to moved
+   annotations.
+6. React correctly to zoom, layout, and expression-backed placement parameters
+   without changing data-driven x/y domains or creating feedback loops.
+7. Make identical inputs and parameters produce identical outputs. Small view
+   changes should avoid unnecessary label churn so labels do not flicker or
+   jump erratically during interaction.
+8. Define performance and placement-quality benchmarks before committing to an
+   algorithm, and prevent meaningful regressions with repeatable benchmark
+   fixtures.
+9. Avoid new runtime dependencies unless a measured implementation clearly
+   outperforms a small local solver and has a compatible long-term API and
+   license.
+
+## Non-goals for the first version
+
+- Inspecting rendered mark bounds or avoiding arbitrary named marks. GenomeSpy
+  intentionally has no retained scene graph, so this would invert the dataflow
+  and rendering ownership boundary.
+- Automatically measuring text. Authors compose `measureText` (or provide
+  explicit width and height fields) before `displace2d`.
+- Rotated, curved, polygonal, or pixel-perfect glyph collision geometry.
+- Globally optimal label placement. Two-dimensional label placement is
+  computationally hard; the contract is a fast deterministic heuristic with
+  explicit failure output.
+- Off-main-thread placement in the initial implementation. A worker introduces
+  asynchronous and stale-result semantics and should be considered only if a
+  well-profiled synchronous solver cannot meet the interaction budget.
+- A public family of pluggable strategies. Keep algorithm boundaries internal
+  until more than one production use case justifies a public abstraction.
+
+## Architectural constraints from GenomeSpy
+
+- `packages/core/src/view/flowBuilder.js` builds transforms as `FlowNode`s.
+  Batch placement therefore collects input, writes output fields, and
+  repropagates through the existing collector mechanism.
+- `packages/core/src/data/transforms/displace1d.js` establishes the precedent
+  for `BEHAVIOR_COLLECTS | BEHAVIOR_MODIFIES`, expression-backed pixel
+  conversion, scale-domain bootstrap, validation, and reactive replay.
+- `packages/core/src/data/transforms/displace1dSolver.js` establishes the
+  preferred separation between a pure numerical solver and the dataflow
+  adapter.
+- `packages/core/src/data/transforms/measureText.js` supplies label widths but
+  does not own placement.
+- Offset channels are already applied in WebGL and structured SVG output. The
+  transform should emit offsets and reuse that renderer-independent contract
+  instead of inventing annotation-specific rendering paths.
+- Core hot paths should avoid per-frame allocations. Buffers and the occupancy
+  structure should be reusable across reactive repropagations.
+
+## Proposed public contract
+
+The first implementation should validate this shape during the algorithm spike
+and change it before the public API milestone if representative examples reveal
+a simpler contract:
+
+```ts
+interface Displace2DParams extends TransformParamsBase {
+    type: "displace2d";
+    x: Field;
+    y: Field;
+    width: number | Field | ExprRef;
+    height: number | Field | ExprRef;
+    padding?: number | ExprRef;
+    xPositionFactor?: number | ExprRef;
+    yPositionFactor?: number | ExprRef;
+    xExtent?: [number, number] | ExprRef;
+    yExtent?: [number, number] | ExprRef;
+    anchors?: Displace2DAnchor[];
+    offsets?: number[];
+    as?: [string, string, string];
+}
+```
+
+Tentative defaults are zero padding, unit position factors, the eight compass
+anchors plus the original center in nearest-first order, one small pixel offset,
+and `as: ["xDisplacement", "yDisplacement", "placed"]`.
+
+Semantics:
+
+- `x` and `y` identify original annotation centers. The factors convert those
+  coordinates into logical pixels, as `positionFactor` does for `displace1d`.
+  Negative factors are valid and extents are normalized after scaling.
+- `width`, `height`, and `padding` use logical pixels. A string names a datum
+  field; an expression is a reactive scalar shared by the batch.
+- Input order is placement priority. Authors can place `collect` immediately
+  upstream to sort by an application-specific score and to provide the replay
+  buffer required by reactive parameters. The transform must not add a second,
+  competing priority API.
+- `anchors` and parallel/repeated `offsets` define a bounded, deterministic
+  candidate sequence around each original center. Exact names and default order
+  should match established Vega terminology where it fits GenomeSpy.
+- Extents are preferred plot bounds in the original x/y coordinate systems.
+  A candidate outside the scaled extents is rejected.
+- The transform never silently drops rows. It writes `placed: false` when no
+  candidate fits; downstream encodings or filters decide whether to hide,
+  de-emphasize, or otherwise represent that annotation. Displacements for an
+  unplaced row remain zero.
+- The output displacement coordinate system must exactly match unscaled
+  `xOffset` and `yOffset`: positive x moves right and positive y moves down.
+- Like `displace1d`, affine position conversion is supported directly.
+  Nonlinear scales require authors to derive pixel positions explicitly; the
+  documentation must not imply otherwise.
+
+Open API question: an array of explicit `[dx, dy]` candidates may be simpler and
+more general than parallel `anchors` and `offsets`. Resolve this with real specs
+before the schema is added. Do not expose both forms in the first version.
+
+## Algorithm decision
+
+Start from a deterministic, prioritized candidate-placement model inspired by
+vega-label, not a direct port of ggrepel's iterative force simulation.
+
+The preferred baseline is:
+
+1. Convert anchor centers, rectangle sizes, padding, and extents to logical
+   pixels.
+2. Visit rows in stable input-priority order.
+3. Test a bounded nearest-first sequence of candidate positions.
+4. Reject candidates outside the preferred extent or colliding with already
+   placed rectangles.
+5. Reserve the accepted rectangle in a compact occupancy bitmap and emit its
+   displacement; otherwise emit `placed: false`.
+
+An occupancy bitmap gives predictable memory and runtime and guarantees that
+all successful placements are mutually non-overlapping. Following Vega's
+design, cap bitmap resolution near one million cells and downsample larger
+viewports. Keep the grid/collision implementation independent of Vega's scene
+graph and Canvas rasterization.
+
+Before finalizing that choice, compare three small pure-JavaScript prototypes on
+the same fixtures:
+
+- occupancy bitmap with fixed candidates;
+- a spatial-hash force relaxation with a fixed iteration count and no random
+  jitter;
+- a nearest-free spiral or expanding-ring search using the bitmap.
+
+Measure solve time, allocations, placed-label count, total squared displacement,
+and placement churn over a recorded zoom sequence. Select the simplest approach
+that meets all hard requirements. Force simulation is acceptable only if it
+meets the frame budget without wall-clock stopping, randomness, or unbounded
+pairwise scans. Record the decision and measurements in this plan before the
+public API is implemented.
+
+The likely bitmap design is based on Vega's BSD-3-Clause implementation. If code
+is closely adapted, retain the University of Washington copyright and license
+notice in the repository and add a durable `Based on ...` source comment near
+the implementation. ggrepel is GPL-3: use its user-facing behavior and published
+ideas only, and do not copy or translate its source into GenomeSpy's MIT code.
+
+## Performance budget
+
+Use a browser benchmark because JSDOM/Node timings do not represent the
+interactive hot path. Record browser, hardware, fixture, warm-up, and percentile
+method with results. Initial targets for a 1000 x 800 logical-pixel viewport are:
+
+- 500 annotations with nine candidates: median solver time at most 4 ms and
+  p95 at most 8 ms during a recorded zoom sequence.
+- 2,000 annotations: p95 at most one 16.7 ms frame, with runtime bounded by the
+  configured candidate count rather than a wall-clock cutoff.
+- Occupancy storage capped near one million bits per layer plus O(n) reusable
+  working arrays.
+- No monotonically growing allocations or retained per-update data during 1,000
+  repeated zoom/layout recomputations.
+
+These thresholds reserve most of a 60 Hz frame for scale updates, buffer work,
+and rendering. If representative GenomeSpy examples require a different label
+count, adjust the fixture and threshold at the algorithm review gate rather than
+quietly weakening the criterion later.
+
+## Commit and delivery strategy
+
+Commit frequently on `feat/displace2d`, but keep every commit focused,
+reviewable, and verified. Do not accumulate the algorithm spike, public API,
+solver, integration, and documentation into one large feature commit.
+
+Expected checkpoints are:
+
+1. Commit this initial researched plan before implementation begins.
+2. Commit the algorithm prototypes, benchmark evidence, selected approach, and
+   reconciled API decision as one reviewable spike. Do not mix discarded
+   prototype implementations into the production solver commit.
+3. Commit the pure solver and its contract tests once its invariants and
+   performance budget pass.
+4. Commit the dataflow adapter and public grammar integration once reactive
+   replay, scale-domain isolation, schema, and TypeScript checks pass.
+5. Commit the interactive example, renderer/export verification, and
+   user-facing documentation as a coherent integration checkpoint.
+6. Commit worthwhile review fixes separately when they are independently
+   meaningful; fold trivial corrections into the checkpoint they belong to.
+7. Before PR creation, commit the fully reconciled plan with every task marked
+   completed or discarded, then delete the temporary plan in a later commit.
+
+Use Conventional Commit messages with rationale-focused bodies. Run the
+narrowest relevant verification before each checkpoint so intermediate commits
+remain useful for review and bisection.
+
+## Correctness and interaction invariants
+
+- Every `placed: true` rectangle is inside the configured extents and does not
+  overlap another placed rectangle after padding and bitmap quantization are
+  accounted for.
+- Higher-priority input cannot be displaced by a lower-priority input.
+- Equal inputs produce equal outputs across runs and platforms within documented
+  pixel quantization.
+- Output order and datum identity follow normal modifying-transform behavior.
+- Empty, singleton, coincident, heterogeneous-size, negative-factor, reversed
+  screen-axis, and infeasible batches have specified behavior.
+- Non-finite positions, dimensions, factors, padding, extents, candidates, and
+  mismatched `as` arrays fail fast with transform-specific messages.
+- Expression-backed parameters bootstrap only after scale domains exist and
+  trigger one coherent replay when their effective values change.
+- Placement output must not feed back into the data-driven domains used to
+  compute the original positions.
+- During small zoom increments, stable priority and candidate order minimize
+  placement churn. The benchmark reports changed candidates per frame so a fast
+  but visibly flickering solver cannot pass on timing alone.
+
+## Milestones
+
+### 1. Algorithm and contract spike
+
+Intended outcome: choose the smallest solver and candidate API that satisfy the
+measured performance, placement quality, determinism, and interaction-stability
+requirements.
+
+Affected areas and downstream consumers:
+
+- Temporary benchmark/prototype code under the plan directory or a dedicated
+  non-published Core benchmark location.
+- Representative scatterplot and genomic annotation fixtures.
+- This plan's algorithm decision, API question, and recorded measurements.
+
+Verification:
+
+- Run the three algorithm families on sparse, clustered, coincident, mixed-size,
+  edge-heavy, and infeasible fixtures at 100, 500, and 2,000 annotations.
+- Replay a deterministic zoom/pan trace and measure both latency and candidate
+  churn.
+- Inspect output visually for leader-line length, edge crowding, and priority
+  behavior.
+- Confirm the chosen source and license obligations before adapting code.
+
+Documentation or migration: none; no public contract exists yet.
+
+Tentative commit: `chore(core): evaluate 2D displacement algorithms`
+
+Review gate: maintainer review of the algorithm, public parameter shape,
+performance evidence, infeasibility policy, and license/provenance decision.
+
+### 2. Pure solver and dataflow transform
+
+Intended outcome: add a self-contained `displace2d` solver and a thin collecting,
+modifying transform with reactive pixel conversion.
+
+Affected areas and downstream consumers:
+
+- `packages/core/src/data/transforms/displace2dSolver.js` and adjacent unit tests
+- `packages/core/src/data/transforms/displace2d.js` and adjacent transform tests
+- `packages/core/src/data/transforms/transformFactory.js`
+- `packages/core/src/spec/transform.d.ts` and generated schema consumers
+
+Verification:
+
+- Solver contract tests cover all correctness invariants without dataflow or
+  rendering dependencies.
+- Transform tests cover defaults, field/scalar inputs, validation, mutation
+  behavior, upstream `collect` replay, expression bootstrap, zoom reactions,
+  negative factors, extent normalization, and unchanged source domains.
+- Run focused Vitest suites with the `agent` reporter, schema checks, workspace
+  TypeScript checks, and lint for touched code.
+- Re-run the accepted performance fixtures and inspect allocation profiles.
+
+Documentation or migration: add schema JSDoc sufficient for generated type
+documentation; there is no migration because this is additive.
+
+Tentative commit: `feat(core): add two-dimensional displacement transform`
+
+### 3. User-facing example, documentation, and integration
+
+Intended outcome: demonstrate a realistic interactive scatterplot with moved
+text annotations and leader lines, and verify the complete contract across
+renderers and interactions.
+
+Affected areas and downstream consumers:
+
+- `docs/grammar/transform/displace2d.md`, transform navigation, and generated
+  type links
+- A shared example spec following `examples/README.md`, if the example belongs
+  under `examples/`; otherwise a focused docs example
+- Text annotation encoding plus rule or link leader-line encoding
+- WebGL rendering, picking, and structured SVG export through existing offset
+  channels
+
+Verification:
+
+- Exercise initial load, resize, wheel zoom, pan, inertial zoom, and restoration
+  to the original domain in a real browser.
+- Confirm no overlap among placed annotations, deterministic priority, stable
+  interaction, correct picking/tooltip positions, correct clipping, and correct
+  leader-line endpoints.
+- Verify representative WebGL and structured SVG output without adding a new
+  renderer-specific placement path.
+- Build/check generated docs and schema, then run the relevant Core tests and
+  final lint/TypeScript checks.
+- Repeat the accepted benchmark on the integrated example and compare it with
+  the pure-solver result so dataflow overhead is visible.
+
+Documentation or migration: document coordinate units, affine-scale limitation,
+priority ordering, `placed` handling, bounds, candidate behavior, and composition
+with `measureText`, offsets, opacity/filtering, and leader lines.
+
+Tentative commit: `docs(core): document two-dimensional displacement`
+
+Review gate: final maintainer review of the public grammar, integrated
+interaction behavior, downstream renderer/picking/export behavior, performance,
+documentation, provenance, and code-size tradeoff.
+
+## Final integration acceptance criteria
+
+- A documented `displace2d` spec labels a dense interactive scatterplot and
+  visibly recomputes during zoom, pan, and resize without blocking interaction.
+- The solver and transform meet the accepted performance and churn thresholds
+  on the recorded fixtures.
+- Successful placements are non-overlapping, deterministic, prioritized, and
+  bounded; unsuccessful placements are explicit and no row is silently lost.
+- The transform remains dataflow-only, the solver remains pure, and no new
+  rendering special cases or runtime dependencies are introduced.
+- WebGL display, picking/tooltips, clipping, and structured SVG export agree on
+  the displaced positions and leader-line endpoints.
+- Public types, generated schema, documentation, navigation, and example specs
+  agree on parameter names, defaults, units, and limitations.
+- Required BSD attribution is present for closely adapted Vega code; no GPL
+  ggrepel source has been copied or translated.
+- Relevant focused tests, schema/docs checks, TypeScript checks, and lint pass.
+- Git history is divided into the coherent, verified checkpoints above rather
+  than one monolithic implementation commit.
+- Before PR creation, every task in this plan is marked completed or discarded,
+  the reconciled plan is committed, and the plan is deleted in a later commit.
+
+## Risks and mitigations
+
+- **Discrete candidate jumps during zoom.** Measure churn, use a stable
+  nearest-first candidate order, and consider a narrowly scoped previous-choice
+  preference only if it remains deterministic and does not require datum-keyed
+  retained state.
+- **Bitmap false positives after downsampling.** Treat conservative rejection as
+  acceptable but never allow false-negative overlaps; test quantization at view
+  edges and mixed rectangle sizes.
+- **Dense infeasible plots.** Expose `placed` and deterministic priority rather
+  than silently overlapping or running until a time limit.
+- **Expression/data-domain feedback.** Reuse `displace1d` bootstrap and collector
+  replay patterns and test data-driven x and y domains explicitly.
+- **API overfitting to text labels.** Define the solver in terms of rectangle
+  centers and extents and keep text measurement, styling, and leader-line
+  rendering outside the transform.
+- **Premature generalization.** Ship one measured strategy and one candidate
+  representation; keep alternative solvers and renderer obstacle avoidance out
+  of the public API.
+
+## Unresolved questions
+
+1. Should candidates be expressed as Vega-like `anchors` plus `offsets`, or as a
+   single explicit array of pixel displacement vectors?
+2. Should the original center be the first default candidate, or should labels
+   avoid their own anchor by default? This affects both ggrepel-like behavior and
+   leader-line use.
+3. Is conservative bitmap quantization visually acceptable at GenomeSpy's
+   largest supported viewport and device-pixel ratio, or should small viewports
+   retain exact logical-pixel resolution?
+4. Does stable input order alone provide acceptable temporal coherence, or is a
+   deterministic previous-candidate preference needed during continuous zoom?
+5. Which existing or new scatterplot should become the canonical integration
+   fixture, and what real annotation counts should set the final benchmark
+   thresholds?

--- a/plans/displace2d/displace2d-plan.md
+++ b/plans/displace2d/displace2d-plan.md
@@ -44,8 +44,8 @@ Temporary reference checkouts used while preparing this plan:
 3. Keep the implementation modular and self-contained: a pure placement solver,
    a thin dataflow adapter, and no dependency from transforms to views, marks,
    Canvas, WebGL, SVG, or DOM geometry.
-4. Support heterogeneous axis-aligned annotation rectangles, padding, preferred
-   plot bounds, stable priority order, and explicit handling of items that
+4. Support heterogeneous axis-aligned annotation rectangles, padding, plot
+   bounds, stable priority order, and explicit handling of items that
    cannot be placed.
 5. Produce pixel-space x and y displacements that work with GenomeSpy's existing
    `xOffset`, `yOffset`, `x2Offset`, and `y2Offset` channels. Preserve the
@@ -56,9 +56,9 @@ Temporary reference checkouts used while preparing this plan:
 7. Make identical inputs and parameters produce identical outputs. Small view
    changes should avoid unnecessary label churn so labels do not flicker or
    jump erratically during interaction.
-8. Define performance and placement-quality benchmarks before committing to an
-   algorithm, and prevent meaningful regressions with repeatable benchmark
-   fixtures.
+8. Measure the simplest correct implementation against representative
+   performance and placement-quality fixtures before adding an acceleration
+   structure or a more sophisticated algorithm.
 9. Avoid new runtime dependencies unless a measured implementation clearly
    outperforms a small local solver and has a compatible long-term API and
    license.
@@ -71,6 +71,9 @@ Temporary reference checkouts used while preparing this plan:
 - Automatically measuring text. Authors compose `measureText` (or provide
   explicit width and height fields) before `displace2d`.
 - Rotated, curved, polygonal, or pixel-perfect glyph collision geometry.
+- Arbitrary annotation alignment or baseline semantics. The first contract uses
+  axis-aligned rectangles centered on `x` and `y`; authors center the mark or
+  pre-adjust its coordinates upstream.
 - Globally optimal label placement. Two-dimensional label placement is
   computationally hard; the contract is a fast deterministic heuristic with
   explicit failure output.
@@ -79,6 +82,9 @@ Temporary reference checkouts used while preparing this plan:
   well-profiled synchronous solver cannot meet the interaction budget.
 - A public family of pluggable strategies. Keep algorithm boundaries internal
   until more than one production use case justifies a public abstraction.
+- Public candidate-generation options, obstacle geometry, leader-line routing,
+  and previous-frame placement state unless the canonical first use case cannot
+  be implemented acceptably without them.
 
 ## Architectural constraints from GenomeSpy
 
@@ -96,53 +102,91 @@ Temporary reference checkouts used while preparing this plan:
 - Offset channels are already applied in WebGL and structured SVG output. The
   transform should emit offsets and reuse that renderer-independent contract
   instead of inventing annotation-specific rendering paths.
-- Core hot paths should avoid per-frame allocations. Buffers and the occupancy
-  structure should be reusable across reactive repropagations.
+- No renderer changes are expected. If integration appears to require them,
+  revisit the transform output contract before adding renderer special cases.
+- Core hot paths should avoid material per-frame allocations. Reuse working
+  buffers across reactive repropagations only when measurement justifies the
+  extra lifetime management.
+
+## KISS and YAGNI implementation rules
+
+These rules are acceptance criteria for the code, not optional cleanup work:
+
+- Implement one concrete, documented annotation use case end to end before
+  generalizing the solver or grammar.
+- Start with direct arrays, loops, and rectangle predicates. Do not introduce a
+  geometry hierarchy, strategy interface, generic spatial-index abstraction,
+  worker protocol, cache layer, or state machine for hypothetical extensions.
+- Keep the public transform smaller than the internal solver contract. Expose
+  only parameters used by the canonical example and backed by a clear user
+  requirement.
+- Use one placement algorithm in production. Alternative algorithms are
+  considered only after the current one fails a named correctness, quality, or
+  performance criterion on a representative fixture.
+- Prefer stateless deterministic recomputation. Retain previous placements only
+  if measured interaction churn is unacceptable and stable input order cannot
+  solve it.
+- Prefer exact rectangle checks first. Add a uniform grid, bitmap, typed array,
+  buffer reuse, or other optimization individually and only with before/after
+  evidence.
+- Reuse `displace1d` lifecycle patterns, but do not create a shared displacement
+  framework until both transforms contain stable, meaningful duplication.
+- Validate once at the transform boundary. Keep the pure solver focused on its
+  explicit numerical contract and fail loudly on violated invariants.
+- Do not add compatibility aliases, deprecated parameter names, fallback
+  behaviors, or configuration combinations that have never shipped.
+- Keep comments about non-obvious intent, coordinate conventions, provenance,
+  and tradeoffs. Do not narrate straightforward control flow.
+- Add representative behavior tests. Avoid exhaustive matrices that merely
+  repeat implementation branches or freeze internal data structures.
+- Delete discarded spike code and unused helpers before committing production
+  milestones.
+- Measure line count and diff size at each implementation milestone. Added
+  complexity must be justified by a requirement or measurement recorded in this
+  plan.
 
 ## Proposed public contract
 
-The first implementation should validate this shape during the algorithm spike
-and change it before the public API milestone if representative examples reveal
-a simpler contract:
+The initial API candidate is intentionally small. The first milestone must try
+to remove optional parameters before adding any:
 
 ```ts
 interface Displace2DParams extends TransformParamsBase {
     type: "displace2d";
     x: Field;
     y: Field;
-    width: number | Field | ExprRef;
-    height: number | Field | ExprRef;
-    padding?: number | ExprRef;
-    xPositionFactor?: number | ExprRef;
-    yPositionFactor?: number | ExprRef;
-    xExtent?: [number, number] | ExprRef;
-    yExtent?: [number, number] | ExprRef;
-    anchors?: Displace2DAnchor[];
-    offsets?: number[];
+    width: number | Field;
+    height: number | Field;
+    padding?: number;
+    positionFactors?: [number, number] | ExprRef;
+    extent?: [[number, number], [number, number]] | ExprRef;
     as?: [string, string, string];
 }
 ```
 
-Tentative defaults are zero padding, unit position factors, the eight compass
-anchors plus the original center in nearest-first order, one small pixel offset,
-and `as: ["xDisplacement", "yDisplacement", "placed"]`.
+Tentative defaults are zero padding, unit position factors, one fixed internal
+nearest-first candidate sequence, and
+`as: ["xDisplacement", "yDisplacement", "placed"]`.
 
 Semantics:
 
-- `x` and `y` identify original annotation centers. The factors convert those
-  coordinates into logical pixels, as `positionFactor` does for `displace1d`.
-  Negative factors are valid and extents are normalized after scaling.
-- `width`, `height`, and `padding` use logical pixels. A string names a datum
-  field; an expression is a reactive scalar shared by the batch.
+- `x` and `y` identify original annotation centers. Marks use matching centered
+  alignment, or authors adjust their anchor coordinates upstream. The factors
+  convert those coordinates into logical pixels, as `positionFactor` does for
+  `displace1d`. Negative factors are valid and extents are normalized after
+  scaling.
+- `width`, `height`, and `padding` use logical pixels. A string width or height
+  names a datum field. Authors can use existing formula and text-measurement
+  transforms instead of adding another expression mechanism here.
 - Input order is placement priority. Authors can place `collect` immediately
   upstream to sort by an application-specific score and to provide the replay
   buffer required by reactive parameters. The transform must not add a second,
   competing priority API.
-- `anchors` and parallel/repeated `offsets` define a bounded, deterministic
-  candidate sequence around each original center. Exact names and default order
-  should match established Vega terminology where it fits GenomeSpy.
-- Extents are preferred plot bounds in the original x/y coordinate systems.
-  A candidate outside the scaled extents is rejected.
+- The candidate sequence is an internal algorithm detail in the first version.
+  Add public candidate customization only when a second demonstrated use case
+  needs placement behavior that the default cannot provide.
+- `extent` contains x and y plot bounds in the original coordinate
+  systems. A candidate outside the scaled extent is rejected.
 - The transform never silently drops rows. It writes `placed: false` when no
   candidate fits; downstream encodings or filters decide whether to hide,
   de-emphasize, or otherwise represent that annotation. Displacements for an
@@ -153,14 +197,16 @@ Semantics:
   Nonlinear scales require authors to derive pixel positions explicitly; the
   documentation must not imply otherwise.
 
-Open API question: an array of explicit `[dx, dy]` candidates may be simpler and
-more general than parallel `anchors` and `offsets`. Resolve this with real specs
-before the schema is added. Do not expose both forms in the first version.
+The API above is an upper bound, not a checklist. If the canonical example can
+derive pixel positions before this transform, remove `positionFactors`. If its
+view bounds can be expressed directly in pixels, simplify `extent`. Avoid
+mirroring every `displace1d` option merely for symmetry.
 
 ## Algorithm decision
 
-Start from a deterministic, prioritized candidate-placement model inspired by
-vega-label, not a direct port of ggrepel's iterative force simulation.
+Start with a deterministic, prioritized candidate-placement model, not a direct
+port of ggrepel's iterative force simulation and not an immediate port of
+vega-label's bitmap implementation.
 
 The preferred baseline is:
 
@@ -168,37 +214,30 @@ The preferred baseline is:
    pixels.
 2. Visit rows in stable input-priority order.
 3. Test a bounded nearest-first sequence of candidate positions.
-4. Reject candidates outside the preferred extent or colliding with already
+4. Reject candidates outside the extent or colliding with already
    placed rectangles.
-5. Reserve the accepted rectangle in a compact occupancy bitmap and emit its
-   displacement; otherwise emit `placed: false`.
+5. Check the candidate against the short array of already placed rectangles,
+   append an accepted rectangle, and emit its displacement; otherwise emit
+   `placed: false`.
 
-An occupancy bitmap gives predictable memory and runtime and guarantees that
-all successful placements are mutually non-overlapping. Following Vega's
-design, cap bitmap resolution near one million cells and downsample larger
-viewports. Keep the grid/collision implementation independent of Vega's scene
-graph and Canvas rasterization.
+This direct implementation is intentionally O(k n^2) for n annotations and k
+bounded candidates. It is the correctness and code-size baseline, not a promise
+to ship an avoidably slow algorithm. Measure it first on the canonical example.
+If it misses the performance budget, add the smallest broad-phase structure that
+fixes the measured bottleneck and preserves exact rectangle checks. Compare a
+uniform grid and Vega-style occupancy bitmap on that fixture only; do not build
+or keep both production implementations.
 
-Before finalizing that choice, compare three small pure-JavaScript prototypes on
-the same fixtures:
+Consider force relaxation or expanding-ring search only if fixed candidates
+fail the agreed placement-quality criterion. Do not implement them merely to
+complete an algorithm survey. Any force implementation must use a fixed,
+deterministic work bound without randomness or wall-clock stopping.
 
-- occupancy bitmap with fixed candidates;
-- a spatial-hash force relaxation with a fixed iteration count and no random
-  jitter;
-- a nearest-free spiral or expanding-ring search using the bitmap.
-
-Measure solve time, allocations, placed-label count, total squared displacement,
-and placement churn over a recorded zoom sequence. Select the simplest approach
-that meets all hard requirements. Force simulation is acceptable only if it
-meets the frame budget without wall-clock stopping, randomness, or unbounded
-pairwise scans. Record the decision and measurements in this plan before the
-public API is implemented.
-
-The likely bitmap design is based on Vega's BSD-3-Clause implementation. If code
-is closely adapted, retain the University of Washington copyright and license
-notice in the repository and add a durable `Based on ...` source comment near
-the implementation. ggrepel is GPL-3: use its user-facing behavior and published
-ideas only, and do not copy or translate its source into GenomeSpy's MIT code.
+If an optimized bitmap design closely adapts Vega's BSD-3-Clause
+implementation, retain the University of Washington copyright and license
+notice and add a durable `Based on ...` source comment. ggrepel is GPL-3: use
+its user-facing behavior and published ideas only, and do not copy or translate
+its source into GenomeSpy's MIT code.
 
 ## Performance budget
 
@@ -210,8 +249,8 @@ method with results. Initial targets for a 1000 x 800 logical-pixel viewport are
   p95 at most 8 ms during a recorded zoom sequence.
 - 2,000 annotations: p95 at most one 16.7 ms frame, with runtime bounded by the
   configured candidate count rather than a wall-clock cutoff.
-- Occupancy storage capped near one million bits per layer plus O(n) reusable
-  working arrays.
+- Baseline working memory remains O(n). Any later acceleration structure must
+  have a documented bound appropriate to the viewport and fixture sizes.
 - No monotonically growing allocations or retained per-update data during 1,000
   repeated zoom/layout recomputations.
 
@@ -229,18 +268,16 @@ solver, integration, and documentation into one large feature commit.
 Expected checkpoints are:
 
 1. Commit this initial researched plan before implementation begins.
-2. Commit the algorithm prototypes, benchmark evidence, selected approach, and
-   reconciled API decision as one reviewable spike. Do not mix discarded
-   prototype implementations into the production solver commit.
-3. Commit the pure solver and its contract tests once its invariants and
-   performance budget pass.
-4. Commit the dataflow adapter and public grammar integration once reactive
+2. Commit the pure solver, measured direct baseline, and reduced API decision
+   once its invariants and performance budget pass. Delete discarded
+   experiments before the commit.
+3. Commit the dataflow adapter and public grammar integration once reactive
    replay, scale-domain isolation, schema, and TypeScript checks pass.
-5. Commit the interactive example, renderer/export verification, and
+4. Commit the interactive example, renderer/export verification, and
    user-facing documentation as a coherent integration checkpoint.
-6. Commit worthwhile review fixes separately when they are independently
+5. Commit worthwhile review fixes separately when they are independently
    meaningful; fold trivial corrections into the checkpoint they belong to.
-7. Before PR creation, commit the fully reconciled plan with every task marked
+6. Before PR creation, commit the fully reconciled plan with every task marked
    completed or discarded, then delete the temporary plan in a later commit.
 
 Use Conventional Commit messages with rationale-focused bodies. Run the
@@ -250,8 +287,8 @@ remain useful for review and bisection.
 ## Correctness and interaction invariants
 
 - Every `placed: true` rectangle is inside the configured extents and does not
-  overlap another placed rectangle after padding and bitmap quantization are
-  accounted for.
+  overlap another placed rectangle after padding and any broad-phase
+  quantization are accounted for.
 - Higher-priority input cannot be displaced by a lower-priority input.
 - Equal inputs produce equal outputs across runs and platforms within documented
   pixel quantization.
@@ -270,44 +307,53 @@ remain useful for review and bisection.
 
 ## Milestones
 
-### 1. Algorithm and contract spike
+### 1. Minimal solver and contract evidence
 
-Intended outcome: choose the smallest solver and candidate API that satisfy the
-measured performance, placement quality, determinism, and interaction-stability
-requirements.
+Intended outcome: implement the smallest production-quality direct solver once,
+validate it against one canonical use case, and reduce the candidate API before
+it becomes public. Introduce a more complex algorithm only if this baseline
+fails an explicit criterion.
 
 Affected areas and downstream consumers:
 
-- Temporary benchmark/prototype code under the plan directory or a dedicated
-  non-published Core benchmark location.
+- `packages/core/src/data/transforms/displace2dSolver.js` and adjacent contract
+  tests
+- A temporary benchmark script under the plan directory. Delete it after its
+  results and reproduction command are recorded unless it proves valuable as a
+  small permanent regression benchmark; do not build a benchmark framework.
 - Representative scatterplot and genomic annotation fixtures.
 - This plan's algorithm decision, API question, and recorded measurements.
 
 Verification:
 
-- Run the three algorithm families on sparse, clustered, coincident, mixed-size,
+- Run the direct baseline on sparse, clustered, coincident, mixed-size,
   edge-heavy, and infeasible fixtures at 100, 500, and 2,000 annotations.
+- If it fails a criterion, identify the bottleneck before implementing one
+  targeted alternative. Record why the added complexity is necessary and its
+  before/after result.
 - Replay a deterministic zoom/pan trace and measure both latency and candidate
   churn.
-- Inspect output visually for leader-line length, edge crowding, and priority
-  behavior.
+- Inspect output visually for displacement, edge crowding, placement churn, and
+  priority behavior.
 - Confirm the chosen source and license obligations before adapting code.
 
-Documentation or migration: none; no public contract exists yet.
+Documentation or migration: record the selected behavior, reduced API decision,
+measurements, and discarded alternatives in this plan. No public contract
+exists yet.
 
-Tentative commit: `chore(core): evaluate 2D displacement algorithms`
+Tentative commit: `feat(core): add two-dimensional displacement solver`
 
 Review gate: maintainer review of the algorithm, public parameter shape,
 performance evidence, infeasibility policy, and license/provenance decision.
 
-### 2. Pure solver and dataflow transform
+### 2. Dataflow transform and public grammar
 
-Intended outcome: add a self-contained `displace2d` solver and a thin collecting,
-modifying transform with reactive pixel conversion.
+Intended outcome: add a thin collecting, modifying `displace2d` transform with
+reactive pixel conversion and the smallest public contract proven by milestone
+1.
 
 Affected areas and downstream consumers:
 
-- `packages/core/src/data/transforms/displace2dSolver.js` and adjacent unit tests
 - `packages/core/src/data/transforms/displace2d.js` and adjacent transform tests
 - `packages/core/src/data/transforms/transformFactory.js`
 - `packages/core/src/spec/transform.d.ts` and generated schema consumers
@@ -321,7 +367,8 @@ Verification:
   negative factors, extent normalization, and unchanged source domains.
 - Run focused Vitest suites with the `agent` reporter, schema checks, workspace
   TypeScript checks, and lint for touched code.
-- Re-run the accepted performance fixtures and inspect allocation profiles.
+- Re-run the accepted performance fixtures. Inspect allocations only if timing
+  or memory measurements identify them as a material problem.
 
 Documentation or migration: add schema JSDoc sufficient for generated type
 documentation; there is no migration because this is additive.
@@ -331,8 +378,8 @@ Tentative commit: `feat(core): add two-dimensional displacement transform`
 ### 3. User-facing example, documentation, and integration
 
 Intended outcome: demonstrate a realistic interactive scatterplot with moved
-text annotations and leader lines, and verify the complete contract across
-renderers and interactions.
+text annotations and verify the complete contract across renderers and
+interactions.
 
 Affected areas and downstream consumers:
 
@@ -340,7 +387,7 @@ Affected areas and downstream consumers:
   type links
 - A shared example spec following `examples/README.md`, if the example belongs
   under `examples/`; otherwise a focused docs example
-- Text annotation encoding plus rule or link leader-line encoding
+- Text annotation encoding using existing offset channels
 - WebGL rendering, picking, and structured SVG export through existing offset
   channels
 
@@ -350,9 +397,10 @@ Verification:
   to the original domain in a real browser.
 - Confirm no overlap among placed annotations, deterministic priority, stable
   interaction, correct picking/tooltip positions, correct clipping, and correct
-  leader-line endpoints.
-- Verify representative WebGL and structured SVG output without adding a new
-  renderer-specific placement path.
+  displaced positions.
+- Smoke-test representative WebGL and structured SVG output through the existing
+  offset path. Add a new permanent cross-renderer test only if the transform
+  introduces behavior that existing offset tests do not cover.
 - Build/check generated docs and schema, then run the relevant Core tests and
   final lint/TypeScript checks.
 - Repeat the accepted benchmark on the integrated example and compare it with
@@ -360,7 +408,8 @@ Verification:
 
 Documentation or migration: document coordinate units, affine-scale limitation,
 priority ordering, `placed` handling, bounds, candidate behavior, and composition
-with `measureText`, offsets, opacity/filtering, and leader lines.
+with `measureText`, offsets, and opacity or filtering. Mention leader-line
+composition only if the canonical example actually uses it.
 
 Tentative commit: `docs(core): document two-dimensional displacement`
 
@@ -379,12 +428,18 @@ documentation, provenance, and code-size tradeoff.
 - The transform remains dataflow-only, the solver remains pure, and no new
   rendering special cases or runtime dependencies are introduced.
 - WebGL display, picking/tooltips, clipping, and structured SVG export agree on
-  the displaced positions and leader-line endpoints.
+  the displaced positions.
 - Public types, generated schema, documentation, navigation, and example specs
   agree on parameter names, defaults, units, and limitations.
 - Required BSD attribution is present for closely adapted Vega code; no GPL
   ggrepel source has been copied or translated.
 - Relevant focused tests, schema/docs checks, TypeScript checks, and lint pass.
+- The production change contains one solver path and no unused strategy,
+  geometry, caching, worker, or compatibility abstractions.
+- Public parameters are exercised by the canonical example. Any parameter that
+  remains only for a hypothetical use case is removed or explicitly deferred.
+- Line-count and diff-size measurements are recorded at implementation
+  milestones, and non-essential helpers, options, and tests are deleted.
 - Git history is divided into the coherent, verified checkpoints above rather
   than one monolithic implementation commit.
 - Before PR creation, every task in this plan is marked completed or discarded,
@@ -392,13 +447,12 @@ documentation, provenance, and code-size tradeoff.
 
 ## Risks and mitigations
 
-- **Discrete candidate jumps during zoom.** Measure churn, use a stable
-  nearest-first candidate order, and consider a narrowly scoped previous-choice
-  preference only if it remains deterministic and does not require datum-keyed
-  retained state.
-- **Bitmap false positives after downsampling.** Treat conservative rejection as
-  acceptable but never allow false-negative overlaps; test quantization at view
-  edges and mixed rectangle sizes.
+- **Discrete candidate jumps during zoom.** Measure churn and use stable input
+  and candidate order first. Consider retained previous choices only after this
+  stateless design demonstrably fails the interaction criterion.
+- **Premature optimization.** Preserve the direct solver as the measured design
+  baseline. Add one broad-phase optimization only if profiling shows that
+  rectangle scans cause a budget failure; do not retain two production paths.
 - **Dense infeasible plots.** Expose `placed` and deterministic priority rather
   than silently overlapping or running until a time limit.
 - **Expression/data-domain feedback.** Reuse `displace1d` bootstrap and collector
@@ -412,16 +466,16 @@ documentation, provenance, and code-size tradeoff.
 
 ## Unresolved questions
 
-1. Should candidates be expressed as Vega-like `anchors` plus `offsets`, or as a
-   single explicit array of pixel displacement vectors?
-2. Should the original center be the first default candidate, or should labels
-   avoid their own anchor by default? This affects both ggrepel-like behavior and
-   leader-line use.
-3. Is conservative bitmap quantization visually acceptable at GenomeSpy's
-   largest supported viewport and device-pixel ratio, or should small viewports
-   retain exact logical-pixel resolution?
-4. Does stable input order alone provide acceptable temporal coherence, or is a
-   deterministic previous-candidate preference needed during continuous zoom?
-5. Which existing or new scatterplot should become the canonical integration
-   fixture, and what real annotation counts should set the final benchmark
-   thresholds?
+1. Which existing or new scatterplot is the canonical first use case, and what
+   real annotation counts should set the final benchmark thresholds?
+2. Should the internal default try the original center first, or avoid the
+   annotation's anchor by default? Resolve this from the canonical example; do
+   not expose a public option in the first version.
+3. Can the canonical spec derive pixel coordinates before `displace2d`, allowing
+   `positionFactors` or `extent` to be removed from the public contract?
+4. Does stable input and candidate order provide acceptable temporal coherence?
+   Previous-frame state remains deferred unless the interaction trace proves it
+   is needed.
+5. Does the direct rectangle scan meet the performance budget? Only if it fails,
+   which single acceleration structure fixes the measured bottleneck with the
+   least code and memory?

--- a/plans/displace2d/displace2d-plan.md
+++ b/plans/displace2d/displace2d-plan.md
@@ -35,6 +35,68 @@ Temporary reference checkouts used while preparing this plan:
 - ggrepel commit
   [`458aa50`](https://github.com/slowkow/ggrepel/tree/458aa50c14c2d4df8792fff1478aca1ba3b3615f)
   at `/private/tmp/genome-spy-ggrepel-reference`
+- [D3-Labeler](https://github.com/tinker10/D3-Labeler) commit `6de86705a8bb`,
+  [adjustText](https://github.com/Phlya/adjustText) commit `92b0397b5de1`,
+  [d3fc-label-layout](https://github.com/ColinEberhardt/d3fc-label-layout)
+  commit `97d1b2f82f39`, [directlabels](https://github.com/tdhock/directlabels)
+  commit `7c5792254f0d`, and
+  [ggwordcloud](https://github.com/lepennec/ggwordcloud) commit `13544e593f54`
+  under `/private/tmp/displace2d-related-work/repos`
+
+Research PDFs downloaded under `/private/tmp/displace2d-related-work/papers`:
+
+- [Fast and Flexible Overlap Detection for Chart Labeling with Occupancy
+  Bitmap](https://www.domoritz.de/papers/2020-OccupancyBitmap-VIS.pdf)
+- [An Efficient Algorithm for Scatter Chart
+  Labeling](https://aaai.org/Papers/AAAI/2006/AAAI06-167.pdf)
+- [Labeling Algorithms, Chapter 15 of the Handbook of Graph Drawing and
+  Visualization](https://cs.brown.edu/people/rtamassi/gdhandbook/chapters/labeling.pdf)
+
+The D3-Labeler paper link no longer responded, but its MIT-licensed repository
+contains the described simulated-annealing implementation and objective terms.
+
+## Related-work conclusions
+
+The reviewed work separates into approaches with different tradeoffs. None can
+be adopted wholesale because most solve a label-specific selection problem,
+while `displace2d` must preserve generic rows and emit offsets only.
+
+- Vega's occupancy-bitmap paper and transform provide the strongest evidence
+  for greedy, ordered candidate placement at interactive scale. The bitmap is
+  an overlap-query acceleration structure, not a placement policy. Vega omits
+  labels when its finite candidates fail, so its failure contract is not
+  suitable here.
+- The scatter-chart paper is directly relevant to interaction: it requires
+  deterministic output to avoid confusing users and discusses arbitrary
+  displacement with leader lines. Its continuous ray search, lookahead, and
+  iterative regrouping optimize placement count and connector length, but even
+  the authors use asynchronous recomputation for interaction. That is too much
+  machinery for the first solver.
+- ggrepel, adjustText, and D3-Labeler repeatedly resolve overlaps using force
+  relaxation or simulated annealing. They expose forces, iteration or time
+  limits, cooling, and movement constraints; D3-Labeler defaults to 1,000
+  Monte Carlo sweeps. These methods are useful sources of quality criteria but
+  are a poor default for deterministic bounded interaction.
+- d3fc-label-layout cleanly models positions and rectangle sizes, supporting
+  the generic geometry contract. Its greedy and annealing strategies may leave
+  overlaps and its cleanup strategy hides labels. Its public strategy layer is
+  broader than GenomeSpy needs.
+- ggwordcloud searches outward along a spiral and checks exact boxes against
+  already placed boxes. This is the closest structural match for preserving
+  items through displacement, but it starts at a random angle, performs linear
+  scans, exposes word-cloud-specific search controls, and can return failed
+  words to their overlapping original positions.
+- directlabels demonstrates the maintenance cost of a highly extensible method
+  pipeline: named and nested positioning methods, method dispatch, and
+  plot-specific heuristics. That flexibility is valuable for its package but
+  reinforces keeping `displace2d` to one solver and a small data contract.
+
+The handbook confirms that practical labeling relies on heuristics because the
+general and point-labeling problems are hard, that four or eight discrete
+positions are common, and that larger candidate sets directly increase cost.
+It also separates placement quality into non-overlap, unambiguous association,
+and preference. `displace2d` owns the first and proximity to the input center;
+rendering and connector composition own association.
 
 ## Goals
 
@@ -152,7 +214,8 @@ These rules are acceptance criteria for the code, not optional cleanup work:
   solve it.
 - Prefer exact rectangle checks first. Add a uniform grid, bitmap, typed array,
   buffer reuse, or other optimization individually and only with before/after
-  evidence.
+  evidence. Keep candidate generation separate from collision lookup without
+  introducing interfaces for either.
 - Reuse `displace1d` lifecycle patterns, but do not create a shared displacement
   framework until both transforms contain stable, meaningful duplication.
 - Validate once at the transform boundary. Keep the pure solver focused on its
@@ -236,25 +299,32 @@ The preferred baseline is:
 
 1. Convert item centers, collision widths and heights, and extents to logical
    pixels.
-2. Visit rows in stable input order and test positions nearest to each original
-   center first.
+2. Visit rows in stable input order and test a small, deterministic sequence of
+   positions nearest to each original center first. The unchanged position is
+   always the first candidate.
 3. Check candidates against the short array of already placed rectangles using
    exact rectangle predicates.
-4. Prefer positions inside the configured extents. If the extents are
-   infeasible, use a deterministic overflow rule rather than dropping a row or
-   emitting a visibility decision.
+4. Give the local search a fixed work bound. If its candidates cannot place a
+   rectangle inside the preferred extents, use a deterministic overflow shelf
+   outside the crowded region. The shelf must guarantee termination and
+   non-overlap rather than dropping a row or returning it to an overlapping
+   original position.
 5. Emit one finite signed x offset and one finite signed y offset for every row.
 
 The direct implementation is the correctness and code-size baseline, not a
 promise to ship an avoidably slow algorithm. Measure it first on representative
 generic rectangles and the canonical annotation example. The initial solver
-spike must resolve how nearest-position search terminates and how overflow is
-minimized without adding public tuning parameters.
+spike must compare the smallest useful finite candidate sequence with a bounded
+expanding-ring or spiral sequence. Choose one based on the named quality and
+latency fixtures, then delete the other. Search controls remain internal, and
+the deterministic overflow shelf is the termination guarantee for either.
 
-If the baseline misses the performance budget, add the smallest broad-phase
-structure that fixes the measured bottleneck and preserves exact rectangle
-checks. Compare a uniform grid and Vega-style occupancy bitmap on that fixture
-only; do not build or keep both production implementations.
+If the baseline misses the performance budget, first determine whether candidate
+count or collision lookup is the bottleneck. Reduce candidate work before adding
+state. If rectangle scans are the bottleneck, add the smallest broad-phase
+structure that fixes the measured case. A uniform grid is the first comparison
+for rectangle-only input; compare Vega-style occupancy bitmap only if the grid
+still misses the budget. Do not keep more than one production lookup path.
 
 Consider force relaxation only if the direct displacement method fails the
 agreed placement-quality criterion. Do not implement it merely to complete an
@@ -485,8 +555,8 @@ documentation, provenance, and code-size tradeoff.
   baseline. Add one broad-phase optimization only if profiling shows that
   rectangle scans cause a budget failure; do not retain two production paths.
 - **Dense infeasible bounds.** Preserve every row and use a documented
-  deterministic overflow rule rather than emitting visibility or silently
-  accepting overlaps.
+  deterministic overflow shelf rather than emitting visibility, silently
+  accepting overlaps, or running an unbounded search.
 - **Expression/data-domain feedback.** Reuse `displace1d` bootstrap and collector
   replay patterns and test data-driven x and y domains explicitly.
 - **API overfitting to text labels.** Define the solver in terms of rectangle
@@ -500,10 +570,10 @@ documentation, provenance, and code-size tradeoff.
 
 1. Which existing or new scatterplot is the canonical first use case, and what
    real annotation counts should set the final benchmark thresholds?
-2. What deterministic nearest-position search and overflow rule preserve all
-   rows while keeping squared displacement and extent overflow acceptably low?
-   Resolve this inside the solver; do not expose search controls in the first
-   public API.
+2. Does a small finite candidate sequence meet the placement-quality fixture,
+   or is a fixed-budget expanding-ring/spiral sequence justified? The overflow
+   shelf is already the termination rule. Resolve the candidate sequence inside
+   the solver and keep its controls out of the first public API.
 3. Are separate x/y position factors and extents clearer than paired parameters?
    Prefer the form that most closely preserves `displace1d` semantics and keeps
    expression-backed replay straightforward.

--- a/plans/displace2d/displace2d-plan.md
+++ b/plans/displace2d/displace2d-plan.md
@@ -7,12 +7,14 @@ reconciled and retired before the pull request is merged.
 
 ## Motivation
 
-Dense two-dimensional plots need annotation placement that remains legible
-during zooming, panning, resizing, and data updates. GenomeSpy already has a
-`displace1d` transform for ordered, one-dimensional items. A new `displace2d`
-transform should extend the same dataflow-oriented pattern to axis-aligned
-rectangular annotations without coupling the dataflow to marks or a retained
-scene graph.
+Dense two-dimensional plots need item placement that remains legible during
+zooming, panning, resizing, and data updates. Annotations are the motivating use
+case, but the transform should operate on generic axis-aligned collision boxes.
+GenomeSpy already has a `displace1d` transform at the right abstraction level: it
+accepts flexible geometry inputs, preserves every row, and emits a signed offset
+without knowing how the item is rendered. A new `displace2d` transform should
+extend that dataflow-oriented pattern without coupling placement to marks or a
+retained scene graph.
 
 The main inspirations are:
 
@@ -44,13 +46,13 @@ Temporary reference checkouts used while preparing this plan:
 3. Keep the implementation modular and self-contained: a pure placement solver,
    a thin dataflow adapter, and no dependency from transforms to views, marks,
    Canvas, WebGL, SVG, or DOM geometry.
-4. Support heterogeneous axis-aligned annotation rectangles, padding, plot
-   bounds, stable priority order, and explicit handling of items that
-   cannot be placed.
-5. Produce pixel-space x and y displacements that work with GenomeSpy's existing
-   `xOffset`, `yOffset`, `x2Offset`, and `y2Offset` channels. Preserve the
-   original anchor fields so layered leader lines can connect anchors to moved
-   annotations.
+4. Support heterogeneous axis-aligned rectangles using the same flexible input
+   forms as `displace1d`: per-row fields, constants, and reactive shared scalars
+   where each form has useful semantics.
+5. Preserve every input row and produce only pixel-space x and y displacement
+   fields. The offsets must compose with GenomeSpy's existing `xOffset`,
+   `yOffset`, `x2Offset`, and `y2Offset` channels without prescribing rendering,
+   visibility, or styling.
 6. React correctly to zoom, layout, and expression-backed placement parameters
    without changing data-driven x/y domains or creating feedback loops.
 7. Make identical inputs and parameters produce identical outputs. Small view
@@ -74,17 +76,17 @@ Temporary reference checkouts used while preparing this plan:
 - Arbitrary annotation alignment or baseline semantics. The first contract uses
   axis-aligned rectangles centered on `x` and `y`; authors center the mark or
   pre-adjust its coordinates upstream.
-- Globally optimal label placement. Two-dimensional label placement is
+- Globally optimal rectangle placement. Two-dimensional placement is
   computationally hard; the contract is a fast deterministic heuristic with
-  explicit failure output.
+  documented preferred-bound overflow behavior.
 - Off-main-thread placement in the initial implementation. A worker introduces
   asynchronous and stale-result semantics and should be considered only if a
   well-profiled synchronous solver cannot meet the interaction budget.
 - A public family of pluggable strategies. Keep algorithm boundaries internal
   until more than one production use case justifies a public abstraction.
-- Public candidate-generation options, obstacle geometry, leader-line routing,
-  and previous-frame placement state unless the canonical first use case cannot
-  be implemented acceptably without them.
+- Public candidate-generation options, obstacle geometry, visibility decisions,
+  leader-line routing, and previous-frame placement state unless a demonstrated
+  use case cannot be implemented acceptably without them.
 
 ## Architectural constraints from GenomeSpy
 
@@ -108,6 +110,28 @@ Temporary reference checkouts used while preparing this plan:
   buffers across reactive repropagations only when measurement justifies the
   extra lifetime management.
 
+## Abstraction-level decision
+
+`displace1d` is the primary design precedent, not merely a source of lifecycle
+code. `displace2d` must preserve these properties:
+
+- Inputs describe generic item geometry rather than text, labels, points, or
+  mark instances.
+- Collision dimensions accept a constant, a datum field, or a reactive scalar
+  where that distinction is useful, matching `displace1d.length`.
+- Position conversion and preferred bounds can react to zoom and layout,
+  matching `displace1d.positionFactor` and `displace1d.extent`.
+- Every row is propagated. Infeasible preferred bounds affect displacement or
+  overflow, not row visibility.
+- Outputs are signed offsets only. The transform does not emit `placed`,
+  opacity, alignment, baseline, anchor, connector, or priority fields.
+- Upstream transforms own sorting, measurement, and derived geometry;
+  downstream encodings own rendering, filtering, styling, and connectors.
+
+Follow the abstraction, but do not manufacture a shared base class or generic
+displacement framework. The 1D and 2D solvers have different mathematical
+contracts and should share code only after real, stable duplication appears.
+
 ## KISS and YAGNI implementation rules
 
 These rules are acceptance criteria for the code, not optional cleanup work:
@@ -117,9 +141,9 @@ These rules are acceptance criteria for the code, not optional cleanup work:
 - Start with direct arrays, loops, and rectangle predicates. Do not introduce a
   geometry hierarchy, strategy interface, generic spatial-index abstraction,
   worker protocol, cache layer, or state machine for hypothetical extensions.
-- Keep the public transform smaller than the internal solver contract. Expose
-  only parameters used by the canonical example and backed by a clear user
-  requirement.
+- Keep the public transform generic through data inputs, not through modes and
+  switches. Expose only geometry, coordinate conversion, bounds, and output
+  field names.
 - Use one placement algorithm in production. Alternative algorithms are
   considered only after the current one fails a named correctness, quality, or
   performance criterion on a representative fixture.
@@ -155,83 +179,88 @@ interface Displace2DParams extends TransformParamsBase {
     type: "displace2d";
     x: Field;
     y: Field;
-    width: number | Field;
-    height: number | Field;
-    padding?: number;
-    positionFactors?: [number, number] | ExprRef;
-    extent?: [[number, number], [number, number]] | ExprRef;
-    as?: [string, string, string];
+    width: number | Field | ExprRef;
+    height: number | Field | ExprRef;
+    xPositionFactor?: number | ExprRef;
+    yPositionFactor?: number | ExprRef;
+    xExtent?: [number, number] | ExprRef;
+    yExtent?: [number, number] | ExprRef;
+    as?: [string, string];
 }
 ```
 
-Tentative defaults are zero padding, unit position factors, one fixed internal
-nearest-first candidate sequence, and
-`as: ["xDisplacement", "yDisplacement", "placed"]`.
+Tentative defaults are unit position factors and
+`as: ["xDisplacement", "yDisplacement"]`. Width and height include any desired
+collision spacing, just as `displace1d.length` includes spacing; a separate
+padding parameter is unnecessary.
 
 Semantics:
 
-- `x` and `y` identify original annotation centers. Marks use matching centered
-  alignment, or authors adjust their anchor coordinates upstream. The factors
-  convert those coordinates into logical pixels, as `positionFactor` does for
-  `displace1d`. Negative factors are valid and extents are normalized after
-  scaling.
-- `width`, `height`, and `padding` use logical pixels. A string width or height
-  names a datum field. Authors can use existing formula and text-measurement
-  transforms instead of adding another expression mechanism here.
-- Input order is placement priority. Authors can place `collect` immediately
-  upstream to sort by an application-specific score and to provide the replay
-  buffer required by reactive parameters. The transform must not add a second,
-  competing priority API.
+- `x` and `y` identify original item centers. Marks use matching centered
+  alignment, or authors adjust their anchor coordinates upstream.
+- `xPositionFactor` and `yPositionFactor` independently convert source
+  coordinates into logical pixels, as `displace1d.positionFactor` does. Negative
+  factors are valid and scaled extents are normalized per axis.
+- `width` and `height` are full collision dimensions in logical pixels. A number
+  is shared by all rows, a string names a datum field, and an expression
+  provides a reactive scalar shared by all rows, matching `displace1d.length`.
+- Input order provides stable deterministic ordering. Authors can place
+  `collect` immediately upstream to sort and to provide the replay buffer
+  required by reactive parameters. The transform must not add a competing
+  priority API.
 - The candidate sequence is an internal algorithm detail in the first version.
   Add public candidate customization only when a second demonstrated use case
   needs placement behavior that the default cannot provide.
-- `extent` contains x and y plot bounds in the original coordinate
-  systems. A candidate outside the scaled extent is rejected.
-- The transform never silently drops rows. It writes `placed: false` when no
-  candidate fits; downstream encodings or filters decide whether to hide,
-  de-emphasize, or otherwise represent that annotation. Displacements for an
-  unplaced row remain zero.
+- `xExtent` and `yExtent` are preferred bounds in their respective original
+  coordinate systems and are scaled with the item centers. When the rectangles
+  cannot fit, every row still receives offsets and the documented overflow
+  policy applies.
 - The output displacement coordinate system must exactly match unscaled
   `xOffset` and `yOffset`: positive x moves right and positive y moves down.
 - Like `displace1d`, affine position conversion is supported directly.
   Nonlinear scales require authors to derive pixel positions explicitly; the
   documentation must not imply otherwise.
 
-The API above is an upper bound, not a checklist. If the canonical example can
-derive pixel positions before this transform, remove `positionFactors`. If its
-view bounds can be expressed directly in pixels, simplify `extent`. Avoid
-mirroring every `displace1d` option merely for symmetry.
+The API mirrors `displace1d` where the concepts have direct two-dimensional
+counterparts. Do not add label anchors, candidate lists, visibility, forces,
+iteration controls, or algorithm selection to the public contract without a
+separate demonstrated requirement.
 
 ## Algorithm decision
 
-Start with a deterministic, prioritized candidate-placement model, not a direct
-port of ggrepel's iterative force simulation and not an immediate port of
-vega-label's bitmap implementation.
+Start with the simplest deterministic rectangle-displacement model that
+preserves all rows, not a direct port of ggrepel's iterative force simulation
+and not an immediate port of vega-label's bitmap implementation.
 
 The preferred baseline is:
 
-1. Convert anchor centers, rectangle sizes, padding, and extents to logical
+1. Convert item centers, collision widths and heights, and extents to logical
    pixels.
-2. Visit rows in stable input-priority order.
-3. Test a bounded nearest-first sequence of candidate positions.
-4. Reject candidates outside the extent or colliding with already
-   placed rectangles.
-5. Check the candidate against the short array of already placed rectangles,
-   append an accepted rectangle, and emit its displacement; otherwise emit
-   `placed: false`.
+2. Visit rows in stable input order and test positions nearest to each original
+   center first.
+3. Check candidates against the short array of already placed rectangles using
+   exact rectangle predicates.
+4. Prefer positions inside the configured extents. If the extents are
+   infeasible, use a deterministic overflow rule rather than dropping a row or
+   emitting a visibility decision.
+5. Emit one finite signed x offset and one finite signed y offset for every row.
 
-This direct implementation is intentionally O(k n^2) for n annotations and k
-bounded candidates. It is the correctness and code-size baseline, not a promise
-to ship an avoidably slow algorithm. Measure it first on the canonical example.
-If it misses the performance budget, add the smallest broad-phase structure that
-fixes the measured bottleneck and preserves exact rectangle checks. Compare a
-uniform grid and Vega-style occupancy bitmap on that fixture only; do not build
-or keep both production implementations.
+The direct implementation is the correctness and code-size baseline, not a
+promise to ship an avoidably slow algorithm. Measure it first on representative
+generic rectangles and the canonical annotation example. The initial solver
+spike must resolve how nearest-position search terminates and how overflow is
+minimized without adding public tuning parameters.
 
-Consider force relaxation or expanding-ring search only if fixed candidates
-fail the agreed placement-quality criterion. Do not implement them merely to
-complete an algorithm survey. Any force implementation must use a fixed,
-deterministic work bound without randomness or wall-clock stopping.
+If the baseline misses the performance budget, add the smallest broad-phase
+structure that fixes the measured bottleneck and preserves exact rectangle
+checks. Compare a uniform grid and Vega-style occupancy bitmap on that fixture
+only; do not build or keep both production implementations.
+
+Consider force relaxation only if the direct displacement method fails the
+agreed placement-quality criterion. Do not implement it merely to complete an
+algorithm survey. Any iterative implementation must use a fixed, deterministic
+work bound without randomness or wall-clock stopping and must still emit offsets
+for every row.
 
 If an optimized bitmap design closely adapts Vega's BSD-3-Clause
 implementation, retain the University of Washington copyright and license
@@ -245,17 +274,17 @@ Use a browser benchmark because JSDOM/Node timings do not represent the
 interactive hot path. Record browser, hardware, fixture, warm-up, and percentile
 method with results. Initial targets for a 1000 x 800 logical-pixel viewport are:
 
-- 500 annotations with nine candidates: median solver time at most 4 ms and
-  p95 at most 8 ms during a recorded zoom sequence.
-- 2,000 annotations: p95 at most one 16.7 ms frame, with runtime bounded by the
-  configured candidate count rather than a wall-clock cutoff.
+- 500 heterogeneous rectangles: median solver time at most 4 ms and p95 at most
+  8 ms during a recorded zoom sequence.
+- 2,000 rectangles: p95 at most one 16.7 ms frame, with deterministic work
+  bounds rather than a wall-clock cutoff.
 - Baseline working memory remains O(n). Any later acceleration structure must
   have a documented bound appropriate to the viewport and fixture sizes.
 - No monotonically growing allocations or retained per-update data during 1,000
   repeated zoom/layout recomputations.
 
 These thresholds reserve most of a 60 Hz frame for scale updates, buffer work,
-and rendering. If representative GenomeSpy examples require a different label
+and rendering. If representative GenomeSpy examples require a different item
 count, adjust the fixture and threshold at the algorithm review gate rather than
 quietly weakening the criterion later.
 
@@ -268,8 +297,8 @@ solver, integration, and documentation into one large feature commit.
 Expected checkpoints are:
 
 1. Commit this initial researched plan before implementation begins.
-2. Commit the pure solver, measured direct baseline, and reduced API decision
-   once its invariants and performance budget pass. Delete discarded
+2. Commit the pure solver, measured direct baseline, and confirmed generic
+   contract once its invariants and performance budget pass. Delete discarded
    experiments before the commit.
 3. Commit the dataflow adapter and public grammar integration once reactive
    replay, scale-domain isolation, schema, and TypeScript checks pass.
@@ -286,33 +315,33 @@ remain useful for review and bisection.
 
 ## Correctness and interaction invariants
 
-- Every `placed: true` rectangle is inside the configured extents and does not
-  overlap another placed rectangle after padding and any broad-phase
-  quantization are accounted for.
-- Higher-priority input cannot be displaced by a lower-priority input.
+- Every input row receives exactly two finite signed displacement values.
+- Output rectangles do not overlap. They remain inside preferred extents when
+  feasible and follow the documented deterministic overflow policy otherwise.
 - Equal inputs produce equal outputs across runs and platforms within documented
   pixel quantization.
 - Output order and datum identity follow normal modifying-transform behavior.
 - Empty, singleton, coincident, heterogeneous-size, negative-factor, reversed
   screen-axis, and infeasible batches have specified behavior.
-- Non-finite positions, dimensions, factors, padding, extents, candidates, and
-  mismatched `as` arrays fail fast with transform-specific messages.
+- Non-finite positions, dimensions, factors, extents, and mismatched `as` arrays
+  fail fast with transform-specific messages.
 - Expression-backed parameters bootstrap only after scale domains exist and
   trigger one coherent replay when their effective values change.
 - Placement output must not feed back into the data-driven domains used to
   compute the original positions.
-- During small zoom increments, stable priority and candidate order minimize
-  placement churn. The benchmark reports changed candidates per frame so a fast
-  but visibly flickering solver cannot pass on timing alone.
+- During small zoom increments, stable input and internal search order minimize
+  placement churn. The benchmark reports materially changed offsets per frame
+  so a fast but visibly flickering solver cannot pass on timing alone.
 
 ## Milestones
 
 ### 1. Minimal solver and contract evidence
 
 Intended outcome: implement the smallest production-quality direct solver once,
-validate it against one canonical use case, and reduce the candidate API before
-it becomes public. Introduce a more complex algorithm only if this baseline
-fails an explicit criterion.
+validate it against generic rectangle fixtures and one canonical annotation use
+case, and confirm the generic solver contract before it becomes public.
+Introduce a more complex algorithm only if this baseline fails an explicit
+criterion.
 
 Affected areas and downstream consumers:
 
@@ -331,15 +360,15 @@ Verification:
 - If it fails a criterion, identify the bottleneck before implementing one
   targeted alternative. Record why the added complexity is necessary and its
   before/after result.
-- Replay a deterministic zoom/pan trace and measure both latency and candidate
+- Replay a deterministic zoom/pan trace and measure both latency and offset
   churn.
 - Inspect output visually for displacement, edge crowding, placement churn, and
-  priority behavior.
+  overflow behavior.
 - Confirm the chosen source and license obligations before adapting code.
 
-Documentation or migration: record the selected behavior, reduced API decision,
-measurements, and discarded alternatives in this plan. No public contract
-exists yet.
+Documentation or migration: record the selected behavior, confirmed generic
+contract, measurements, and discarded alternatives in this plan. No public
+contract exists yet.
 
 Tentative commit: `feat(core): add two-dimensional displacement solver`
 
@@ -395,9 +424,9 @@ Verification:
 
 - Exercise initial load, resize, wheel zoom, pan, inertial zoom, and restoration
   to the original domain in a real browser.
-- Confirm no overlap among placed annotations, deterministic priority, stable
-  interaction, correct picking/tooltip positions, correct clipping, and correct
-  displaced positions.
+- Confirm no overlap among annotations, preservation of every row,
+  deterministic offsets, stable interaction, correct picking/tooltip positions,
+  correct clipping, and correct displaced positions.
 - Smoke-test representative WebGL and structured SVG output through the existing
   offset path. Add a new permanent cross-renderer test only if the transform
   introduces behavior that existing offset tests do not cover.
@@ -406,9 +435,9 @@ Verification:
 - Repeat the accepted benchmark on the integrated example and compare it with
   the pure-solver result so dataflow overhead is visible.
 
-Documentation or migration: document coordinate units, affine-scale limitation,
-priority ordering, `placed` handling, bounds, candidate behavior, and composition
-with `measureText`, offsets, and opacity or filtering. Mention leader-line
+Documentation or migration: document flexible geometry inputs, coordinate
+units, affine-scale limitation, input ordering, preferred-bound overflow, and
+composition with `measureText` and offset channels. Mention leader-line
 composition only if the canonical example actually uses it.
 
 Tentative commit: `docs(core): document two-dimensional displacement`
@@ -423,8 +452,9 @@ documentation, provenance, and code-size tradeoff.
   visibly recomputes during zoom, pan, and resize without blocking interaction.
 - The solver and transform meet the accepted performance and churn thresholds
   on the recorded fixtures.
-- Successful placements are non-overlapping, deterministic, prioritized, and
-  bounded; unsuccessful placements are explicit and no row is silently lost.
+- Every row is preserved and receives deterministic x and y offsets. Output
+  rectangles are non-overlapping and follow the documented preferred-bound
+  overflow behavior.
 - The transform remains dataflow-only, the solver remains pure, and no new
   rendering special cases or runtime dependencies are introduced.
 - WebGL display, picking/tooltips, clipping, and structured SVG export agree on
@@ -436,8 +466,9 @@ documentation, provenance, and code-size tradeoff.
 - Relevant focused tests, schema/docs checks, TypeScript checks, and lint pass.
 - The production change contains one solver path and no unused strategy,
   geometry, caching, worker, or compatibility abstractions.
-- Public parameters are exercised by the canonical example. Any parameter that
-  remains only for a hypothetical use case is removed or explicitly deferred.
+- Public parameter forms are exercised by the canonical example or focused
+  contract tests. Any parameter that remains only for a hypothetical use case
+  is removed or explicitly deferred.
 - Line-count and diff-size measurements are recorded at implementation
   milestones, and non-essential helpers, options, and tests are deleted.
 - Git history is divided into the coherent, verified checkpoints above rather
@@ -447,33 +478,36 @@ documentation, provenance, and code-size tradeoff.
 
 ## Risks and mitigations
 
-- **Discrete candidate jumps during zoom.** Measure churn and use stable input
-  and candidate order first. Consider retained previous choices only after this
+- **Displacement jumps during zoom.** Measure churn and use stable input and
+  search order first. Consider retained previous offsets only after this
   stateless design demonstrably fails the interaction criterion.
 - **Premature optimization.** Preserve the direct solver as the measured design
   baseline. Add one broad-phase optimization only if profiling shows that
   rectangle scans cause a budget failure; do not retain two production paths.
-- **Dense infeasible plots.** Expose `placed` and deterministic priority rather
-  than silently overlapping or running until a time limit.
+- **Dense infeasible bounds.** Preserve every row and use a documented
+  deterministic overflow rule rather than emitting visibility or silently
+  accepting overlaps.
 - **Expression/data-domain feedback.** Reuse `displace1d` bootstrap and collector
   replay patterns and test data-driven x and y domains explicitly.
 - **API overfitting to text labels.** Define the solver in terms of rectangle
   centers and extents and keep text measurement, styling, and leader-line
   rendering outside the transform.
-- **Premature generalization.** Ship one measured strategy and one candidate
-  representation; keep alternative solvers and renderer obstacle avoidance out
-  of the public API.
+- **Premature generalization.** Ship one measured solver with generic geometry
+  inputs and offset outputs; keep algorithm selection and renderer obstacle
+  avoidance out of the public API.
 
 ## Unresolved questions
 
 1. Which existing or new scatterplot is the canonical first use case, and what
    real annotation counts should set the final benchmark thresholds?
-2. Should the internal default try the original center first, or avoid the
-   annotation's anchor by default? Resolve this from the canonical example; do
-   not expose a public option in the first version.
-3. Can the canonical spec derive pixel coordinates before `displace2d`, allowing
-   `positionFactors` or `extent` to be removed from the public contract?
-4. Does stable input and candidate order provide acceptable temporal coherence?
+2. What deterministic nearest-position search and overflow rule preserve all
+   rows while keeping squared displacement and extent overflow acceptably low?
+   Resolve this inside the solver; do not expose search controls in the first
+   public API.
+3. Are separate x/y position factors and extents clearer than paired parameters?
+   Prefer the form that most closely preserves `displace1d` semantics and keeps
+   expression-backed replay straightforward.
+4. Does stable input and search order provide acceptable temporal coherence?
    Previous-frame state remains deferred unless the interaction trace proves it
    is needed.
 5. Does the direct rectangle scan meet the performance budget? Only if it fails,

--- a/plans/displace2d/displace2d-plan.md
+++ b/plans/displace2d/displace2d-plan.md
@@ -129,6 +129,9 @@ rendering and connector composition own association.
 
 ## Non-goals for the first version
 
+- Modifying, refactoring, or fixing `displace1d`. It is an established precedent
+  whose good abstraction choices inform this design, not part of this change.
+  No `displace1d` implementation, tests, types, or documentation are in scope.
 - Inspecting rendered mark bounds or avoiding arbitrary named marks. GenomeSpy
   intentionally has no retained scene graph, so this would invert the dataflow
   and rendering ownership boundary.
@@ -166,6 +169,9 @@ rendering and connector composition own association.
 - `packages/core/src/data/transforms/displace1dSolver.js` establishes the
   preferred separation between a pure numerical solver and the dataflow
   adapter.
+- Reuse `displace1d`'s contracts selectively, not its implementation verbatim.
+  In particular, `displace2d` must avoid stale derived extent state, duplicate
+  reactive replays, and uncancelled deferred bootstrap work.
 - `packages/core/src/data/transforms/measureText.js` supplies label widths but
   does not own placement.
 - Offset channels are already applied in WebGL and structured SVG output. The
@@ -181,6 +187,13 @@ rendering and connector composition own association.
   replay per settled parameter update. Prefer the existing expression-property
   batching utility or an equally small local use of it; do not create a new
   scheduler.
+- Source-coordinate extents are the source of truth. Derive both scaled extents
+  coherently for each solve, or explicitly clear an axis when its source extent
+  becomes undefined. Never let a retained scaled extent outlive the parameter
+  value from which it was derived.
+- Deferred bootstrap replay must check that the transform is still live before
+  walking to an upstream collector. Disposal between initial completion and the
+  queued replay must be a no-op.
 
 ## Abstraction-level decision
 
@@ -228,6 +241,10 @@ These rules are acceptance criteria for the code, not optional cleanup work:
   introducing interfaces for either.
 - Reuse `displace1d` lifecycle patterns, but do not create a shared displacement
   framework until both transforms contain stable, meaningful duplication.
+- Keep scalar readers and per-datum field accessors distinct. A field-name
+  string for `width` or `height` must never leak into reactive scalar state.
+- Keep one source of truth for source extents and position factors. Scaled
+  bounds are derived solve inputs, not independently meaningful state.
 - Validate once at the transform boundary. Keep the pure solver focused on its
   explicit numerical contract and fail loudly on violated invariants.
 - Do not add compatibility aliases, deprecated parameter names, fallback
@@ -290,7 +307,9 @@ Semantics:
   coordinate systems and are scaled with the item centers. When the rectangles
   cannot be placed by the bounded local search, every row still receives
   offsets and the documented overflow policy applies. Overflow does not imply
-  that no globally feasible arrangement exists.
+  that no globally feasible arrangement exists. An expression may evaluate to
+  `undefined` to disable that axis's preferred extent and must not leave stale
+  scaled bounds behind.
 - The output displacement coordinate system must exactly match unscaled
   `xOffset` and `yOffset`: positive x moves right and positive y moves down.
 - Like `displace1d`, affine position conversion is supported directly.
@@ -455,6 +474,12 @@ remain useful for review and bisection.
 - Expression-backed parameters bootstrap only after scale domains exist and
   coalesce into at most one coherent replay when their effective values change
   in one settled parameter update.
+- A queued bootstrap replay after transform disposal is ignored.
+- Independently reactive x/y extents can be enabled, changed, and disabled
+  without retaining stale scaled bounds on either axis.
+- Reactive x/y factors may change sign because 2D placement uses stable input
+  order rather than `displace1d`'s scaled-position ordering requirement. Scaled
+  extents are normalized after every effective factor change.
 - Placement output must not feed back into the data-driven domains used to
   compute the original positions.
 - During small zoom increments, stable input and internal search order minimize
@@ -480,6 +505,7 @@ Affected areas and downstream consumers:
   small permanent regression benchmark; do not build a benchmark framework.
 - Representative scatterplot and genomic annotation fixtures.
 - This plan's algorithm decision, API question, and recorded measurements.
+- No changes under the `displace1d` implementation, tests, types, or docs.
 
 Verification:
 
@@ -525,6 +551,12 @@ Verification:
   behavior, upstream `collect` replay, expression bootstrap, zoom reactions,
   negative factors, extent normalization, unchanged source domains, and one
   replay when several reactive placement properties change together.
+- Transform tests independently toggle expression-backed x/y extents between
+  defined and undefined values, change factor signs, and dispose the transform
+  before its queued bootstrap replay. No stale extent or post-disposal replay is
+  permitted.
+- Tests distinguish datum-field dimensions from reactive shared dimensions so
+  the overloaded public input forms cannot share accidental mutable state.
 - Run focused Vitest suites with the `agent` reporter, schema checks, workspace
   TypeScript checks, and lint for touched code.
 - Re-run the accepted performance fixtures. Inspect allocations only if timing
@@ -589,6 +621,8 @@ documentation, provenance, and code-size tradeoff.
   rule without claiming global infeasibility.
 - The transform remains dataflow-only, the solver remains pure, and no new
   rendering special cases or runtime dependencies are introduced.
+- `displace1d` implementation, tests, public types, and documentation remain
+  unchanged; any issue discovered there is out of scope for this pull request.
 - WebGL display, picking/tooltips, clipping, and structured SVG export agree on
   the displaced positions.
 - Public types, generated schema, documentation, navigation, and example specs
@@ -622,6 +656,10 @@ documentation, provenance, and code-size tradeoff.
 - **Duplicate reactive work.** Coalesce all expression-backed placement
   invalidations and test that a settled multi-property change causes at most
   one replay.
+- **Stale derived bounds.** Derive scaled bounds coherently from the current
+  source extents and clear each axis explicitly when its extent is disabled.
+- **Deferred work after disposal.** Guard the queued bootstrap replay with the
+  transform lifecycle so removed views cannot replay stale branches.
 - **Expression/data-domain feedback.** Reuse `displace1d` bootstrap and collector
   replay patterns and test data-driven x and y domains explicitly.
 - **API overfitting to text labels.** Define the solver in terms of rectangle

--- a/plans/displace2d/displace2d-plan.md
+++ b/plans/displace2d/displace2d-plan.md
@@ -149,6 +149,11 @@ rendering and connector composition own association.
 - Public candidate-generation options, obstacle geometry, visibility decisions,
   leader-line routing, and previous-frame placement state unless a demonstrated
   use case cannot be implemented acceptably without them.
+- Avoiding anchor points or unrelated marks. The canonical first example must
+  still be useful with annotation-to-annotation collision only. If labels
+  obscuring points makes that example unacceptable, stop at the first review
+  gate and revise the generic input contract instead of adding a renderer-aware
+  exception.
 
 ## Architectural constraints from GenomeSpy
 
@@ -171,6 +176,11 @@ rendering and connector composition own association.
 - Core hot paths should avoid material per-frame allocations. Reuse working
   buffers across reactive repropagations only when measurement justifies the
   extra lifetime management.
+- A 2D transform can have up to six reactive placement properties. Their
+  invalidations must be coalesced into one refresh and at most one dataflow
+  replay per settled parameter update. Prefer the existing expression-property
+  batching utility or an equally small local use of it; do not create a new
+  scheduler.
 
 ## Abstraction-level decision
 
@@ -267,6 +277,8 @@ Semantics:
 - `width` and `height` are full collision dimensions in logical pixels. A number
   is shared by all rows, a string names a datum field, and an expression
   provides a reactive scalar shared by all rows, matching `displace1d.length`.
+  Rectangle interiors collide; touching edges do not. Width and height may be
+  zero, matching `displace1d`'s non-negative collision-length contract.
 - Input order provides stable deterministic ordering. Authors can place
   `collect` immediately upstream to sort and to provide the replay buffer
   required by reactive parameters. The transform must not add a competing
@@ -276,8 +288,9 @@ Semantics:
   needs placement behavior that the default cannot provide.
 - `xExtent` and `yExtent` are preferred bounds in their respective original
   coordinate systems and are scaled with the item centers. When the rectangles
-  cannot fit, every row still receives offsets and the documented overflow
-  policy applies.
+  cannot be placed by the bounded local search, every row still receives
+  offsets and the documented overflow policy applies. Overflow does not imply
+  that no globally feasible arrangement exists.
 - The output displacement coordinate system must exactly match unscaled
   `xOffset` and `yOffset`: positive x moves right and positive y moves down.
 - Like `displace1d`, affine position conversion is supported directly.
@@ -305,19 +318,39 @@ The preferred baseline is:
 3. Check candidates against the short array of already placed rectangles using
    exact rectangle predicates.
 4. Give the local search a fixed work bound. If its candidates cannot place a
-   rectangle inside the preferred extents, use a deterministic overflow shelf
-   outside the crowded region. The shelf must guarantee termination and
-   non-overlap rather than dropping a row or returning it to an overlapping
-   original position.
+   rectangle while respecting every supplied preferred extent, use a
+   deterministic overflow row to the right of the crowded region. The row must
+   guarantee termination and non-overlap rather than dropping a row or returning
+   it to an overlapping original position.
 5. Emit one finite signed x offset and one finite signed y offset for every row.
 
 The direct implementation is the correctness and code-size baseline, not a
 promise to ship an avoidably slow algorithm. Measure it first on representative
 generic rectangles and the canonical annotation example. The initial solver
 spike must compare the smallest useful finite candidate sequence with a bounded
-expanding-ring or spiral sequence. Choose one based on the named quality and
-latency fixtures, then delete the other. Search controls remain internal, and
-the deterministic overflow shelf is the termination guarantee for either.
+rectangular-ring sequence. Choose one based on the named quality and latency
+fixtures, then delete the other. Search controls remain internal, and the
+deterministic overflow row is the termination guarantee for either. Do not use
+randomness or trigonometric spiral steps; lattice candidates make ordering and
+boundary decisions easier to reproduce across platforms.
+
+The overflow rule is deliberately plain:
+
+1. Initialize an overflow cursor from the maximum original right edge and the
+   right edge of the scaled `xExtent`, when present. Keep it at least as large
+   as the maximum right edge of every rectangle already placed.
+2. On local-search failure, place the rectangle immediately to the right of
+   that cursor, with its left edge touching the cursor. Preserve its original y
+   center, clamped to `yExtent` when the rectangle fits there, and advance the
+   cursor by its full width.
+3. Because each overflow rectangle is horizontally disjoint from everything
+   already placed, no additional search is required. Touching edges are
+   allowed. The rule may violate `xExtent` and may produce large offsets; those
+   effects are explicit and measured.
+
+A bounded greedy search makes no claim about global feasibility. The contract
+is only that accepted local candidates respect supplied extents and that every
+other row is placed by the deterministic overflow rule without overlap.
 
 If the baseline misses the performance budget, first determine whether candidate
 count or collision lookup is the bottleneck. Reduce candidate work before adding
@@ -358,6 +391,26 @@ and rendering. If representative GenomeSpy examples require a different item
 count, adjust the fixture and threshold at the algorithm review gate rather than
 quietly weakening the criterion later.
 
+## Placement-quality budget
+
+Record quality alongside runtime using the following metrics:
+
+- number and fraction of rows using overflow;
+- mean and p95 center displacement, both in pixels and normalized by each
+  rectangle's diagonal when it is positive;
+- fraction of rows whose original position remains unchanged;
+- number of materially changed offsets at each step of the zoom trace.
+
+Before selecting the production candidate sequence, choose the canonical
+annotation example and commit its deterministic fixture and quality thresholds
+to this plan. The selection gate is invalid until those thresholds exist. At a
+minimum, an already non-overlapping fixture must remain completely unchanged,
+a fixture constructed so the bounded local candidates can resolve it must have
+zero overflow, and infeasible or search-exhausted fixtures must preserve all
+rows without overlaps. For the canonical dense fixture, set explicit maximum
+overflow and displacement thresholds before comparing implementations; do not
+derive the thresholds from whichever implementation happens to win.
+
 ## Commit and delivery strategy
 
 Commit frequently on `feat/displace2d`, but keep every commit focused,
@@ -387,16 +440,21 @@ remain useful for review and bisection.
 
 - Every input row receives exactly two finite signed displacement values.
 - Output rectangles do not overlap. They remain inside preferred extents when
-  feasible and follow the documented deterministic overflow policy otherwise.
-- Equal inputs produce equal outputs across runs and platforms within documented
-  pixel quantization.
+  their accepted local candidate satisfies them and follow the documented
+  deterministic overflow policy after local-search exhaustion. Overflow is not
+  a statement about global feasibility.
+- Rectangle interiors define overlap; touching edges are allowed.
+- Equal inputs produce equal outputs across runs in the same runtime. Candidate
+  generation uses deterministic basic arithmetic without randomness or
+  platform-sensitive trigonometric ordering.
 - Output order and datum identity follow normal modifying-transform behavior.
 - Empty, singleton, coincident, heterogeneous-size, negative-factor, reversed
   screen-axis, and infeasible batches have specified behavior.
 - Non-finite positions, dimensions, factors, extents, and mismatched `as` arrays
   fail fast with transform-specific messages.
 - Expression-backed parameters bootstrap only after scale domains exist and
-  trigger one coherent replay when their effective values change.
+  coalesce into at most one coherent replay when their effective values change
+  in one settled parameter update.
 - Placement output must not feed back into the data-driven domains used to
   compute the original positions.
 - During small zoom increments, stable input and internal search order minimize
@@ -427,6 +485,8 @@ Verification:
 
 - Run the direct baseline on sparse, clustered, coincident, mixed-size,
   edge-heavy, and infeasible fixtures at 100, 500, and 2,000 annotations.
+- Freeze the canonical fixture's overflow and normalized-displacement budgets
+  before choosing between the finite and rectangular-ring candidate sequences.
 - If it fails a criterion, identify the bottleneck before implementing one
   targeted alternative. Record why the added complexity is necessary and its
   before/after result.
@@ -463,7 +523,8 @@ Verification:
   rendering dependencies.
 - Transform tests cover defaults, field/scalar inputs, validation, mutation
   behavior, upstream `collect` replay, expression bootstrap, zoom reactions,
-  negative factors, extent normalization, and unchanged source domains.
+  negative factors, extent normalization, unchanged source domains, and one
+  replay when several reactive placement properties change together.
 - Run focused Vitest suites with the `agent` reporter, schema checks, workspace
   TypeScript checks, and lint for touched code.
 - Re-run the accepted performance fixtures. Inspect allocations only if timing
@@ -523,8 +584,9 @@ documentation, provenance, and code-size tradeoff.
 - The solver and transform meet the accepted performance and churn thresholds
   on the recorded fixtures.
 - Every row is preserved and receives deterministic x and y offsets. Output
-  rectangles are non-overlapping and follow the documented preferred-bound
-  overflow behavior.
+  rectangles are non-overlapping and accepted local candidates respect the
+  documented preferred bounds; exhausted local searches follow the overflow
+  rule without claiming global infeasibility.
 - The transform remains dataflow-only, the solver remains pure, and no new
   rendering special cases or runtime dependencies are introduced.
 - WebGL display, picking/tooltips, clipping, and structured SVG export agree on
@@ -554,9 +616,12 @@ documentation, provenance, and code-size tradeoff.
 - **Premature optimization.** Preserve the direct solver as the measured design
   baseline. Add one broad-phase optimization only if profiling shows that
   rectangle scans cause a budget failure; do not retain two production paths.
-- **Dense infeasible bounds.** Preserve every row and use a documented
-  deterministic overflow shelf rather than emitting visibility, silently
-  accepting overlaps, or running an unbounded search.
+- **Dense or search-exhausted bounds.** Preserve every row and use the
+  documented deterministic right-side overflow row rather than emitting
+  visibility, silently accepting overlaps, or running an unbounded search.
+- **Duplicate reactive work.** Coalesce all expression-backed placement
+  invalidations and test that a settled multi-property change causes at most
+  one replay.
 - **Expression/data-domain feedback.** Reuse `displace1d` bootstrap and collector
   replay patterns and test data-driven x and y domains explicitly.
 - **API overfitting to text labels.** Define the solver in terms of rectangle
@@ -569,11 +634,13 @@ documentation, provenance, and code-size tradeoff.
 ## Unresolved questions
 
 1. Which existing or new scatterplot is the canonical first use case, and what
-   real annotation counts should set the final benchmark thresholds?
+   real annotation counts, overflow fraction, and normalized displacement
+   should set the final benchmark thresholds? Freeze these before selecting the
+   candidate sequence.
 2. Does a small finite candidate sequence meet the placement-quality fixture,
-   or is a fixed-budget expanding-ring/spiral sequence justified? The overflow
-   shelf is already the termination rule. Resolve the candidate sequence inside
-   the solver and keep its controls out of the first public API.
+   or is a fixed-budget rectangular-ring sequence justified? The right-side
+   overflow row is already the termination rule. Resolve the candidate sequence
+   inside the solver and keep its controls out of the first public API.
 3. Are separate x/y position factors and extents clearer than paired parameters?
    Prefer the form that most closely preserves `displace1d` semantics and keeps
    expression-backed replay straightforward.
@@ -583,3 +650,7 @@ documentation, provenance, and code-size tradeoff.
 5. Does the direct rectangle scan meet the performance budget? Only if it fails,
    which single acceleration structure fixes the measured bottleneck with the
    least code and memory?
+6. Does the canonical example remain useful when only annotation rectangles
+   avoid one another? If avoiding anchor points is essential, revise the generic
+   solver input contract at the first review gate rather than adding mark or
+   renderer coupling.


### PR DESCRIPTION
## Summary

This PR proposes a plan for making the package more similar to Altair, focusing on transform API compatibility.

It compares both transform surfaces, identifies semantic differences, and prioritizes improvements that can be implemented without misrepresenting unsupported GenomeSpy functionality.

## Steps

1. Add faithful aliases such as `transform_calculate()` and Altair-style flatten and sample calls.
2. Support Altair-style aggregate, window, joinaggregate, and stack arguments where GenomeSpy provides equivalent semantics.
3. Add expression helpers such as `gs.datum.x` and `gs.expr.cos(...)`.
4. Improve filter compatibility within GenomeSpy’s existing predicate model.
5. Evaluate a constrained adapter for ordinary data lookups.
6. Add serialization, schema-validation, and renderer smoke tests.
7. Document the supported compatibility subset and its limitations.
