### PR TITLE
fix(core): honor scale assembly in configured locus domains

### DIFF
--- a/packages/core/src/scales/scaleResolution.assembly.test.js
+++ b/packages/core/src/scales/scaleResolution.assembly.test.js
@@ -206,6 +206,34 @@ describe("Scale resolution genome assembly", () => {
         ]);
     });
 
+    test("disabled locus scales do not require a default assembly", async () => {
+        /** @type {import("../spec/view.js").UnitSpec} */
+        const spec = {
+            data: {
+                values: [{ chrom: "chr1", pos: 1 }],
+            },
+            mark: "point",
+            encoding: {
+                x: {
+                    chrom: "chrom",
+                    pos: "pos",
+                    type: "locus",
+                    scale: null,
+                },
+            },
+        };
+
+        const context = createTestViewContext();
+        const view = await context.createOrImportView(spec, null, null, "root");
+
+        expect(
+            getRequiredScaleResolution(view, "x").getAssemblyRequirement()
+        ).toEqual({
+            assembly: undefined,
+            needsDefaultAssembly: false,
+        });
+    });
+
     test("locus scales can use inline contigs in assembly definitions", async () => {
         const genomeStore = new GenomeStore(".");
 

--- a/packages/core/src/scales/scaleResolution.assembly.test.js
+++ b/packages/core/src/scales/scaleResolution.assembly.test.js
@@ -167,6 +167,45 @@ describe("Scale resolution genome assembly", () => {
         );
     });
 
+    test("configured locus domain uses scale assembly without root assembly", async () => {
+        const genomeStore = new GenomeStore(".");
+        const start = 43_000_000;
+        const end = 43_100_000;
+
+        /** @type {import("../spec/view.js").UnitSpec} */
+        const spec = {
+            data: {
+                values: [{ chrom: "chr17", pos: 43_044_295 }],
+            },
+            mark: "point",
+            encoding: {
+                x: {
+                    chrom: "chrom",
+                    pos: "pos",
+                    type: "locus",
+                    scale: {
+                        type: "locus",
+                        assembly: "hg38",
+                        domain: [
+                            { chrom: "chr17", pos: start },
+                            { chrom: "chr17", pos: end },
+                        ],
+                    },
+                },
+            },
+        };
+
+        const { view } = await createHeadlessEngine(spec, {
+            contextOptions: { genomeStore },
+        });
+        const genome = genomeStore.getGenome("hg38");
+
+        expect(getRequiredScaleResolution(view, "x").getDomain()).toEqual([
+            genome.toContinuous("chr17", start),
+            genome.toContinuous("chr17", end) + 1,
+        ]);
+    });
+
     test("locus scales can use inline contigs in assembly definitions", async () => {
         const genomeStore = new GenomeStore(".");
 

--- a/packages/core/src/scales/scaleResolution.js
+++ b/packages/core/src/scales/scaleResolution.js
@@ -1405,7 +1405,9 @@ export default class ScaleResolution {
                   .map((member) => member.channelDef.scale)
                   .filter((props) => props !== undefined);
 
-        if (scaleProps.some((props) => props?.type === "null")) {
+        if (
+            scaleProps.some((props) => props === null || props.type === "null")
+        ) {
             return {
                 assembly: undefined,
                 needsDefaultAssembly: false,

--- a/packages/core/src/scales/scaleResolution.js
+++ b/packages/core/src/scales/scaleResolution.js
@@ -1382,8 +1382,8 @@ export default class ScaleResolution {
     /**
      * Returns locus assembly requirements without initializing the scale.
      *
-     * This is intentionally side-effect free: it only inspects merged scale
-     * properties from registered members and does not touch default domains or
+     * This is intentionally side-effect free: it only inspects explicit scale
+     * properties from registered members and does not resolve domains or
      * instantiate scale instances.
      *
      * @returns {{
@@ -1392,17 +1392,33 @@ export default class ScaleResolution {
      * }}
      */
     getAssemblyRequirement() {
-        const props = this.#getMergedScaleProps();
-        if (props === null || props.type === "null" || props.type !== LOCUS) {
+        if (this.type !== LOCUS) {
             return {
                 assembly: undefined,
                 needsDefaultAssembly: false,
             };
         }
 
+        const scaleProps = this.#viewLevelScaleProps
+            ? [this.#viewLevelScaleProps.props]
+            : this.#getOrderedMembers()
+                  .map((member) => member.channelDef.scale)
+                  .filter((props) => props !== undefined);
+
+        if (scaleProps.some((props) => props?.type === "null")) {
+            return {
+                assembly: undefined,
+                needsDefaultAssembly: false,
+            };
+        }
+
+        const assembly = scaleProps.find(
+            (props) => props?.assembly !== undefined
+        )?.assembly;
+
         return {
-            assembly: props.assembly,
-            needsDefaultAssembly: props.assembly === undefined,
+            assembly,
+            needsDefaultAssembly: assembly === undefined,
         };
     }
 
@@ -1973,7 +1989,10 @@ export default class ScaleResolution {
      */
     fromComplexInterval(interval) {
         if (this.type == LOCUS) {
-            return locusFromComplexInterval(this.#getGenomeSource(), interval);
+            return locusFromComplexInterval(
+                this.#getGenomeSource(this.getAssemblyRequirement().assembly),
+                interval
+            );
         }
         return /** @type {number[]} */ (interval);
     }


### PR DESCRIPTION
Fixes #475.

Locus scales with an explicit chromosomal domain now resolve that domain using
the assembly declared directly on the scale, without requiring a root assembly.

## Design

Assembly preflight reads the explicit scale properties without initializing the
scale or resolving its domain. Complex locus intervals then use that assembly
when converting chromosome-position values to continuous coordinates. Keeping
these paths separate avoids recursive scale resolution.

## Changes

- Resolve configured locus domains with the scale-level assembly.
- Preserve view-level and shared-scale property precedence.
- Preserve disabled-scale behavior during assembly preflight.
- Add regression tests for explicit hg38 domains and disabled locus scales.

## Verification

- Focused scale, domain, and assembly tests
- Full unit suite: 448 files, 3,764 passed
- Core TypeScript check
- ESLint check

_Posted by Codex (AI agent) at the user's request._