### PR TITLE
fix(core): default zoomable marks to xy clipping

### DIFF
--- a/packages/core/src/marks/mark.js
+++ b/packages/core/src/marks/mark.js
@@ -85,21 +85,13 @@ export default class Mark {
                 configurable: true,
                 enumerable: true,
                 get() {
-                    const clipX = unitView
+                    const zoomableX = unitView
                         .getScaleResolution("x")
                         ?.isZoomable();
-                    const clipY = unitView
+                    const zoomableY = unitView
                         .getScaleResolution("y")
                         ?.isZoomable();
-                    /** @type {boolean | "x" | "y"} */
-                    let clip = false;
-                    if (clipX && clipY) {
-                        clip = true;
-                    } else if (clipX) {
-                        clip = "x";
-                    } else if (clipY) {
-                        clip = "y";
-                    }
+                    const clip = !!(zoomableX || zoomableY);
 
                     Object.defineProperty(properties, "clip", {
                         configurable: true,

--- a/packages/core/src/marks/markConfigPrecedence.test.js
+++ b/packages/core/src/marks/markConfigPrecedence.test.js
@@ -96,7 +96,7 @@ describe("mark config precedence", () => {
         expect(view.mark.properties.clip).toBe("y");
     });
 
-    test("zoomability-backed clip default uses the zoomable direction", async () => {
+    test("one zoomable positional scale defaults to xy clipping", async () => {
         const view = /** @type {UnitView} */ (
             await create(
                 {
@@ -116,12 +116,12 @@ describe("mark config precedence", () => {
         const xResolution = view.getScaleResolution("x");
         const zoomSpy = vi.spyOn(xResolution, "isZoomable");
 
-        expect(view.mark.properties.clip).toBe("x");
-        expect(view.mark.properties.clip).toBe("x");
+        expect(view.mark.properties.clip).toBe(true);
+        expect(view.mark.properties.clip).toBe(true);
         expect(zoomSpy).toHaveBeenCalledTimes(1);
     });
 
-    test("zoomability-backed clip default uses y when only y is zoomable", async () => {
+    test("a zoomable y scale also defaults to xy clipping", async () => {
         const view = /** @type {UnitView} */ (
             await create(
                 {
@@ -145,7 +145,7 @@ describe("mark config precedence", () => {
             true
         );
 
-        expect(view.mark.properties.clip).toBe("y");
+        expect(view.mark.properties.clip).toBe(true);
     });
 
     test("zoomability-backed clip default uses both directions when both axes are zoomable", async () => {

--- a/packages/core/src/spec/mark.d.ts
+++ b/packages/core/src/spec/mark.d.ts
@@ -51,7 +51,8 @@ export interface MarkPropsBase {
      * direction. Inherited clipping from parent containers still applies unless
      * `"never"` is used.
      *
-     * __Default value:__ the direction of zoomable positional scales
+     * __Default value:__ `true` when either positional scale is zoomable;
+     * otherwise `false`
      */
     clip?: boolean | "x" | "y" | "never";
 


### PR DESCRIPTION
Zoomable views are updated frequently during interaction. Clipping them to the full view rectangle by default keeps the drawable region bounded in both dimensions, which generally reduces rendering and compositing work.

Single-axis clipping is still available explicitly for the rare cases where content must overflow in the other direction.

- Default to xy clipping when either positional scale is zoomable.
- Preserve explicit x-only, y-only, disabled, and never-clip settings.
- Document the revised default in the mark specification.
- Cover x-only, y-only, and two-axis zoomability.

This PR is intended to merge before #498.

_Posted by Codex (AI agent) at the user’s request._